### PR TITLE
tests: stop checking scamp_native.ilk in distribution

### DIFF
--- a/skymp5-server/cpp/unit/DistContentsExpected.json
+++ b/skymp5-server/cpp/unit/DistContentsExpected.json
@@ -98,15 +98,6 @@
   },
   {
     "configurationTags": [
-      "Debug",
-      "Win32"
-    ],
-    "expectedFiles": [
-      "server/scamp_native.ilk"
-    ]
-  },
-  {
-    "configurationTags": [
       "Win32"
     ],
     "expectedFiles": [

--- a/skymp5-server/cpp/unit/DistContentsTest.h
+++ b/skymp5-server/cpp/unit/DistContentsTest.h
@@ -89,9 +89,9 @@ TEST_CASE("Distribution folder must contain all requested files",
   // But this would extend tags responsibilities. Currently, they are
   // only responsible for platform selection.
   std::vector<std::filesystem::path> distContentsIgnore = {
-    "server/data/Dawnguard.esm", "server/data/Dragonborn.esm",
+    "server/data/Dawnguard.esm",   "server/data/Dragonborn.esm",
     "server/data/HearthFires.esm", "server/data/Skyrim.esm",
-    "server/data/Update.esm"
+    "server/data/Update.esm",      "server/scamp_native.ilk"
   };
   for (auto& path : distContentsIgnore) {
     expectedPaths.erase(path);


### PR DESCRIPTION
When building Debug and then Release, dist is not being cleaned so `scamp_native.ilk` may stay and ruin unit tests (DistContentsTest.h)