### PR TITLE
docs: add refact commit type

### DIFF
--- a/docs/docs_maintainer_rules.md
+++ b/docs/docs_maintainer_rules.md
@@ -20,6 +20,7 @@ Commit types used (sorted by priority):
 * tests - changes in tests.
 * perf - changes in code that target improving performance.
 * docs - changes in text files.
+* refact - changes in code that target improving readability.
 * internal - fixes or changes in the build system, catalog structure, or anything that doesn't execute on the user's machine.
 
 Repo subdirectories are used to name commit scopes. Commits without scope are allowed.


### PR DESCRIPTION
It seems that our naming convention doesn't allow us to give a reasonable name to #149
I think introducing `refact` commit type solves this problem.