### PR TITLE
internal: some minor build fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*]
-indent_style = space
-indent_size = 2
-charset = utf-8
-end_of_line = crlf
-insert_final_newline = true
-trim_trailing_whitespace = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,21 @@ endif()
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_LIST_DIR}/overlay_triplets")
 set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/overlay_ports")
-set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+
+macro(set_from_environment VARIABLE)
+	if (NOT DEFINED ${VARIABLE} AND DEFINED ENV{${VARIABLE}})
+		set(${VARIABLE} $ENV{${VARIABLE}})
+	endif ()
+endmacro()
+
+set_from_environment(VCPKG_ROOT)
+
+# Use installed VCPKG if exists
+if (DEFINED VCPKG_ROOT)
+	set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+else ()
+	set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+endif ()
 
 # File from vcpkg submodule. This indicates inability to find this file or checkout submodules.
 if(NOT EXISTS "${CMAKE_TOOLCHAIN_FILE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_LIST_DIR}/overlay_triplets")
 set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/overlay_ports")
 
 macro(set_from_environment VARIABLE)
-	if (NOT DEFINED ${VARIABLE} AND DEFINED ENV{${VARIABLE}})
-		set(${VARIABLE} $ENV{${VARIABLE}})
-	endif ()
+  if (NOT DEFINED ${VARIABLE} AND DEFINED ENV{${VARIABLE}})
+    set(${VARIABLE} $ENV{${VARIABLE}})
+  endif ()
 endmacro()
 
 set_from_environment(VCPKG_ROOT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(USE_SYSTEM_VCPKG "Use vcpkg from your system instead of skymp submodule" OFF)
+
 if(WIN32)
   set(VCPKG_TARGET_TRIPLET "x64-windows-sp")
 else()
@@ -16,10 +18,10 @@ endmacro()
 set_from_environment(VCPKG_ROOT)
 
 # Use installed VCPKG if exists
-if (DEFINED VCPKG_ROOT)
-	set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+if (USE_SYSTEM_VCPKG AND DEFINED VCPKG_ROOT AND EXISTS ${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
+  set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 else ()
-	set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+  set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif ()
 
 # File from vcpkg submodule. This indicates inability to find this file or checkout submodules.

--- a/skymp5-server/CMakeLists.txt
+++ b/skymp5-server/CMakeLists.txt
@@ -24,10 +24,17 @@ add_subdirectory(ts)
 # Solution:
 # 1. Give cmake-js a special CMakeLists.txt from the `cmake-js-fetch` directory.
 #    Look into package.json and `cmake-js-fetch/CMakeLists.txt` to understand mechanism
-yarn_execute_command(
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  COMMAND cmake-js-fetch
-)
+if (MSVC)
+  yarn_execute_command(
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    COMMAND cmake-js-fetch-msvc
+  )
+else ()
+  yarn_execute_command(
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    COMMAND cmake-js-fetch
+  )
+endif ()
 
 # 2. `cmake-js-fetch/CMakeLists.txt` creates `node.cmake` while generating
 
@@ -83,9 +90,9 @@ if(WIN32)
   set(bat "set NODE_PATH=${SKYMP5_SERVER_SOURCE_DIR}/node_modules\n")
   set(bat "${bat}node dist_back/index.js\n")
   set(bat "${bat}pause\n")
-  
+
   file(WRITE ${PROJECT_BINARY_DIR}/launch_server.bat.tmp "${bat}")
-  
+
   add_custom_command(
     TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/launch_server.bat.tmp ${CMAKE_BINARY_DIR}/dist/server/launch_server.bat

--- a/skymp5-server/cpp/CMakeLists.txt
+++ b/skymp5-server/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@ if(WIN32)
   set_target_properties(MpClientPlugin PROPERTIES OUTPUT_NAME "MpClientPlugin")
   apply_default_settings(TARGETS MpClientPlugin)
   list(APPEND VCPKG_DEPENDENT MpClientPlugin)
-  
+
   # Not mistake that skyrim-platform depends on MpClientPlugin
   # skyrim-platform is a logical target that invokes dev_service
   # dev_service wants to access built MpClientPlugin.dll
@@ -118,13 +118,12 @@ foreach(target ${VCPKG_DEPENDENT})
   find_package(ZLIB REQUIRED)
   target_link_libraries(${target} PUBLIC ZLIB::ZLIB)
 
-  find_package(libmongocxx REQUIRED)
-  find_package(libbsoncxx REQUIRED)
-  find_package(libmongoc-1.0 CONFIG REQUIRED)
-  target_link_libraries(${target} PUBLIC ${LIBMONGOCXX_LIBRARIES} ${LIBBSONCXX_LIBRARIES} ${MONGOC_LIBRARIES} ${MONGOC_STATIC_LIBRARIES})
+  find_package(mongocxx REQUIRED)
+  find_package(mongoc-1.0 CONFIG REQUIRED)
+  target_link_libraries(${target} PUBLIC mongo::mongocxx_static mongo::bsoncxx_static mongo::mongoc_static mongo::bson_static)
   find_package(OpenSSL REQUIRED)
   target_link_libraries(${target} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
-  
+
   if(UNIX)
     target_link_libraries(${target} PUBLIC pthread resolv rt m)
   endif()

--- a/skymp5-server/package.json
+++ b/skymp5-server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build-ts": "tsc",
-    "cmake-js-fetch": "cmake-js configure --directory cmake-js-fetch --out cmake-js-fetch-build"
+    "cmake-js-fetch": "cmake-js configure -G \"Visual Studio 16 2019\" --directory cmake-js-fetch --out cmake-js-fetch-build"
   },
   "author": "Leonid Pospelov <pospelovlm@yandex.ru>",
   "dependencies": {

--- a/skymp5-server/package.json
+++ b/skymp5-server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "build-ts": "tsc",
-    "cmake-js-fetch": "cmake-js configure -G \"Visual Studio 16 2019\" --directory cmake-js-fetch --out cmake-js-fetch-build"
+    "cmake-js-fetch": "cmake-js configure --directory cmake-js-fetch --out cmake-js-fetch-build",
+    "cmake-js-fetch-msvc": "cmake-js configure -G \"Visual Studio 16 2019\" --directory cmake-js-fetch --out cmake-js-fetch-build"
   },
   "author": "Leonid Pospelov <pospelovlm@yandex.ru>",
   "dependencies": {


### PR DESCRIPTION
Changes:

- Use system-wide `vcpkg` by default if it's installed and configured correctly.
- Changed some deprecated library naming in server's cmake
- Force `cmake-js` to use `-G "Visual Studio 16 2019"`, which fixes build error which pops if VS 2022 build tools are installed alongside. Might not be the best option, especially if Linux build support is required.

closes #80 