### PR TITLE
internal: allow .git to be a file in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ if [ "`basename "$PWD"`" = "build" ]; then
   cd ..
 fi
 
-if [ ! -d .git ]; then
+if [ ! -e .git ]; then
   eecho "This script should be run from either source root or build directory."
   exit 1
 fi


### PR DESCRIPTION
Turns out `.git` in the repository root can be a regular file if we deal with secondary working trees: \
https://stackoverflow.com/a/30185564