### PR TITLE
docs: fix highlighting in running server docs

### DIFF
--- a/docs/docs_database_drivers.md
+++ b/docs/docs_database_drivers.md
@@ -8,7 +8,7 @@ This page describes the differences between database drivers and their functiona
 
 Skyrim Multiplayer uses `file` driver by default. Default `databaseName` is `world`. So if you change nothing in the config file, the server would save all data using `world` subdirectory of the server folder. Only relative paths are supported.
 
-```json
+```json5
 {
   // ...
   "databaseDriver": "file",
@@ -25,7 +25,7 @@ Uses MongoDB to store data. Built for servers targeting real-world players from 
 
 We recommend [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) as a cloud database service.
 
-```json
+```json5
 {
   // ...
   "databaseDriver": "mongodb",
@@ -39,7 +39,7 @@ We recommend [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) as a cloud dat
 
 A special database driver is used to move from one type of database to another on the fly. Do not forget to backup everything before using this.
 
-```json
+```json5
 {
   // ...
   "databaseDriver": "migration",

--- a/docs/docs_running_a_server.md
+++ b/docs/docs_running_a_server.md
@@ -20,7 +20,7 @@ Only Windows builds are supported currently.
 
 Once you build the server, you should be able to launch it. But default config values are only usable to verify that server works. After launching the server you will see a server called `My Server` in the master list: https://skymp.io/api/servers. You also will be able to connect, but players from the Internet will not. You need to change the `ip` field in `server-settings.json` to get this functionality to work. This file is placed into `build/dist/server` directory during build.
 
-```json
+```json5
 {
   "dataDir": "data",
   "loadOrder": [

--- a/docs/docs_server_configuration_reference.md
+++ b/docs/docs_server_configuration_reference.md
@@ -6,7 +6,7 @@ The recommended way to configure the server is setting up all required values in
 
 Server's name. Displayed on skymp.io and in launcher.
 
-```json
+```json5
 {
   // ...
   "name": "My Server"
@@ -18,7 +18,7 @@ Server's name. Displayed on skymp.io and in launcher.
 
 This IP-address would be used by player clients to connect to your server. Do not try to type `"0.0.0.0"`, just remove this option from document if you want to use your current public IP.
 
-```json
+```json5
 {
   // ...
   "ip": "127.0.0.1"
@@ -30,7 +30,7 @@ This IP-address would be used by player clients to connect to your server. Do no
 
 This port would be used by player clients to connect to your server. At the current version of Skyrim Multiplayer servers use multiple ports and different protocols to manage different sorts of packets. See [Server Ports Usage](docs_server_ports_usage.md) page to learn more.
 
-```json
+```json5
 {
   // ...
   "port": 7777
@@ -42,7 +42,7 @@ This port would be used by player clients to connect to your server. At the curr
 
 Sets player limit of the server. Visible in launcher and on skymp.io.
 
-```json
+```json5
 {
   // ...
   "maxPlayers": 108
@@ -64,7 +64,7 @@ At this moment, the server uses this directory for non-vanilla needs too:
 * storing web-based GUI in `${dataDir}/ui`
 * storing auto-generated manifest describing .esm/.esp files used and CRC32 of them
 
-```json
+```json5
 {
   // ...
   "dataDir": "data"
@@ -80,7 +80,7 @@ Relative paths are searched in `${dataDir}` directory.
 
 Absolute paths work but aren't accessible via `uiPort`. External tooling wouldn't be able to download them from the server.
 
-```json
+```json5
 {
   // ...
   "loadOrder": [
@@ -98,7 +98,7 @@ Absolute paths work but aren't accessible via `uiPort`. External tooling wouldn'
 
 Name of a database driver which would be used to store server data. `sqlite` by default. There are also related options like `"databaseName"`. See [Database Drivers](docs_database_drivers.md) page to learn more.
 
-```json
+```json5
 {
   // ...
   "databaseDriver": "sqlite"
@@ -110,7 +110,7 @@ Name of a database driver which would be used to store server data. `sqlite` by 
 
 A time before a game object restores its original state in milliseconds. Unlike Skyrim SE, Skyrim Multiplayer doesn't have a built-in Cell Reset mechanism. The server resets every object in the world every hour instead. With this option, you can change this time interval for every kind of game object. `"CONT"`, for example, means "Container" - chests, barrels, etc. See "record types" on [UESP](https://en.uesp.net/wiki/Skyrim_Mod:Mod_File_Format).
 
-```json
+```json5
 {
   // ...
   "reloot": {
@@ -136,7 +136,7 @@ A time before a game object restores its original state in milliseconds. Unlike 
 Contains a relative or an absolute path to a file or directory with a gamemode.
 Searches for `index.js` if a directory specified.
 
-```json
+```json5
 {
   // ...
   "gamemodePath": "gamemode.js"
@@ -148,7 +148,7 @@ Searches for `index.js` if a directory specified.
 
 A boolean setting that enables to turn on or turn off hot reload for compiled Papyrus scripts (.pex)
 
-```json
+```json5
 {
   // ...
   "isPapyrusHotReloadEnabled": false
@@ -160,7 +160,7 @@ A boolean setting that enables to turn on or turn off hot reload for compiled Pa
 
 The name of a localizaiton file in `data/localization` that would be used by `M.GetText` Papyrus function (without extension).
 
-```json
+```json5
 {
   // ...
   "locale": "ru-RU"


### PR DESCRIPTION
Using `json5` syntax instead of `json` will not highlight comments in red