### PR TITLE
internal: make Linux builds RelWithDebInfo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
                 description: action (deploy/restart/stop)
                 required: true
                 default: deploy
+
+env:
+    BUILD_TYPE: RelWithDebInfo
+
 jobs:
     deploy:
         runs-on: ubuntu-latest
@@ -96,6 +100,12 @@ jobs:
                     cd /src \
                     && ./build.sh --configure \
                        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+          - name: Upload compile_commands.json
+            uses: actions/upload-artifact@v2
+            with:
+                name: compile_commands.json
+                path: ${{github.workspace}}/build/compile_commands.json
 
           - name: Build
             if: ${{env.DEPLOY_ACTION == 'deploy'}}

--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -5,6 +5,10 @@ on:
     push:
         branches:
           - main
+
+env:
+    BUILD_TYPE: RelWithDebInfo
+
 jobs:
     pr-ubuntu-docker:
         runs-on: ubuntu-latest
@@ -62,14 +66,14 @@ jobs:
                 run: |
                     cd /src \
                     && ./build.sh --configure \
-                       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                       -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                        -DUNIT_DATA_DIR="/src/skyrim_data_files"
 
           - name: Upload compile_commands.json
             uses: actions/upload-artifact@v2
             with:
-              name: compile_commands.json
-              path: ${{github.workspace}}/build/compile_commands.json
+                name: compile_commands.json
+                path: ${{github.workspace}}/build/compile_commands.json
 
           - name: Build
             uses: addnab/docker-run-action@v3

--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -62,10 +62,10 @@ jobs:
                 run: |
                     cd /src \
                     && ./build.sh --configure \
-                       -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+                       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                        -DUNIT_DATA_DIR="/src/skyrim_data_files"
 
-          - name: Upload dist.tar.gz
+          - name: Upload compile_commands.json
             uses: actions/upload-artifact@v2
             with:
               name: compile_commands.json

--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -65,6 +65,12 @@ jobs:
                        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                        -DUNIT_DATA_DIR="/src/skyrim_data_files"
 
+          - name: Upload dist.tar.gz
+            uses: actions/upload-artifact@v2
+            with:
+              name: compile_commands.json
+              path: ${{github.workspace}}/build/compile_commands.json
+
           - name: Build
             uses: addnab/docker-run-action@v3
             with:


### PR DESCRIPTION
`scamp_native.node` became a bit more of a size (34.9 MiB -> 40.6 MiB), but the builds are now both optimized (`-O2`) and have debug info (`-g`):
```json5
[
{
  "directory": "/src/build/viet",
  "command": "/usr/bin/clang++-12  -I/src/viet/src -I/src/viet/include -O2 -g -DNDEBUG -fPIC -std=c++17 -o CMakeFiles/viet.dir/src/Promise.cpp.o -c /src/viet/src/Promise.cpp",
  "file": "/src/viet/src/Promise.cpp"
},
...
]
```