### PR TITLE
fix(skyrim-platform): change behavior of cursor render

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
@@ -22,10 +22,10 @@
 #include <RE/BSScript/ObjectTypeInfo.h>
 #include <RE/SkyrimScript/HandlePolicy.h>
 
-#include <sstream>
-#include <windows.h>
 #include "hooks/DInputHook.hpp"
 #include "ui/DX11RenderHandler.h"
+#include <sstream>
+#include <windows.h>
 
 typedef struct _ExampleListener ExampleListener;
 typedef enum _ExampleHookId ExampleHookId;

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
@@ -332,22 +332,6 @@ static void example_listener_on_leave(GumInvocationListener* listener,
       EventsApi::SendAnimationEventLeave(res);
       break;
     }
-    case RENDER_CURSOR_MENU: {
-      auto _ic = (_GumInvocationContext*)ic;
-
-      static auto fsCursorMenu = new BSFixedString("Cursor Menu");
-      auto cursorMenu = FridaHooksUtils::GetMenuByName(fsCursorMenu);
-      auto this_ = (int64_t*)_ic->cpu_context->rcx;
-      auto viewPtr = reinterpret_cast<void**>(((uint8_t*)this_) + 0x10);
-      bool renderHookInProgress = g_prevCursorMenuView != nullptr;
-      if (renderHookInProgress)
-        if (this_)
-          if (cursorMenu == this_) {
-            *viewPtr = g_prevCursorMenuView;
-            g_prevCursorMenuView = nullptr;
-          }
-      break;
-    }
     case SEND_EVENT: {
       EventsApi::SendPapyrusEventLeave();
       break;

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
@@ -292,25 +292,27 @@ static void example_listener_on_enter(GumInvocationListener* listener,
       auto cursorMenu = FridaHooksUtils::GetMenuByName(fsCursorMenu);
       auto this_ = (int64_t*)_ic->cpu_context->rcx;
       if (g_allowHideCursorMenu) {
-        if (this_)
+        if (this_) {
           if (cursorMenu == this_) {
             bool& visibleFlag = CEFUtils::DX11RenderHandler::Visible();
             bool& focusFlag = CEFUtils::DInputHook::ChromeFocus();
             if (visibleFlag && focusFlag) {
               if (!g_transparentCursor) {
-                g_transparentCursor = true;
-                FridaHooksUtils::SetMenuNumberVariable(
-                  fsCursorMenu, "_root.mc_Cursor._alpha", 0);
+                if (FridaHooksUtils::SetMenuNumberVariable(
+                      fsCursorMenu, "_root.mc_Cursor._alpha", 0)) {
+                  g_transparentCursor = true;
+                }
               }
-
             } else {
               if (g_transparentCursor) {
-                g_transparentCursor = false;
-                FridaHooksUtils::SetMenuNumberVariable(
-                  fsCursorMenu, "_root.mc_Cursor._alpha", 100);
+                if (FridaHooksUtils::SetMenuNumberVariable(
+                      fsCursorMenu, "_root.mc_Cursor._alpha", 100)) {
+                  g_transparentCursor = false;
+                }
               }
             }
           }
+        }
       }
       break;
     }

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
@@ -22,7 +22,6 @@
 #include <RE/BSScript/ObjectTypeInfo.h>
 #include <RE/SkyrimScript/HandlePolicy.h>
 
-#include "hooks/DInputHook.hpp"
 #include "ui/DX11RenderHandler.h"
 #include <sstream>
 #include <windows.h>
@@ -302,10 +301,9 @@ static void example_listener_on_enter(GumInvocationListener* listener,
           if (cursorMenu == this_) {
             auto viewPtr = reinterpret_cast<void**>(((uint8_t*)this_) + 0x10);
 
-            bool& focusFlag = CEFUtils::DInputHook::ChromeFocus();
             bool& visibleFlag = CEFUtils::DX11RenderHandler::Visible();
 
-            if (focusFlag && visibleFlag) {
+            if (visibleFlag) {
               g_prevCursorMenuView = *viewPtr;
               *viewPtr = nullptr;
             } else {

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooks.cpp
@@ -112,7 +112,6 @@ void SetupFridaHooks()
 
 thread_local uint32_t g_queueNiNodeActorId = 0;
 thread_local void* g_prevCursorMenuView = nullptr;
-thread_local void* g_prevMemorizedCursorMenuView = nullptr;
 
 bool g_allowHideCursorMenu = true;
 
@@ -288,10 +287,6 @@ static void example_listener_on_enter(GumInvocationListener* listener,
       break;
     }
     case RENDER_CURSOR_MENU: {
-      if (g_prevCursorMenuView != nullptr) {
-        g_prevMemorizedCursorMenuView = g_prevCursorMenuView;
-      }
-
       static auto fsCursorMenu = new BSFixedString("Cursor Menu");
       auto cursorMenu = FridaHooksUtils::GetMenuByName(fsCursorMenu);
       auto this_ = (int64_t*)_ic->cpu_context->rcx;
@@ -304,11 +299,13 @@ static void example_listener_on_enter(GumInvocationListener* listener,
             bool& visibleFlag = CEFUtils::DX11RenderHandler::Visible();
 
             if (visibleFlag) {
-              g_prevCursorMenuView = *viewPtr;
+              if (*viewPtr != nullptr) {
+                g_prevCursorMenuView = *viewPtr;
+              }
               *viewPtr = nullptr;
             } else {
-              if (*viewPtr == nullptr && g_prevMemorizedCursorMenuView) {
-                *viewPtr = g_prevMemorizedCursorMenuView;
+              if (*viewPtr == nullptr && g_prevCursorMenuView) {
+                *viewPtr = g_prevCursorMenuView;
               }
             }
           }

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.cpp
@@ -11,3 +11,16 @@ void* FridaHooksUtils::GetMenuByName(void* name)
   }
   return nullptr;
 }
+
+void FridaHooksUtils::SetMenuNumberVariable(void* name, const char* target,
+                                            double value)
+{
+  if (auto mm = MenuManager::GetSingleton()) {
+    auto view = mm->GetMovieView((BSFixedString*)name);
+    if (view) {
+      GFxValue fxValue;
+      fxValue.SetNumber(value);
+      view->SetVariable(target, &fxValue, 1);
+    }
+  }
+}

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.cpp
@@ -12,15 +12,17 @@ void* FridaHooksUtils::GetMenuByName(void* name)
   return nullptr;
 }
 
-void FridaHooksUtils::SetMenuNumberVariable(void* name, const char* target,
+bool FridaHooksUtils::SetMenuNumberVariable(void* fsName, const char* target,
                                             double value)
 {
   if (auto mm = MenuManager::GetSingleton()) {
-    auto view = mm->GetMovieView((BSFixedString*)name);
+    auto view = mm->GetMovieView(reinterpret_cast<BSFixedString*>(fsName));
     if (view) {
       GFxValue fxValue;
       fxValue.SetNumber(value);
       view->SetVariable(target, &fxValue, 1);
+      return true;
     }
   }
+  return false;
 }

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.h
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.h
@@ -1,4 +1,4 @@
 namespace FridaHooksUtils {
 void* GetMenuByName(void* name);
-void SetMenuNumberVariable(void* name, const char* target, double value);
+bool SetMenuNumberVariable(void* fsName, const char* target, double value);
 }

--- a/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.h
+++ b/skyrim-platform/src/platform_se/skyrim_platform/FridaHooksUtils.h
@@ -1,3 +1,4 @@
 namespace FridaHooksUtils {
 void* GetMenuByName(void* name);
+void SetMenuNumberVariable(void* name, const char* target, double value);
 }

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -1,4 +1,5 @@
 #include "TextToDraw.h"
+#include <DInputHook.hpp>
 #include <DX11RenderHandler.h>
 #include <DirectXColors.h>
 #include <DirectXTK/CommonStates.h>
@@ -81,12 +82,17 @@ void DX11RenderHandler::Render(
     });
   }
 
-  if (m_pCursorTexture && m_cursorX >= 0 && m_cursorY >= 0) {
-    m_pSpriteBatch->Draw(
-      m_pCursorTexture.Get(),
-      DirectX::SimpleMath::Vector2(m_cursorX - 24, m_cursorY - 25), nullptr,
-      DirectX::Colors::White, 0.f, DirectX::SimpleMath::Vector2(0, 0),
-      m_width / 1920.f);
+  bool& focusFlag = CEFUtils::DInputHook::ChromeFocus();
+  bool& visibleFlag = CEFUtils::DX11RenderHandler::Visible();
+
+  if (focusFlag && visibleFlag) {
+    if (m_pCursorTexture && m_cursorX >= 0 && m_cursorY >= 0) {
+      m_pSpriteBatch->Draw(
+        m_pCursorTexture.Get(),
+        DirectX::SimpleMath::Vector2(m_cursorX - 24, m_cursorY - 25), nullptr,
+        DirectX::Colors::White, 0.f, DirectX::SimpleMath::Vector2(0, 0),
+        m_width / 1920.f);
+    }
   }
 
   m_pSpriteBatch->End();

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -1,5 +1,5 @@
 #include "TextToDraw.h"
-#include <DInputHook.hpp>
+#include "DInputHook.hpp"
 #include <DX11RenderHandler.h>
 #include <DirectXColors.h>
 #include <DirectXTK/CommonStates.h>

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -1,4 +1,3 @@
-#include "DInputHook.hpp"
 #include "TextToDraw.h"
 #include <DX11RenderHandler.h>
 #include <DirectXColors.h>
@@ -82,10 +81,9 @@ void DX11RenderHandler::Render(
     });
   }
 
-  bool& focusFlag = CEFUtils::DInputHook::ChromeFocus();
   bool& visibleFlag = CEFUtils::DX11RenderHandler::Visible();
 
-  if (focusFlag && visibleFlag) {
+  if (visibleFlag) {
     if (m_pCursorTexture && m_cursorX >= 0 && m_cursorY >= 0) {
       m_pSpriteBatch->Draw(
         m_pCursorTexture.Get(),

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -1,5 +1,5 @@
-#include "TextToDraw.h"
 #include "DInputHook.hpp"
+#include "TextToDraw.h"
 #include <DX11RenderHandler.h>
 #include <DirectXColors.h>
 #include <DirectXTK/CommonStates.h>

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -1,3 +1,4 @@
+#include "DInputHook.hpp"
 #include "TextToDraw.h"
 #include <DX11RenderHandler.h>
 #include <DirectXColors.h>
@@ -81,9 +82,9 @@ void DX11RenderHandler::Render(
     });
   }
 
-  bool& visibleFlag = CEFUtils::DX11RenderHandler::Visible();
+  bool& focusFlag = CEFUtils::DInputHook::ChromeFocus();
 
-  if (visibleFlag) {
+  if (Visible() && focusFlag) {
     if (m_pCursorTexture && m_cursorX >= 0 && m_cursorY >= 0) {
       m_pSpriteBatch->Draw(
         m_pCursorTexture.Get(),


### PR DESCRIPTION
closes #506 

This little patch changes the behaviour of rendering custom png cursor.

Before: sp redraws cursor with custom all the time
After: cursor swtiched to png only in case of browser focused and visible

The reason why we need this two flags is that people can use broswer in "widget" mode.