### PR TITLE
feat(skymp5-functions-lib): keep round info for SweetPie game mode in persistent storage

### DIFF
--- a/skymp5-functions-lib/src/logic/PlayerController.ts
+++ b/skymp5-functions-lib/src/logic/PlayerController.ts
@@ -1,3 +1,5 @@
+import { SweetPieRound } from "./SweetPieRound";
+
 export type PlayerController = {
   setSpawnPoint(player: number, pointName: string): void;
   teleport(player: number, pointName: string): void;
@@ -6,4 +8,7 @@ export type PlayerController = {
   quitGame(actorId: number): void;
   getName(actorId: number): string;
   addItem(actorId: number, itemId: number, count: number): void;
+  getRoundsArray(): SweetPieRound[];
+  setRoundsArray(rounds: SweetPieRound[]): void;
+  getOnlinePlayers(): number[];
 }

--- a/skymp5-functions-lib/src/logic/TestUtils.ts
+++ b/skymp5-functions-lib/src/logic/TestUtils.ts
@@ -11,11 +11,15 @@ export const makePlayerController = (): PlayerController => {
     quitGame: jest.fn(),
     getName: jest.fn(x => { return `Player${x}`; }),
     addItem: jest.fn(),
+    getRoundsArray: jest.fn().mockReturnValue([]),
+    setRoundsArray: jest.fn(),
+    getOnlinePlayers: jest.fn().mockReturnValue([1, 2]),
   };
 };
 
 export const resetMocks = (controller: PlayerController) => {
+  const freshController = makePlayerController();
   for (const key in controller) {
-    (controller as Record<string, unknown>)[key] = jest.fn();
+    (controller as Record<string, unknown>)[key] = (freshController as Record<string, unknown>)[key];
   }
 }

--- a/skymp5-functions-lib/src/mpApiInteractor.ts
+++ b/skymp5-functions-lib/src/mpApiInteractor.ts
@@ -1,5 +1,6 @@
 import { GameModeListener } from "./logic/GameModeListener";
 import { PlayerController } from "./logic/PlayerController";
+import { SweetPieRound } from "./logic/SweetPieRound";
 import { ChatProperty } from "./props/chatProperty";
 import { DialogProperty } from "./props/dialogProperty";
 import { EvalProperty } from "./props/evalProperty";
@@ -171,6 +172,15 @@ export class MpApiInteractor {
           { type: 'form', desc: mp.getDescFromId(actorId) },
           [{ type: 'espm', desc: mp.getDescFromId(itemId) }, count, /*silent*/false]
         );
+      },
+      getRoundsArray(): SweetPieRound[] {
+        return PersistentStorage.getSingleton().rounds;
+      },
+      setRoundsArray(rounds: SweetPieRound[]): void {
+        PersistentStorage.getSingleton().rounds = rounds;
+      },
+      getOnlinePlayers(): number[] {
+        return PersistentStorage.getSingleton().onlinePlayers;
       },
     }
   }

--- a/skymp5-functions-lib/src/utils/persistentStorage.ts
+++ b/skymp5-functions-lib/src/utils/persistentStorage.ts
@@ -1,4 +1,5 @@
 import { Mp } from '../types/mp';
+import { SweetPieRound } from "../logic/SweetPieRound";
 
 declare const mp: Mp;
 
@@ -8,6 +9,53 @@ export class PersistentStorage {
       PersistentStorage.instance = new PersistentStorage();
     }
     return PersistentStorage.instance;
+  }
+
+  get rounds(): SweetPieRound[] {
+    const str = mp.readDataFile('persistentStorage.json');
+    const obj = this.parse(str);
+    if (Array.isArray(obj['rounds']) && !obj['rounds'].find((x) => typeof x !== 'object')) {
+      const rounds: SweetPieRound[] = [];
+      for (const round of obj['rounds']) {
+        const players = new Map<number, { kills?: number }>();
+        for (const obj of round['players']) {
+          players.set(
+            Number.parseInt(obj['key']),
+            typeof obj['val'] === 'object' ? obj['val'] : {}
+          );
+        }
+        rounds.push({
+          state: round['state'],
+          map: round['map'],
+          hallPointName: round['hallPointName'],
+          secondsPassed: round['secondsPassed'],
+          players: players
+        });
+      }
+      return rounds;
+    }
+    return [];
+  }
+
+  set rounds(newValue: SweetPieRound[]) {
+    const str = mp.readDataFile('persistentStorage.json');
+    const obj = this.parse(str);
+    const rounds = new Array();
+    for (const round of newValue) {
+      const players = new Array();
+      for (const [key, val] of round.players || new Map()) {
+        players.push({ key: key, val: val });
+      }
+      rounds.push({
+        state: round.state,
+        map: round.map,
+        hallPointName: round.hallPointName,
+        secondsPassed: round.secondsPassed,
+        players: players
+      });
+    }
+    obj['rounds'] = rounds;
+    mp.writeDataFile('persistentStorage.json', JSON.stringify(obj, null, 2));
   }
 
   get reloads(): number {


### PR DESCRIPTION
closes #872

This should help to save round info during script hot reload.

Saved state is also used to get disconnected from active session user back to action
Added logic to cleanup rounds in warmup from disconnected users and reset round if everyone left before starting active phase
TODO: Clear round info on normal server shutdown/startup.