### PR TITLE
fix(skymp5-server): fix race between death and teleport packets

### DIFF
--- a/skymp5-server/cpp/mp_common/Networking.cpp
+++ b/skymp5-server/cpp/mp_common/Networking.cpp
@@ -79,7 +79,7 @@ public:
   void Send(Networking::PacketData data, size_t length, bool reliable) override
   {
     peer->Send(reinterpret_cast<const char*>(data), length, MEDIUM_PRIORITY,
-               reliable ? RELIABLE : UNRELIABLE, 0, serverGuid, false);
+               reliable ? RELIABLE_ORDERED : UNRELIABLE, 0, serverGuid, false);
   }
 
   void Tick(OnPacket onPacket, void* state) override


### PR DESCRIPTION
closes #467 

Decided to enable `RELIABLE_ORDERED` by default since the server was written thinking that **packets arrive on the client in the order they were sent.**

Needs further discussion and testing.

1. Is the original issue fixed or not?
2. Does it hit networking performance? (Need to learn RakNet docs)