### PR TITLE
internal: fix chakra-wrapper linking on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
-add_subdirectory(chakra-wrapper)
 add_subdirectory(skyrim-platform)
 add_subdirectory(skymp5-client)
 add_subdirectory(skymp5-front)

--- a/chakra-wrapper/CMakeLists.txt
+++ b/chakra-wrapper/CMakeLists.txt
@@ -1,4 +1,0 @@
-project(chakra-wrapper)
-
-add_library(chakra-wrapper INTERFACE)
-target_include_directories(chakra-wrapper INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/skymp5-server/cpp/CMakeLists.txt
+++ b/skymp5-server/cpp/CMakeLists.txt
@@ -89,7 +89,8 @@ add_library(server_guest_lib STATIC ${src})
 target_include_directories(server_guest_lib PUBLIC "${CMAKE_CURRENT_LIST_DIR}/server_guest_lib")
 apply_default_settings(TARGETS server_guest_lib)
 list(APPEND VCPKG_DEPENDENT server_guest_lib)
-target_link_libraries(server_guest_lib PUBLIC mp_common espm papyrus-vm-lib geo chakra-wrapper)
+target_link_libraries(server_guest_lib PUBLIC mp_common espm papyrus-vm-lib geo)
+target_include_directories(server_guest_lib PUBLIC "${CMAKE_SOURCE_DIR}/chakra-wrapper")
 
 #
 # papyrus-vm-lib

--- a/skyrim-platform/src/platform_se/CMakeLists.txt
+++ b/skyrim-platform/src/platform_se/CMakeLists.txt
@@ -119,7 +119,7 @@ if(NOT "${SKIP_SKYRIM_PLATFORM_BUILDING}")
     target_include_directories(skyrim_platform PRIVATE "${third_party}")
     target_link_libraries(skyrim_platform PRIVATE "${third_party}/frida/frida-gum.lib")
     target_link_libraries(skyrim_platform PRIVATE cef)
-    target_link_libraries(skyrim_platform PRIVATE chakra-wrapper)
+    target_include_directories(skyrim_platform PRIVATE "${CMAKE_SOURCE_DIR}/chakra-wrapper")
     apply_default_settings(TARGETS skyrim_platform)
     list(APPEND VCPKG_DEPENDENT skyrim_platform)
 


### PR DESCRIPTION
One of our devs (@bogdasar1985) is able to reproduce the issue linking `chakra-wrapper`. Instead of linking interface target properly (by adding include path), it attempts to perform real linking. It thinks there is a shared library called `chakra-wrapper`.

This PR removes this target in order to fix the issue. Instead of using an interface target we just use `target_include_directories`.