### PR TITLE
fix(skymp5-server): improve DLC worldspaces support

### DIFF
--- a/skymp5-server/cpp/addon/main.cc
+++ b/skymp5-server/cpp/addon/main.cc
@@ -1187,8 +1187,7 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
         }
         res = arr;
       } else if (propertyName == "worldOrCellDesc") {
-        auto desc = FormDesc::FromFormId(refr.GetCellOrWorld(),
-                                         partOne->worldState.espmFiles);
+        auto desc = refr.GetCellOrWorld();
         res = JsValue(desc.ToString());
       } else if (propertyName == "baseDesc") {
         auto desc = FormDesc::FromFormId(refr.GetBaseId(),
@@ -1272,9 +1271,7 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
         refr.SetTeleportFlag(true);
       } else if (propertyName == "worldOrCellDesc") {
         std::string str = newValue.get<std::string>();
-        uint32_t formId =
-          FormDesc::FromString(str).ToFormId(partOne->worldState.espmFiles);
-        refr.SetCellOrWorld(formId);
+        refr.SetCellOrWorld(FormDesc::FromString(str));
       } else if (propertyName == "isOpen") {
         refr.SetOpen(newValue.get<bool>());
       } else if (propertyName == "appearance") {
@@ -1337,7 +1334,9 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
 
       std::string type = akFormToPlace.rec->GetType().ToString();
 
-      LocationalData locationalData = { { 0, 0, 0 }, { 0, 0, 0 }, 0x3c };
+      LocationalData locationalData = { { 0, 0, 0 },
+                                        { 0, 0, 0 },
+                                        FormDesc::Tamriel() };
       FormCallbacks callbacks = partOne->CreateFormCallbacks();
 
       std::unique_ptr<MpObjectReference> newRefr;

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -88,10 +88,13 @@ void ActionListener::OnUpdateMovement(const RawMessageData& rawMsgData,
       std::numeric_limits<float>::infinity()
     };
 
+    auto& espmFiles = actor->GetParent()->espmFiles;
     if (!MovementValidation::Validate(
-          *actor, teleportFlag ? reallyWrongPos : pos, worldOrCell,
+          *actor, teleportFlag ? reallyWrongPos : pos,
+          FormDesc::FromFormId(worldOrCell, espmFiles),
           isMe ? static_cast<IMessageOutput&>(msgOutput)
-               : static_cast<IMessageOutput&>(msgOutputDummy))) {
+               : static_cast<IMessageOutput&>(msgOutputDummy),
+          espmFiles)) {
       return;
     }
 

--- a/skymp5-server/cpp/server_guest_lib/DummyWorldObject.h
+++ b/skymp5-server/cpp/server_guest_lib/DummyWorldObject.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "FormDesc.h"
 #include "IWorldObject.h"
 #include "NiPoint3.h"
 #include <cstdint>
@@ -6,7 +7,7 @@
 class DummyWorldObject : public IWorldObject
 {
 public:
-  DummyWorldObject(NiPoint3 pos_, NiPoint3 angle_, uint32_t cellOrWorld_)
+  DummyWorldObject(NiPoint3 pos_, NiPoint3 angle_, FormDesc cellOrWorld_)
     : pos(pos_)
     , angle(angle_)
     , cellOrWorld(cellOrWorld_)
@@ -15,9 +16,9 @@ public:
 
   const NiPoint3& GetPos() const override { return pos; }
   const NiPoint3& GetAngle() const override { return angle; }
-  const uint32_t& GetCellOrWorld() const override { return cellOrWorld; }
+  const FormDesc& GetCellOrWorld() const override { return cellOrWorld; }
 
 private:
   NiPoint3 pos, angle;
-  uint32_t cellOrWorld;
+  FormDesc cellOrWorld;
 };

--- a/skymp5-server/cpp/server_guest_lib/FormDesc.h
+++ b/skymp5-server/cpp/server_guest_lib/FormDesc.h
@@ -39,6 +39,8 @@ public:
       std::make_tuple(right.shortFormId, right.file);
   }
 
+  static FormDesc Tamriel() { return FromString("3c:Skyrim.esm"); }
+
   uint32_t shortFormId = 0;
   std::string file;
 };

--- a/skymp5-server/cpp/server_guest_lib/IWorldObject.h
+++ b/skymp5-server/cpp/server_guest_lib/IWorldObject.h
@@ -1,6 +1,7 @@
 #pragma once
 
 class NiPoint3;
+class FormDesc;
 
 class IWorldObject
 {
@@ -9,5 +10,5 @@ public:
 
   virtual const NiPoint3& GetPos() const = 0;
   virtual const NiPoint3& GetAngle() const = 0;
-  virtual const uint32_t& GetCellOrWorld() const = 0;
+  virtual const FormDesc& GetCellOrWorld() const = 0;
 };

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
@@ -1,4 +1,5 @@
 #include "MovementValidation.h"
+#include "FormDesc.h"
 #include "NetworkingInterface.h"
 #include "NiPoint3.h"
 #include <nlohmann/json.hpp>
@@ -6,7 +7,9 @@
 
 bool MovementValidation::Validate(const IWorldObject& worldObject,
                                   const NiPoint3& newPos,
-                                  uint32_t newCellOrWorld, IMessageOutput& tgt)
+                                  const FormDesc& newCellOrWorld,
+                                  IMessageOutput& tgt,
+                                  const std::vector<std::string>& espmFiles)
 {
   const auto& currentPos = worldObject.GetPos();
   const auto& currentRot = worldObject.GetAngle();
@@ -21,7 +24,7 @@ bool MovementValidation::Validate(const IWorldObject& worldObject,
       { "type", "teleport" },
       { "pos", { currentPos[0], currentPos[1], currentPos[2] } },
       { "rot", { currentRot[0], currentRot[1], currentRot[2] } },
-      { "worldOrCell", currentCellOrWorld }
+      { "worldOrCell", currentCellOrWorld.ToFormId(espmFiles) }
     }.dump();
     tgt.Send(reinterpret_cast<uint8_t*>(s.data()), s.length(), true);
     return false;

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.h
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.h
@@ -2,8 +2,11 @@
 #include "IMessageOutput.h"
 #include "IWorldObject.h"
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace MovementValidation {
 bool Validate(const IWorldObject& worldObject, const NiPoint3& newPos,
-              uint32_t newCellOrWorld, IMessageOutput& tgt);
+              const FormDesc& newCellOrWorld, IMessageOutput& tgt,
+              const std::vector<std::string>& espmFiles);
 }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -304,7 +304,7 @@ void MpActor::SendAndSetDeathState(const LocationalData& position, bool isDead,
     changeForm.staminaPercentage = attribute;
   });
   if (shouldTeleport) {
-    SetCellOrWorldObsolete(position.cellOrWorld);
+    SetCellOrWorldObsolete(position.cellOrWorldDesc);
     SetPos(position.pos);
     SetAngle(position.rot);
   }
@@ -321,7 +321,8 @@ std::string MpActor::GetDeathStateMsg(const LocationalData& position,
     tTeleport = nlohmann::json{
       { "pos", { position.pos[0], position.pos[1], position.pos[2] } },
       { "rot", { position.rot[0], position.rot[1], position.rot[2] } },
-      { "worldOrCell", position.cellOrWorld },
+      { "worldOrCell",
+        position.cellOrWorldDesc.ToFormId(GetParent()->espmFiles) },
       { "type", "teleport" }
     };
   }
@@ -397,12 +398,13 @@ void MpActor::Teleport(const LocationalData& position)
   teleportMsg += nlohmann::json{
     { "pos", { position.pos[0], position.pos[1], position.pos[2] } },
     { "rot", { position.rot[0], position.rot[1], position.rot[2] } },
-    { "worldOrCell", position.cellOrWorld },
+    { "worldOrCell",
+      position.cellOrWorldDesc.ToFormId(GetParent()->espmFiles) },
     { "type", "teleport" }
   }.dump();
   SendToUser(teleportMsg.data(), teleportMsg.size(), true);
 
-  SetCellOrWorldObsolete(position.cellOrWorld);
+  SetCellOrWorldObsolete(position.cellOrWorldDesc);
   SetPos(position.pos);
   SetAngle(position.rot);
 }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -11,7 +11,7 @@ class WorldState;
 constexpr float kRespawnTimeSeconds = 5.f;
 static const LocationalData kSpawnPos = { { 133857, -61130, 14662 },
                                           { 0.f, 0.f, 72.f },
-                                          0x3c };
+                                          FormDesc::Tamriel() };
 
 class MpActor : public MpObjectReference
 {

--- a/skymp5-server/cpp/server_guest_lib/MpChangeForms.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpChangeForms.cpp
@@ -11,7 +11,7 @@ nlohmann::json MpChangeForm::ToJson(const MpChangeForm& changeForm)
                       changeForm.position[2] };
   res["angle"] = { changeForm.angle[0], changeForm.angle[1],
                    changeForm.angle[2] };
-  res["worldOrCell"] = changeForm.worldOrCell;
+  res["worldOrCellDesc"] = changeForm.worldOrCellDesc.ToString();
   res["inv"] = changeForm.inv.ToJson();
   res["isHarvested"] = changeForm.isHarvested;
   res["isOpen"] = changeForm.isOpen;
@@ -46,7 +46,7 @@ MpChangeForm MpChangeForm::JsonToChangeForm(simdjson::dom::element& element)
 {
   static const JsonPointer recType("recType"), formDesc("formDesc"),
     baseDesc("baseDesc"), position("position"), angle("angle"),
-    worldOrCell("worldOrCell"), inv("inv"), isHarvested("isHarvested"),
+    worldOrCellDesc("worldOrCellDesc"), inv("inv"), isHarvested("isHarvested"),
     isOpen("isOpen"), baseContainerAdded("baseContainerAdded"),
     nextRelootDatetime("nextRelootDatetime"), isDisabled("isDisabled"),
     profileId("profileId"), isRaceMenuOpen("isRaceMenuOpen"),
@@ -68,14 +68,17 @@ MpChangeForm MpChangeForm::JsonToChangeForm(simdjson::dom::element& element)
   res.baseDesc = FormDesc::FromString(tmp);
 
   ReadEx(element, position, &jTmp);
-  for (int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i) {
     ReadEx(jTmp, i, &res.position[i]);
+  }
 
   ReadEx(element, angle, &jTmp);
-  for (int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i) {
     ReadEx(jTmp, i, &res.angle[i]);
+  }
 
-  ReadEx(element, worldOrCell, &res.worldOrCell);
+  ReadEx(element, worldOrCellDesc, &tmp);
+  res.worldOrCellDesc = FormDesc::FromString(tmp);
 
   ReadEx(element, inv, &jTmp);
   res.inv = Inventory::FromJson(jTmp);
@@ -90,33 +93,25 @@ MpChangeForm MpChangeForm::JsonToChangeForm(simdjson::dom::element& element)
 
   ReadEx(element, appearanceDump, &jTmp);
   res.appearanceDump = simdjson::minify(jTmp);
-  if (res.appearanceDump == "null")
+  if (res.appearanceDump == "null") {
     res.appearanceDump.clear();
+  }
 
   ReadEx(element, equipmentDump, &jTmp);
   res.equipmentDump = simdjson::minify(jTmp);
-  if (res.equipmentDump == "null")
+  if (res.equipmentDump == "null") {
     res.equipmentDump.clear();
-
-  try {
-    ReadEx(element, healthPercentage, &res.healthPercentage);
-    ReadEx(element, magickaPercentage, &res.magickaPercentage);
-    ReadEx(element, staminaPercentage, &res.staminaPercentage);
-    ReadEx(element, isDead, &res.isDead);
-  } catch (JsonIndexException&) {
-  } catch (...) {
-    throw;
   }
 
-  try {
-    simdjson::dom::element jDynamicFields;
-    ReadEx(element, dynamicFields, &jDynamicFields);
-    res.dynamicFields = DynamicFields::FromJson(nlohmann::json::parse(
-      static_cast<std::string>(simdjson::minify(jDynamicFields))));
-  } catch (JsonIndexException&) {
-  } catch (...) {
-    throw;
-  }
+  ReadEx(element, healthPercentage, &res.healthPercentage);
+  ReadEx(element, magickaPercentage, &res.magickaPercentage);
+  ReadEx(element, staminaPercentage, &res.staminaPercentage);
+  ReadEx(element, isDead, &res.isDead);
+
+  simdjson::dom::element jDynamicFields;
+  ReadEx(element, dynamicFields, &jDynamicFields);
+  res.dynamicFields = DynamicFields::FromJson(nlohmann::json::parse(
+    static_cast<std::string>(simdjson::minify(jDynamicFields))));
 
   return res;
 }

--- a/skymp5-server/cpp/server_guest_lib/MpChangeForms.h
+++ b/skymp5-server/cpp/server_guest_lib/MpChangeForms.h
@@ -28,7 +28,7 @@ public:
   FormDesc baseDesc;
   NiPoint3 position = { 0, 0, 0 };
   NiPoint3 angle = { 0, 0, 0 };
-  uint32_t worldOrCell = 0;
+  FormDesc worldOrCellDesc;
   Inventory inv;
   bool isHarvested = false;
   bool isOpen = false;
@@ -61,7 +61,7 @@ public:
   {
     return std::make_tuple(
       recType, formDesc, baseDesc, position.x, position.y, position.z, angle.x,
-      angle.y, angle.z, worldOrCell, inv.ToJson(), isHarvested, isOpen,
+      angle.y, angle.z, worldOrCellDesc, inv.ToJson(), isHarvested, isOpen,
       baseContainerAdded, nextRelootDatetime, isDisabled, profileId,
       isRaceMenuOpen, appearanceDump, equipmentDump);
   }

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -129,7 +129,7 @@ MpObjectReference::MpObjectReference(
   MpChangeFormREFR changeForm;
   changeForm.position = locationalData_.pos;
   changeForm.angle = locationalData_.rot;
-  changeForm.worldOrCell = locationalData_.cellOrWorld;
+  changeForm.worldOrCellDesc = locationalData_.cellOrWorldDesc;
   pImpl.reset(new Impl{ changeForm, this });
 
   if (primitiveBoundsDiv2)
@@ -146,9 +146,9 @@ const NiPoint3& MpObjectReference::GetAngle() const
   return pImpl->ChangeForm().angle;
 }
 
-const uint32_t& MpObjectReference::GetCellOrWorld() const
+const FormDesc& MpObjectReference::GetCellOrWorld() const
 {
-  return pImpl->ChangeForm().worldOrCell;
+  return pImpl->ChangeForm().worldOrCellDesc;
 }
 
 const uint32_t& MpObjectReference::GetBaseId() const
@@ -417,7 +417,7 @@ void MpObjectReference::SetChanceNoneOverride(uint8_t newChanceNone)
   chanceNoneOverride.reset(new uint8_t(newChanceNone));
 }
 
-void MpObjectReference::SetCellOrWorld(uint32_t newWorldOrCell)
+void MpObjectReference::SetCellOrWorld(const FormDesc& newWorldOrCell)
 {
   SetCellOrWorldObsolete(newWorldOrCell);
   ForceSubscriptionsUpdate();
@@ -451,17 +451,21 @@ void MpObjectReference::SetActivationBlocked(bool blocked)
 
 void MpObjectReference::ForceSubscriptionsUpdate()
 {
-  if (!GetParent() || IsDisabled())
+  auto worldState = GetParent();
+  if (!worldState || IsDisabled()) {
     return;
+  }
   InitListenersAndEmitters();
 
-  auto& gridInfo = GetParent()->grids[GetCellOrWorld()];
+  auto worldOrCell = GetCellOrWorld().ToFormId(worldState->espmFiles);
+
+  auto& gridInfo = worldState->grids[worldOrCell];
   MoveOnGrid(*gridInfo.grid);
 
   auto& was = *this->listeners;
   auto pos = GetGridPos(GetPos());
-  auto& now = GetParent()->GetReferencesAtPosition(GetCellOrWorld(), pos.first,
-                                                   pos.second);
+  auto& now =
+    worldState->GetReferencesAtPosition(worldOrCell, pos.first, pos.second);
 
   std::vector<MpObjectReference*> toRemove;
   std::set_difference(was.begin(), was.end(), now.begin(), now.end(),
@@ -777,7 +781,7 @@ void MpObjectReference::ApplyChangeForm(const MpChangeForm& changeForm)
 
   // Perform all required grid operations
   changeForm.isDisabled ? Disable() : Enable();
-  SetCellOrWorldObsolete(changeForm.worldOrCell);
+  SetCellOrWorldObsolete(changeForm.worldOrCellDesc);
   SetPos(changeForm.position);
 
   if (changeForm.profileId >= 0)
@@ -814,41 +818,53 @@ const DynamicFields& MpObjectReference::GetDynamicFields() const
   return pImpl->ChangeForm().dynamicFields;
 }
 
-void MpObjectReference::SetCellOrWorldObsolete(uint32_t newWorldOrCell)
+void MpObjectReference::SetCellOrWorldObsolete(const FormDesc& newWorldOrCell)
 {
   auto worldState = GetParent();
-  if (!worldState)
+  if (!worldState) {
     return;
+  }
+
+  auto worldOrCell =
+    pImpl->ChangeForm().worldOrCellDesc.ToFormId(worldState->espmFiles);
 
   everSubscribedOrListened = false;
-  auto gridIterator = worldState->grids.find(pImpl->ChangeForm().worldOrCell);
-  if (gridIterator != worldState->grids.end())
+  auto gridIterator = worldState->grids.find(worldOrCell);
+  if (gridIterator != worldState->grids.end()) {
     gridIterator->second.grid->Forget(this);
+  }
 
   pImpl->EditChangeForm([&](MpChangeFormREFR& changeForm) {
-    changeForm.worldOrCell = newWorldOrCell;
+    changeForm.worldOrCellDesc = newWorldOrCell;
   });
 }
 
 void MpObjectReference::VisitNeighbours(const Visitor& visitor)
 {
-  if (IsDisabled())
+  if (IsDisabled()) {
     return;
+  }
 
   auto worldState = GetParent();
-  if (!worldState)
+  if (!worldState) {
     return;
+  }
 
-  auto gridIterator = worldState->grids.find(pImpl->ChangeForm().worldOrCell);
-  if (gridIterator == worldState->grids.end())
+  auto worldOrCell =
+    pImpl->ChangeForm().worldOrCellDesc.ToFormId(worldState->espmFiles);
+
+  auto gridIterator = worldState->grids.find(worldOrCell);
+  if (gridIterator == worldState->grids.end()) {
     return;
+  }
 
   auto& grid = gridIterator->second;
   auto pos = GetGridPos(GetPos());
-  auto& neighbours = worldState->GetReferencesAtPosition(
-    GetCellOrWorld(), pos.first, pos.second);
-  for (auto neighbour : neighbours)
+  auto& neighbours =
+    worldState->GetReferencesAtPosition(worldOrCell, pos.first, pos.second);
+  for (auto neighbour : neighbours) {
     visitor(neighbour);
+  }
 }
 
 void MpObjectReference::SendPapyrusEvent(const char* eventName,
@@ -899,6 +915,7 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
 {
   auto actorActivator = dynamic_cast<MpActor*>(&activationSource);
 
+  auto worldState = GetParent();
   auto& loader = GetParent()->GetEspm();
   auto& compressedFieldsCache = GetParent()->GetEspmCache();
 
@@ -946,14 +963,16 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
         RequestReloot();
       }
 
-      auto destinationRecord = espm::Convert<espm::REFR>(
-        loader.GetBrowser().LookupById(teleport->destinationDoor).rec);
-      if (!destinationRecord)
+      auto destination =
+        loader.GetBrowser().LookupById(teleport->destinationDoor);
+      auto destinationRecord = espm::Convert<espm::REFR>(destination.rec);
+      if (!destinationRecord) {
         throw std::runtime_error(
           "No destination found for this teleport door");
+      }
 
-      auto teleportWorldOrCell =
-        GetWorldOrCell(loader.GetBrowser(), destinationRecord);
+      auto teleportWorldOrCell = destination.ToGlobalId(
+        GetWorldOrCell(loader.GetBrowser(), destinationRecord));
 
       static const auto g_pi = std::acos(-1.f);
       const NiPoint3 rot = { teleport->rotRadians[0] / g_pi * 180,
@@ -971,7 +990,8 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
       if (actorActivator)
         actorActivator->SendToUser(msg.data(), msg.size(), true);
 
-      activationSource.SetCellOrWorldObsolete(teleportWorldOrCell);
+      activationSource.SetCellOrWorldObsolete(
+        FormDesc::FromFormId(teleportWorldOrCell, worldState->espmFiles));
       activationSource.SetPos(
         { teleport->pos[0], teleport->pos[1], teleport->pos[2] });
       activationSource.SetAngle(rot);
@@ -1033,13 +1053,16 @@ bool MpObjectReference::MpApiOnActivate(MpObjectReference& caster)
 
 void MpObjectReference::RemoveFromGrid()
 {
-  auto gridIterator = GetParent()->grids.find(GetCellOrWorld());
-  if (gridIterator != GetParent()->grids.end())
+  auto worldOrCell = GetCellOrWorld().ToFormId(GetParent()->espmFiles);
+  auto gridIterator = GetParent()->grids.find(worldOrCell);
+  if (gridIterator != GetParent()->grids.end()) {
     gridIterator->second.grid->Forget(this);
+  }
 
   auto listenersCopy = GetListeners();
-  for (auto listener : listenersCopy)
+  for (auto listener : listenersCopy) {
     Unsubscribe(this, listener);
+  }
 
   everSubscribedOrListened = false;
 }
@@ -1255,19 +1278,23 @@ void MpObjectReference::CheckInteractionAbility(MpObjectReference& refr)
   auto& loader = GetParent()->GetEspm();
   auto& compressedFieldsCache = GetParent()->GetEspmCache();
 
-  auto casterWorld = loader.GetBrowser().LookupById(refr.GetCellOrWorld()).rec;
-  auto targetWorld = loader.GetBrowser().LookupById(GetCellOrWorld()).rec;
+  auto casterWorldId = refr.GetCellOrWorld().ToFormId(GetParent()->espmFiles);
+  auto targetWorldId = GetCellOrWorld().ToFormId(GetParent()->espmFiles);
+
+  auto casterWorld = loader.GetBrowser().LookupById(casterWorldId).rec;
+  auto targetWorld = loader.GetBrowser().LookupById(targetWorldId).rec;
 
   if (targetWorld != casterWorld) {
     const char* casterWorldName =
-      casterWorld ? casterWorld->GetEditorId(compressedFieldsCache) : "";
+      casterWorld ? casterWorld->GetEditorId(compressedFieldsCache) : "<null>";
 
     const char* targetWorldName =
-      targetWorld ? targetWorld->GetEditorId(compressedFieldsCache) : "";
-    std::stringstream ss;
-    ss << "WorldSpace doesn't match: caster is in " << casterWorldName
-       << ", target is in " << targetWorldName;
-    throw std::runtime_error(ss.str());
+      targetWorld ? targetWorld->GetEditorId(compressedFieldsCache) : "<null>";
+
+    throw std::runtime_error(fmt::format(
+      "WorldSpace doesn't match: caster is in {} ({:#x}), target is in "
+      "{} ({:#x})",
+      casterWorldName, casterWorldId, targetWorldName, targetWorldId));
   }
 }
 

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -22,7 +22,7 @@
 struct LocationalData
 {
   NiPoint3 pos, rot;
-  uint32_t cellOrWorld = 0;
+  FormDesc cellOrWorldDesc;
 };
 
 struct GridPosInfo
@@ -72,7 +72,7 @@ public:
 
   const NiPoint3& GetPos() const override;
   const NiPoint3& GetAngle() const override;
-  const uint32_t& GetCellOrWorld() const override;
+  const FormDesc& GetCellOrWorld() const override;
   const uint32_t& GetBaseId() const;
   const Inventory& GetInventory() const;
   const bool& IsHarvested() const;
@@ -103,7 +103,7 @@ public:
   void TakeItem(MpActor& actor, const Inventory::Entry& entry);
   void SetRelootTime(std::chrono::system_clock::duration newRelootTime);
   void SetChanceNoneOverride(uint8_t chanceNone);
-  void SetCellOrWorld(uint32_t worldOrCell);
+  void SetCellOrWorld(const FormDesc& worldOrCell);
   void SetAnimationVariableBool(const char* name, bool value);
   void Disable();
   void Enable();
@@ -155,7 +155,7 @@ public:
 
   // This method removes ObjectReference from a current grid and doesn't attach
   // to another grid
-  void SetCellOrWorldObsolete(uint32_t worldOrCell);
+  void SetCellOrWorldObsolete(const FormDesc& worldOrCell);
 
   using Visitor = std::function<void(MpObjectReference*)>;
   void VisitNeighbours(const Visitor& visitor);

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -285,7 +285,8 @@ bool WorldState::AttachEspmRecord(const espm::CombineBrowser& br,
   auto formId = espm::GetMappedId(record->GetId(), mapping);
   auto locationalData = data.loc;
 
-  uint32_t worldOrCell = GetWorldOrCell(br, record);
+  uint32_t worldOrCell =
+    espm::GetMappedId(GetWorldOrCell(br, record), mapping);
   if (!worldOrCell) {
     logger->error("Anomally: refr without world/cell");
     return false;
@@ -318,9 +319,10 @@ bool WorldState::AttachEspmRecord(const espm::CombineBrowser& br,
 
     auto typeStr = t.ToString();
     std::unique_ptr<MpForm> form;
-    LocationalData formLocationalData = { GetPos(locationalData),
-                                          GetRot(locationalData),
-                                          worldOrCell };
+    LocationalData formLocationalData = {
+      GetPos(locationalData), GetRot(locationalData),
+      FormDesc::FromFormId(worldOrCell, espmFiles)
+    };
     if (t != "NPC_") {
       form.reset(new MpObjectReference(formLocationalData,
                                        formCallbacksFactory(), baseId,

--- a/unit/CraftTest.cpp
+++ b/unit/CraftTest.cpp
@@ -64,7 +64,8 @@ TEST_CASE("Player is able to craft item", "[Craft][espm]")
   auto& refr = p.worldState.GetFormAt<MpObjectReference>(workbenchId);
 
   DoConnect(p, 0);
-  p.CreateActor(0xff000000, refr.GetPos(), 0, refr.GetCellOrWorld());
+  p.CreateActor(0xff000000, refr.GetPos(), 0,
+                refr.GetCellOrWorld().ToFormId(p.worldState.espmFiles));
   p.SetUserActor(0, 0xff000000);
   auto& ac = p.worldState.GetFormAt<MpActor>(0xff000000);
   for (auto entry : requiredItems.entries)
@@ -115,7 +116,8 @@ TEST_CASE(
   auto& workbench = p.worldState.GetFormAt<MpObjectReference>(workbenchId);
 
   DoConnect(p, 0);
-  p.CreateActor(0xff000000, workbench.GetPos(), 0, workbench.GetCellOrWorld());
+  p.CreateActor(0xff000000, workbench.GetPos(), 0,
+                workbench.GetCellOrWorld().ToFormId(p.worldState.espmFiles));
   p.SetUserActor(0, 0xff000000);
   auto& ac = p.worldState.GetFormAt<MpActor>(0xff000000);
   for (auto entry : requiredItems.entries)

--- a/unit/MovementValidationTest.cpp
+++ b/unit/MovementValidationTest.cpp
@@ -9,11 +9,11 @@
 TEST_CASE("Returns true and sends nothing for normal movement",
           "[MovementValidation]")
 {
-  DummyWorldObject obj({ 0, 0, 0 }, { 0, 0, 0 }, 0x3c);
+  DummyWorldObject obj({ 0, 0, 0 }, { 0, 0, 0 }, FormDesc::Tamriel());
   DummyMessageOutput messageOutput;
 
-  bool res =
-    MovementValidation::Validate(obj, { 1, 1, 1 }, 0x3c, messageOutput);
+  bool res = MovementValidation::Validate(
+    obj, { 1, 1, 1 }, FormDesc::Tamriel(), messageOutput, { "Skyrim.esm" });
   REQUIRE(res);
   REQUIRE(messageOutput.messages.empty());
 }
@@ -21,13 +21,14 @@ TEST_CASE("Returns true and sends nothing for normal movement",
 TEST_CASE("Returns false and sends teleport packet when moving too fast",
           "[MovementValidation]")
 {
-  DummyWorldObject obj({ 1, -1, 1 }, { 123, 111, 123 }, 0x3c);
+  DummyWorldObject obj({ 1, -1, 1 }, { 123, 111, 123 }, FormDesc::Tamriel());
   DummyMessageOutput messageOutput;
 
   float maxLegalMove = 4096;
 
   bool res = MovementValidation::Validate(
-    obj, obj.GetPos() + NiPoint3{ maxLegalMove, 0, 0 }, 0x3c, messageOutput);
+    obj, obj.GetPos() + NiPoint3{ maxLegalMove, 0, 0 }, FormDesc::Tamriel(),
+    messageOutput, { "Skyrim.esm" });
   REQUIRE(!res);
   REQUIRE(messageOutput.messages.size() == 1);
   REQUIRE(messageOutput.messages[0].j ==
@@ -41,11 +42,12 @@ TEST_CASE(
   "Returns false and sends teleport packet when moving between locations",
   "[MovementValidation]")
 {
-  DummyWorldObject obj({ 1, -1, 1 }, { 123, 111, 123 }, 0x3c);
+  DummyWorldObject obj({ 1, -1, 1 }, { 123, 111, 123 }, FormDesc::Tamriel());
   DummyMessageOutput messageOutput;
 
-  bool res =
-    MovementValidation::Validate(obj, obj.GetPos(), 0x00ffffff, messageOutput);
+  bool res = MovementValidation::Validate(
+    obj, obj.GetPos(), FormDesc::FromString("ffffff:Skyrim.esm"),
+    messageOutput, { "Skyrim.esm" });
   REQUIRE(!res);
   REQUIRE(messageOutput.messages.size() == 1);
   REQUIRE(messageOutput.messages[0].j ==

--- a/unit/ObjectReferenceTest.cpp
+++ b/unit/ObjectReferenceTest.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Disable makes ref invisible", "[ObjectReference]")
   PartOne p;
 
   auto& ref = CreateMpObjectReference_(p.worldState, 0xff000000);
-  ref.SetCellOrWorld(0x3c);
+  ref.SetCellOrWorld(FormDesc::Tamriel());
 
   p.CreateActor(0xff000001, { 0, 0, 0 }, 0, 0x3c);
   DoConnect(p, 0);

--- a/unit/PapyrusCompatibilityTest.cpp
+++ b/unit/PapyrusCompatibilityTest.cpp
@@ -79,7 +79,7 @@ TEST_CASE("Activate auto load door in BrokenOarGrotto01", "[PartOne][espm]")
 
   ref.Activate(actor);
 
-  REQUIRE(actor.GetCellOrWorld() == 0x3c);
+  REQUIRE(actor.GetCellOrWorld() == FormDesc::Tamriel());
 
   partOne.worldState.DestroyForm(0xff000000);
 

--- a/unit/PartOne_ActivateTest.cpp
+++ b/unit/PartOne_ActivateTest.cpp
@@ -96,8 +96,8 @@ TEST_CASE("Activate with incorrect WorldSpace", "[PartOne][espm]")
       nlohmann::json{
         { "t", MsgType::Activate },
         { "data", { { "caster", 0x14 }, { "target", barrelInWhiterun } } } }),
-    Contains("WorldSpace doesn't match: caster is in Tamriel, target is in "
-             "WhiterunWorld"));
+    Contains("WorldSpace doesn't match: caster is in Tamriel (0x3c), target "
+             "is in WhiterunWorld (0x1a26f)"));
 
   DoDisconnect(partOne, 0);
   partOne.DestroyActor(0xff000000);
@@ -258,7 +258,7 @@ TEST_CASE("Activate WRDoorMainGate01 in Whiterun", "[PartOne][espm]")
   REQUIRE(partOne.Messages()[1].j["worldOrCell"] == 0x3c);
 
   auto& ac = partOne.worldState.GetFormAt<MpActor>(0xff000000);
-  REQUIRE(ac.GetCellOrWorld() == 0x3c);
+  REQUIRE(ac.GetCellOrWorld() == FormDesc::Tamriel());
 
   partOne.Messages().clear();
   std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/unit/PartOne_ActorTest.cpp
+++ b/unit/PartOne_ActorTest.cpp
@@ -20,7 +20,7 @@ TEST_CASE("CreateActor/DestroyActor", "[PartOne]")
   REQUIRE(ac);
   REQUIRE(ac->GetPos() == NiPoint3{ 1.f, 2.f, 3.f });
   REQUIRE(ac->GetAngle() == NiPoint3{ 0.f, 0.f, 180.f });
-  REQUIRE(ac->GetCellOrWorld() == 0x3c);
+  REQUIRE(ac->GetCellOrWorld() == FormDesc::Tamriel());
 
   // Destroy:
 

--- a/unit/RespawnTest.cpp
+++ b/unit/RespawnTest.cpp
@@ -42,7 +42,7 @@ TEST_CASE("DeathState packed is correct if actor is respawning", "[Respawn]")
   auto& ac = p.worldState.GetFormAt<MpActor>(0xff000000);
   ac.SetPos(kSpawnPos.pos);
   ac.SetAngle(kSpawnPos.rot);
-  ac.SetCellOrWorld(kSpawnPos.cellOrWorld);
+  ac.SetCellOrWorld(kSpawnPos.cellOrWorldDesc);
 
   ac.Kill();
   p.Messages().clear();

--- a/unit/WorldStateTest.cpp
+++ b/unit/WorldStateTest.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Load ChangeForm of created Actor", "[WorldState]")
   MpChangeForm changeForm;
   changeForm.recType = MpChangeForm::ACHR;
   changeForm.position = { 1, 2, 3 };
-  changeForm.worldOrCell = 0x3c;
+  changeForm.worldOrCellDesc = FormDesc::Tamriel();
   changeForm.baseDesc = { 0xabcd, "Tribunal.esm" };
 
   worldState.LoadChangeForm(changeForm, FormCallbacks::DoNothing());
@@ -47,7 +47,7 @@ TEST_CASE("Load ChangeForm of created Actor", "[WorldState]")
   REQUIRE(refr.GetFormId() == 0xff000000);
   REQUIRE(refr.GetChangeForm().formDesc.ToString() == "0");
   REQUIRE(refr.GetPos() == NiPoint3{ 1, 2, 3 });
-  REQUIRE(refr.GetCellOrWorld() == 0x3c);
+  REQUIRE(refr.GetCellOrWorld() == FormDesc::Tamriel());
   REQUIRE(refr.GetBaseId() == 0x0100abcd);
 }
 
@@ -59,7 +59,7 @@ TEST_CASE("Load ChangeForm of created Actor with isDisabled=true",
 
   MpChangeForm changeForm;
   changeForm.recType = MpChangeForm::ACHR;
-  changeForm.worldOrCell = 0xdead;
+  changeForm.worldOrCellDesc = FormDesc::FromString("dead:Morrowind.esm");
   changeForm.baseDesc = { 0xabcd, "Tribunal.esm" };
   changeForm.isDisabled = true;
 
@@ -79,7 +79,7 @@ TEST_CASE("Load ChangeForm of created Actor with profileId", "[WorldState]")
 
   MpChangeForm changeForm;
   changeForm.recType = MpChangeForm::ACHR;
-  changeForm.worldOrCell = 0xdead;
+  changeForm.worldOrCellDesc = FormDesc::FromString("dead:Morrowind.esm");
   changeForm.baseDesc = { 0xabcd, "Tribunal.esm" };
   changeForm.isDisabled = true;
   changeForm.profileId = 100;
@@ -100,7 +100,7 @@ TEST_CASE("Load ChangeForm of modified object", "[WorldState]")
   MpChangeForm changeForm;
   changeForm.formDesc = { 0xeeee, "Skyrim.esm" };
   changeForm.position = { 1, 2, 3 };
-  changeForm.worldOrCell = 0x3c;
+  changeForm.worldOrCellDesc = FormDesc::Tamriel();
   changeForm.baseDesc = { 0xabcd, "Skyrim.esm" };
 
   auto newRefr = new MpObjectReference(
@@ -112,7 +112,7 @@ TEST_CASE("Load ChangeForm of modified object", "[WorldState]")
   REQUIRE(refr.GetFormId() == 0xeeee);
   REQUIRE(refr.GetChangeForm().formDesc.ToString() == "eeee:Skyrim.esm");
   REQUIRE(refr.GetPos() == NiPoint3{ 1, 2, 3 });
-  REQUIRE(refr.GetCellOrWorld() == 0x3c);
+  REQUIRE(refr.GetCellOrWorld() == FormDesc::Tamriel());
   REQUIRE(refr.GetBaseId() == 0x0000abcd);
   REQUIRE(refr.Type() == std::string("ObjectReference"));
   REQUIRE(&refr == newRefr);


### PR DESCRIPTION
closes #50 

1. You can now activate objects in non-Skyrim.esm world spaces.
2. Save files now using `formDesc` instead of `formId` to store your current world space.

**Warning! Old save files are incompatible.**