### PR TITLE
Remove -fpermissive compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,6 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-if (UNIX)
-  # TODO: Fix all errors instead of passing -fpermissive
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
-endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 


### PR DESCRIPTION
Actually, Clang does not even have this option. Other compilers are not supported currently due to Chakracore restrictions.