### PR TITLE
internal: remove skymp5-client.js from server dist

### DIFF
--- a/skymp5-client/CMakeLists.txt
+++ b/skymp5-client/CMakeLists.txt
@@ -15,14 +15,6 @@ add_custom_target(skymp5-client ALL
 )
 add_dependencies(skymp5-client skyrim-platform)
 
-# The server requires `dist/server/dist_front` to contain `skymp5-client.js`
-# This is to be able to reload `skymp5-client.js` for all users when changed
-# That feature is deprecated and would be removed
-add_custom_command(
-  TARGET skymp5-client POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/dist/client/Data/Platform/Plugins/skymp5-client.js ${CMAKE_BINARY_DIR}/dist/server/dist_front/skymp5-client.js
-)
-
 set(skymp5_client_settings_txt "{
   \"server-ip\": \"127.0.0.1\",
   \"server-port\": 7777,

--- a/unit/DistContentsExpected.json
+++ b/unit/DistContentsExpected.json
@@ -71,7 +71,6 @@
       "server/dist_back/systems/system.js.map",
       "server/dist_back/ui.js",
       "server/dist_back/ui.js.map",
-      "server/dist_front/skymp5-client.js",
       "server/gamemode.js",
       "server/scamp_native.node",
       "server/package.json",


### PR DESCRIPTION
This PR follows https://github.com/skyrim-multiplayer/skymp/pull/388
The original PR drops legacy functionality. My PR cleans build system 

TODO: merge this to indev after shipping #722 and then test and merge