### PR TITLE
refact(skyrim-platform): configure webpack for development mode

### DIFF
--- a/skyrim-platform/tools/plugin-example/webpack.config.js
+++ b/skyrim-platform/tools/plugin-example/webpack.config.js
@@ -62,7 +62,7 @@ if (process.env['DEPLOY_PLUGIN']?.includes('true')) {
 
 module.exports = {
     plugins,
-    mode: 'production',
+    mode: 'development',
     devtool: 'inline-source-map',
     entry: { main: entryPoint, },
     output: { path: outputFolder, filename: outputFilename },


### PR DESCRIPTION
Change webpack of the plugin-example to use mode: development instead of mode: production.

With mode: production, the code is minified to one line making debugging runtime .js errors pretty much impossible.