### PR TITLE
fix(skymp5-server): fix error in log message forming

### DIFF
--- a/skymp5-server/cpp/lib_espm/espm.cpp
+++ b/skymp5-server/cpp/lib_espm/espm.cpp
@@ -1100,7 +1100,7 @@ espm::Effects::Data espm::Effects::GetData(
       if (!isValid) {
         auto name = parent->GetEditorId(compressedFieldsCache);
         throw std::runtime_error(
-          fmt::format("Bad effect array for edid={}", *name));
+          fmt::format("Bad effect array for edid={}", name));
       }
     },
     compressedFieldsCache);

--- a/skymp5-server/cpp/lib_espm/espm.cpp
+++ b/skymp5-server/cpp/lib_espm/espm.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <fmt/format.h>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -1098,7 +1099,8 @@ espm::Effects::Data espm::Effects::GetData(
       }
       if (!isValid) {
         auto name = parent->GetEditorId(compressedFieldsCache);
-        throw std::runtime_error("Bad effect array. " + *name);
+        throw std::runtime_error(
+          fmt::format("Bad effect array for edid={}", *name));
       }
     },
     compressedFieldsCache);


### PR DESCRIPTION
Fixes this warning:
```
/src/skymp5-server/cpp/lib_espm/espm.cpp:1101:55: warning: adding 'const char' to a string does not append to the string [-Wstring-plus-int]
        throw std::runtime_error("Bad effect array. " + *name);
                                 ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```