### PR TITLE
fix(skymp5-client): respawn didn't work in SweetPie world

### DIFF
--- a/skymp5-client/src/browser.ts
+++ b/skymp5-client/src/browser.ts
@@ -52,7 +52,14 @@ export const main = (): void => {
   on('update', () => {
     if (Date.now() - lastBadMenuCheck > 200) {
       lastBadMenuCheck = Date.now();
-      badMenuOpen = badMenus.findIndex((menu) => Ui.isMenuOpen(menu)) !== -1;
+
+      badMenuOpen = false;
+      for (let i = 0; i < badMenus.length; ++i) {
+        if (Ui.isMenuOpen(badMenus[i])) {
+          badMenuOpen = true;
+          break;
+        }
+      }
       browser.setVisible(browserVisibleState && !badMenuOpen);
     }
   });

--- a/skymp5-client/src/remoteServer.ts
+++ b/skymp5-client/src/remoteServer.ts
@@ -168,11 +168,10 @@ export class RemoteServer implements MsgHandler, ModelSource, SendTarget {
         "cell/world is",
         msg.worldOrCell.toString(16)
       );
-      const playerActor = Game.getPlayer()!;
       // todo: think about track ragdoll state of player
-      safeRemoveRagdollFromWorld(playerActor, () => {
+      safeRemoveRagdollFromWorld(Game.getPlayer()!, () => {
         TESModPlatform.moveRefrToPosition(
-          playerActor,
+          Game.getPlayer()!,
           Cell.from(Game.getFormEx(msg.worldOrCell)),
           WorldSpace.from(Game.getFormEx(msg.worldOrCell)),
           msg.pos[0],


### PR DESCRIPTION
1. Do not keep player reference across async operations.
2. Shittify code a bit in `browser.ts` to prevent `Unsupported JavaScript type (6)` error (reproduced by killing myself too). By the right of skymp's maintainer, I merge my shitty code piece to see if it really helps. After shittifying the code I wasn't able to reproduce the bug.