### PR TITLE
feat(skymp5-server): add sendCustomPacket method to mp api

### DIFF
--- a/skymp5-server/cpp/addon/main.cc
+++ b/skymp5-server/cpp/addon/main.cc
@@ -1566,14 +1566,10 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
   mp.SetProperty(
     "sendCustomPacket",
     JsValue::Function([this, update](const JsFunctionArguments& args) {
-      try {
-        auto formId = ExtractFormId(args[1]);
-        std::string packet = ExtractNewValueStr(args[2]);
-        auto userId = partOne->GetUserByActor(formId);
-        partOne->SendCustomPacket(userId, packet);
-      } catch (std::exception& e) {
-        throw Napi::Error::New(info.Env(), (std::string)e.what());
-      }
+      auto formId = ExtractFormId(args[1]);
+      std::string packet = ExtractNewValueStr(args[2]);
+      auto userId = partOne->GetUserByActor(formId);
+      partOne->SendCustomPacket(userId, packet);
       return JsValue::Undefined();
     }));
 

--- a/skymp5-server/cpp/addon/main.cc
+++ b/skymp5-server/cpp/addon/main.cc
@@ -1563,6 +1563,20 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
       return JsValue::Undefined();
     }));
 
+  mp.SetProperty(
+    "sendCustomPacket",
+    JsValue::Function([this, update](const JsFunctionArguments& args) {
+      try {
+        auto formId = ExtractFormId(args[1]);
+        std::string packet = ExtractNewValueStr(args[2]);
+        auto userId = partOne->GetUserByActor(formId);
+        partOne->SendCustomPacket(userId, packet);
+      } catch (std::exception& e) {
+        throw Napi::Error::New(info.Env(), (std::string)e.what());
+      }
+      return JsValue::Undefined();
+    }));
+
   JsValue::GlobalObject().SetProperty("mp", mp);
 
   JsValue console = JsValue::Object();


### PR DESCRIPTION
Sometimes you have to execute client code from the api.

In functions-lib we use eval function

```ts
static eval(actorId: number, f: (ctx: Ctx, ...args: any[]) => void, args?: Record<string, unknown>) {
    const code = new FunctionInfo(f).getText(args);
    const value: EvalValue = mp.get(actorId, 'eval') || { commands: [], nextId: 0 };
    value.commands.push({ code, id: value.nextId });
    value.nextId++;
    mp.set(actorId, 'eval', value);
  }
```

but this method requires the conversion of the function into a string and then execution via eval, which is not good, as it seems to me

I propose to describe the logic of the client function in skymp5-client. And when we send a packet like this
```ts
mp.sendCustomPacket(selfId, { type: 'function', name: 'equipItem', data: { itemId, preventRemoval, silent } })
```
then we parse it on the client and call the equipItem function like this

```ts
interface CustomPacket {
	type: 'customPacket';
	content: {
		type: string;
		name: string;
		data: Record<string, unknown>;
	};
}

const customFunctions: any = {
	equipItem: ({ itemId, preventRemoval, silent }: { itemId: number; preventRemoval: boolean; silent: boolean }) => {
		const ac = Game.getPlayer();
		const form = Game.getFormEx(itemId);
		ac?.equipItem(form, preventRemoval, silent);
	},
};

storage.customPacketHandlers = [
	(packet: CustomPacket) => {
		once('update', () => {
			if (packet.content.type === 'function') {
				customFunctions[packet.content.name]?.(packet.content.data);
			}
			printConsole(packet);
		});
	},
];
```