### PR TITLE
fix(skyrim-platform): plugins didn't work without WorldSpace.pex installed

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
@@ -32,6 +32,7 @@
 #include <RE/TESObjectARMO.h>
 #include <RE/TESObjectWEAP.h>
 #include <RE/UI.h>
+#include <algorithm>
 #include <atomic>
 #include <map>
 #include <mutex>
@@ -797,7 +798,7 @@ public:
         }
       }
     }
-    std::sort(missing.begin(), myvector.end());
+    std::sort(missing.begin(), missing.end());
     return missing;
   }
 };

--- a/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
@@ -38,7 +38,6 @@
 #include <nlohmann/json.hpp>
 #include <re/BGSEquipSlot.h>
 #include <re/Offsets_RTTI.h>
-#include <set>
 #include <skse64/Colors.h>
 #include <skse64/GameData.h>
 #include <skse64/GameExtraData.h>
@@ -782,9 +781,7 @@ public:
 
   std::vector<std::string> GetMissingFiles()
   {
-    // We prefer std::set here to keep strings sorted. We want the same output
-    // on different user machines
-    std::set<std::string> missing;
+    std::vector<std::string> missing;
     std::istringstream stream(PAPYRUS_SOURCES);
     std::string tmp;
     while (std::getline(stream, tmp, ' ')) {
@@ -794,12 +791,13 @@ public:
       path /= "Scripts";
       path /= tmp;
       if (!std::filesystem::exists(path)) {
-        missing.insert(tmp);
+        // WorldSpace doesn't have any functions declared so isn't required
+        if (tmp != "WorldSpace.pex") {
+          missing.push_back(tmp);
+        }
       }
     }
-    // Doesn't have any functions declared so isn't required
-    missing.erase("WorldSpace.pex");
-    return { missing.begin(), missing.end() };
+    return missing;
   }
 };
 

--- a/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
@@ -797,6 +797,7 @@ public:
         }
       }
     }
+    std::sort(missing.begin(), myvector.end());
     return missing;
   }
 };


### PR DESCRIPTION
closes #143

After internal discussion, we decided that error handling itself isn't implemented properly here: it's unexpectedly hard to understand what's going on when the `Missing files` error is thrown. But that's out of the scope of this PR, it's more like a **hotfix**. Hope we can merge it as soon as possible. We can not distribute Skyrim Platform until this fix is integrated.