### PR TITLE
internal: improve server deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,6 @@
 name: Deploy
 on:
-    workflow_dispatch:
-        inputs:
-            action:
-                description: action (deploy/restart/stop)
-                required: true
-                default: deploy
+    push:
 
 env:
     BUILD_TYPE: RelWithDebInfo
@@ -17,7 +12,7 @@ jobs:
           - name: Get action
             run: |
                 echo "DEPLOY_BRANCH=indev" >> "$GITHUB_ENV"
-                echo "DEPLOY_ACTION=${{github.event.inputs.action}}" >> "$GITHUB_ENV"
+                echo "DEPLOY_ACTION=restart" >> "$GITHUB_ENV"
 
           - name: Checkout (full)
             if: ${{env.DEPLOY_ACTION == 'deploy'}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
           - name: Get action
             run: |
                 echo "DEPLOY_BRANCH=indev" >> "$GITHUB_ENV"
-                echo "DEPLOY_ACTION=restart" >> "$GITHUB_ENV"
+                echo "DEPLOY_ACTION=deploy" >> "$GITHUB_ENV"
 
           - name: Checkout (full)
             if: ${{env.DEPLOY_ACTION == 'deploy'}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
           - name: Get action
             run: |
                 echo "DEPLOY_BRANCH=indev" >> "$GITHUB_ENV"
-                echo "DEPLOY_ACTION=deploy" >> "$GITHUB_ENV"
+                echo "DEPLOY_ACTION=restart" >> "$GITHUB_ENV"
 
           - name: Checkout (full)
             if: ${{env.DEPLOY_ACTION == 'deploy'}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,11 @@
 name: Deploy
 on:
-    push:
+    workflow_dispatch:
+        inputs:
+            action:
+                description: action (deploy/restart/stop)
+                required: true
+                default: deploy
 
 env:
     BUILD_TYPE: RelWithDebInfo
@@ -12,7 +17,7 @@ jobs:
           - name: Get action
             run: |
                 echo "DEPLOY_BRANCH=indev" >> "$GITHUB_ENV"
-                echo "DEPLOY_ACTION=restart" >> "$GITHUB_ENV"
+                echo "DEPLOY_ACTION=${{github.event.inputs.action}}" >> "$GITHUB_ENV"
 
           - name: Checkout (full)
             if: ${{env.DEPLOY_ACTION == 'deploy'}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Image used as runtime base for a game server.
-# Should only contain a minimal subset of stuff needed for running the server.
-# Not the case currently, too much of a bloat here.
-# TODO: fix it, make another redo of a (cleaner) Dockerfile
+# Contains a minimal subset of stuff needed for running (and debugging, if needed) the server.
 FROM ubuntu:focal AS skymp-runtime-base
 
 # Prevent apt-get from asking us about timezone
@@ -24,7 +22,6 @@ RUN useradd -m skymp
 FROM skymp-runtime-base AS skymp-build-base
 
 # TODO: are perl, upx-ucl, ninja needed?
-# TODO: add gdb to base image
 RUN \
   curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarnkey.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM ubuntu:focal AS skymp-base
 ENV TZ=Europe/London
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# TODO: are perl, upx-ucl, ninja needed?
+# TODO: add gdb to base image
 RUN \
   apt-get update && apt-get install -y curl \
   && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
@@ -59,3 +61,13 @@ FROM skymp-base AS skymp-vcpkg-deps
 
 COPY --from=skymp-vcpkg-deps-builder --chown=skymp:skymp \
   /home/skymp/.cache/vcpkg /home/skymp/.cache/vcpkg
+
+# Image used as runtime base for a game server.
+# Should only contain a minimal subset of stuff needed for running the server.
+# Not the case currently, too much of a bloat here.
+# TODO: fix it, make another redo of a (cleaner) Dockerfile
+FROM skymp-base AS skymp-runtime-base
+
+RUN \
+  apt-get update && apt-get install -y gdb \
+  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
-# This is the base image for building SkyMP source.
-# It contains everything that should be installed on the system.
-FROM ubuntu:focal AS skymp-base
+# Image used as runtime base for a game server.
+# Should only contain a minimal subset of stuff needed for running the server.
+# Not the case currently, too much of a bloat here.
+# TODO: fix it, make another redo of a (cleaner) Dockerfile
+FROM ubuntu:focal AS skymp-runtime-base
 
 # Prevent apt-get from asking us about timezone
 # London is UTC+0:00
 ENV TZ=Europe/London
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+RUN \
+  apt-get update && apt-get install -y curl \
+  && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+  && apt-get update \
+  && apt-get install -y nodejs yarn gdb \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m skymp
+
+
+# This is the base image for building SkyMP source.
+# It contains everything that should be installed on the system.
+FROM skymp-runtime-base AS skymp-build-base
+
 # TODO: are perl, upx-ucl, ninja needed?
 # TODO: add gdb to base image
 RUN \
-  apt-get update && apt-get install -y curl \
-  && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
-  && curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarnkey.gpg \
+  curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarnkey.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list \
   && curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg \
   && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' > /etc/apt/sources.list.d/kitware.list \
@@ -33,17 +47,15 @@ RUN \
     zip \
     pkg-config \
     upx-ucl \
-    cmake=3.22.1-0kitware1ubuntu20.04.1 \
+    cmake=3.22.2-0kitware1ubuntu20.04.1 \
     clang-12 \
   && rm -rf /var/lib/apt/lists/*
-
-RUN useradd -m skymp
 
 
 # Intermediate image to build
 # TODO: copy less stuff, use args to pass the desired vcpkg submodule revision
 # TODO: build huge deps separately
-FROM skymp-base AS skymp-vcpkg-deps-builder
+FROM skymp-build-base AS skymp-vcpkg-deps-builder
 
 COPY --chown=skymp:skymp . /src
 
@@ -61,13 +73,3 @@ FROM skymp-base AS skymp-vcpkg-deps
 
 COPY --from=skymp-vcpkg-deps-builder --chown=skymp:skymp \
   /home/skymp/.cache/vcpkg /home/skymp/.cache/vcpkg
-
-# Image used as runtime base for a game server.
-# Should only contain a minimal subset of stuff needed for running the server.
-# Not the case currently, too much of a bloat here.
-# TODO: fix it, make another redo of a (cleaner) Dockerfile
-FROM skymp-base AS skymp-runtime-base
-
-RUN \
-  apt-get update && apt-get install -y gdb \
-  && rm -rf /var/lib/apt/lists/*

--- a/ci/deploy/push_branch_to_server.sh
+++ b/ci/deploy/push_branch_to_server.sh
@@ -69,7 +69,7 @@ fi
 run_remote "$remote_tmp_dir/branchctl.sh" restart "$DEPLOY_BRANCH"
 
 get_ip_port() {
-  jq --raw-output '"IP: `" + .ip + "`, port: `" + (.port | tostring) + "`"'
+  jq --raw-output '"IP: `'"$DEPLOY_TARGET_HOST"'`, port: `" + (.port | tostring) + "`"'
 }
 
 ip_port="`run_remote cat "$remote_branch_dir/server-settings.json" | get_ip_port`"

--- a/ci/deploy/push_branch_to_server.sh
+++ b/ci/deploy/push_branch_to_server.sh
@@ -40,6 +40,8 @@ remote_branch_dir="skymp-server-$DEPLOY_BRANCH"
 run_remote test -e "$remote_branch_dir" \
   || (echo "no branch on remote server" && exit 1)
 
+# TODO: remove this dir after we're finished
+
 rsync --rsh="$remote_shell" -vazPh --checksum \
     ci/deploy/remote/ "$remote_server_connstr:$remote_tmp_dir/"
 

--- a/ci/deploy/remote/branchctl.sh
+++ b/ci/deploy/remote/branchctl.sh
@@ -24,6 +24,8 @@ docker run -d --restart=always --name="skymp-server-$branch" --network=host \
     skymp/skymp-runtime-base ./run.sh
 # ^ limited to 50% of CPU: https://stackoverflow.com/a/41552172
 
+# This looks a bit ugly, but apparently is more fault-tolerant than older version:
+# docker logs -f ... |& grep -q ...
 for ((t = 0; t < 150; t += 5)); do
     if docker logs "skymp-server-$branch" \
             |& grep -q 'AttachSaveStorage took'; then

--- a/ci/deploy/remote/branchctl.sh
+++ b/ci/deploy/remote/branchctl.sh
@@ -24,5 +24,14 @@ docker run -d --restart=always --name="skymp-server-$branch" --network=host \
 # ^ limited to 50% of CPU: https://stackoverflow.com/a/41552172
 # TODO(#584): replace vcpkg-deps with lite runtime image
 
-timeout 7m docker logs -f "skymp-server-$branch" \
-  |& grep -q 'AttachSaveStorage took'
+for ((t = 0; t < 150; t += 5)); do
+    if docker logs "skymp-server-$branch" \
+            |& grep -q 'AttachSaveStorage took'; then
+        echo health check success
+        exit 0
+    fi
+    sleep 5
+done
+
+echo health check failed
+exit 1

--- a/ci/deploy/remote/branchctl.sh
+++ b/ci/deploy/remote/branchctl.sh
@@ -17,6 +17,7 @@ docker rm "skymp-server-$branch" || true
 
 cp ./server-settings.json server/
 docker run -d --restart=always --name="skymp-server-$branch" --network=host \
+    -v "/var/crash:/var/crash" \
     -v "$PWD/server:/work" --workdir=/work \
     -u "`id -u`:`id -g`" \
     --cpu-period=50000 --cpu-quota=25000 \

--- a/ci/deploy/remote/branchctl.sh
+++ b/ci/deploy/remote/branchctl.sh
@@ -21,6 +21,7 @@ docker run -d --restart=always --name="skymp-server-$branch" --network=host \
     -v "$PWD/server:/work" --workdir=/work \
     -u "`id -u`:`id -g`" \
     --cpu-period=50000 --cpu-quota=25000 \
+    --cap-add=SYS_PTRACE \
     skymp/skymp-runtime-base ./run.sh
 # ^ limited to 50% of CPU: https://stackoverflow.com/a/41552172
 

--- a/ci/deploy/remote/branchctl.sh
+++ b/ci/deploy/remote/branchctl.sh
@@ -20,9 +20,8 @@ docker run -d --restart=always --name="skymp-server-$branch" --network=host \
     -v "$PWD/server:/work" --workdir=/work \
     -u "`id -u`:`id -g`" \
     --cpu-period=50000 --cpu-quota=25000 \
-    skymp/skymp-vcpkg-deps ./run.sh
+    skymp/skymp-runtime-base ./run.sh
 # ^ limited to 50% of CPU: https://stackoverflow.com/a/41552172
-# TODO(#584): replace vcpkg-deps with lite runtime image
 
 for ((t = 0; t < 150; t += 5)); do
     if docker logs "skymp-server-$branch" \

--- a/docs/docs_deploy.md
+++ b/docs/docs_deploy.md
@@ -105,3 +105,70 @@ Several actions are available:
   source, upload build artifacts to the server and restart it
 * `restart` - just restart the server (stop if it is running and start)
 * `stop` - just stop the server
+
+## Debugging crashes
+
+Deployed server might crash under some circumstances. It's important to be able
+to be able to debug it in case something goes wrong.
+
+Prerequisites:
+1. `scamp_server.node` should contain debug symbols, otherwise core dump won't make much sense.
+   Our [CI build](https://github.com/skyrim-multiplayer/skymp/blob/688c5dfeabffd6510d759d5a128349de8898743c/.github/workflows/pr-ubuntu-docker.yml#L10)
+   does include them, but if you're building everything yourself, you may need
+   to explicitly specify `-DCMAKE_BUILD_TYPE=Debug` or `RelWithDebInfo`.
+2. `gdb` should be installed in the environment where your server is running.
+   If server is running inside of a container, its image should include `gdb`:
+   debugging a process inside of a container from the host is not going to work well.
+
+To attach to the server
+
+!!! TODO
+
+### Collecting core dumps
+
+The following is also required if you wish to debug the cases when your server
+crashes without `gdb` being attached. So, this is also strongly recommended to set up.
+1. Configure core dumps on the host system (i.e. if you run it inside of a container,
+   do that on the main machine).
+   1. `ulimit -c` should say `unlimited` (or at least something like 500-1000 MB)
+   2. You may also change `sysctl kernel.core_pattern` to point to an arbitrary
+      FS location (i.e. it should not preferably begin with `|`, in that case it
+      may be hard to use with Docker AND you'll need to properly configure
+      the program core dump would be piped to, i.e. apport for Ubuntu). \
+      Ideally, you should:
+      * Run `sudo sysctl kernel.core_pattern=/var/crash/core-%P-%u-%g-%s-%t-%c-%h`
+      * Add `kernel.core_pattern=/var/crash/core-%P-%u-%g-%s-%t-%c-%h` to the bottom
+        of `/etc/sysctl.cfg` for this setting to persist across reboots
+2. If you run the server inside of a container, `/var/crash` should be volume-mounted.
+   Otherwise, core dumps would go to `/var/crash`, but inside of a container, not the host!
+
+How to check that everything is working fine:
+1. Get server's PID using something like that:
+   ```
+   $ ps aux | grep 'node dist_back' | grep -v grep
+   ubuntu   1532646  5.8  3.7 35411280 609416 ?     SLl  Jan28   2:21 node dist_back/skymp5-server.js  
+            ^~~~~~~ PID you're looking for
+   ```
+2. Force abnormal termination by killing it with `SIGABRT`:
+   ```
+   $ kill -QUIT 1532646
+   ```
+3. If you run it inside of a container, then `docker logs <container name>` should contain:
+   ```
+   ./run.sh: line 8:     7 Quit                    (core dumped) LD_LIBRARY_PATH="$PWD" node dist_back/skymp5-server.js
+   ```
+4. You should also be able to see the core dump in `/var/crash`:
+   ```
+   $ ls -lh /var/crash
+   total 204M
+   -rw------- 1 ubuntu ubuntu 326M Jan 29 00:33 core-1532646-1000-1000-3-<...>
+                                          ^~~~~      ^~~~~~~
+                                   Current time      Server's PID when it crashed
+   ```
+
+Debugging a core dump:
+1. Attach to en existing container with a server (or create a new container
+   with a similar setup) and run `gdb`:
+   `docker exec -it skymp-server-indev gdb /work/scamp_native.node /var/crash/...`
+2. Run `bt` to view a stack trace
+3. Have fun with debugging it...

--- a/docs/docs_deploy.md
+++ b/docs/docs_deploy.md
@@ -119,10 +119,18 @@ Prerequisites:
 2. `gdb` should be installed in the environment where your server is running.
    If server is running inside of a container, its image should include `gdb`:
    debugging a process inside of a container from the host is not going to work well.
+3. If inside of a container, `ptrace` syscall should be available.
+   Add `--cap-add=SYS_PTRACE` argument to your `docker run` command.
 
-To attach to the server
+To attach to the server, run:
+```
+$ docker exec -it -u 0:0 skymp-server-indev sh -c 'gdb -p "`pgrep node`"'
+<...>
+(gdb) c
+```
 
-!!! TODO
+All typical gdb commands should be available now. Set breakpoints or just type
+`c` to contrinue execution right away.
 
 ### Collecting core dumps
 


### PR DESCRIPTION
closes #883

Things that are done in this PR (or along with it):
1. Fix for stuck `timeout 5m docker logs -f ... |& grep -q ...`. It is a bit ugly, but is apparently more stable.
2. Separate image as a runtime base. Docker build system forced me to build new image anyway, so I had no choice but to add `gdb` to base image in a better way ¯\\\_(ツ)\_/¯
3. [related system maintenance, not in PR itself] Setting `kernel.core_pattern` on the host server for core dumps to go to a predefined location (instead of that strange Ubuntu's `apport`)
4. Now also mounting `/var/crash` as a Docker volume (otherwise core dumps go inside of the container's FS)
5. Added `SYS_PTRACE` capability to `docker run` command
6. Docs