### PR TITLE
feat: SweetPie game mode logic update

### DIFF
--- a/skymp5-functions-lib/index.ts
+++ b/skymp5-functions-lib/index.ts
@@ -174,7 +174,9 @@ const maps: Required<SweetPieMap>[] = [{
   mainSpawnPointName: 'whiterun:spawnPoint',
   safePlaceEnterDoors: ['1a6f4:Skyrim.esm'],
   safePlaceLeaveDoors: ['16072:Skyrim.esm'],
-  leaveRoundDoors: ['1b1f3:Skyrim.esm']
+  leaveRoundDoors: ['1b1f3:Skyrim.esm'],
+  playerRestoreActivators: ['3a99d6:SweetPie.esp'],
+  playerRestoreWaitTime: 30000,
 }];
 
 const createGameModeListener = (controller: PlayerController, maps: SweetPieMap[], playersToStart: unknown): SweetPieGameModeListener => {

--- a/skymp5-functions-lib/src/logic/GameModeListener.ts
+++ b/skymp5-functions-lib/src/logic/GameModeListener.ts
@@ -5,5 +5,5 @@ export interface GameModeListener {
   everySecond?: () => void;
   onPlayerChatInput?: (actorId: number, inputText: string, neighbors: number[], senderName: string) => void;
   onPlayerDialogResponse?: (actorId: number, dialogId: number, buttonIndex: number) => void;
-  onPlayerActivateObject?: (casterActorId: number, targetObjectDesc: string, isTeleportDoor: boolean) => 'continue' | 'blockActivation';
+  onPlayerActivateObject?: (casterActorId: number, targetObjectDesc: string, targetActorId: number) => 'continue' | 'blockActivation';
 }

--- a/skymp5-functions-lib/src/logic/PlayerController.ts
+++ b/skymp5-functions-lib/src/logic/PlayerController.ts
@@ -1,5 +1,11 @@
 import { SweetPieRound } from "./SweetPieRound";
 
+export type Percentages = {
+  health?: number;
+  magicka?: number;
+  stamina?: number;
+}
+
 export type PlayerController = {
   setSpawnPoint(player: number, pointName: string): void;
   teleport(player: number, pointName: string): void;
@@ -11,4 +17,8 @@ export type PlayerController = {
   getRoundsArray(): SweetPieRound[];
   setRoundsArray(rounds: SweetPieRound[]): void;
   getOnlinePlayers(): number[];
+  setPercentages(actorId: number, percentages: Percentages): void;
+  getPercentages(actorId: number): Percentages;
+  getScriptName(refrId: number): string;
+  isTeleportActivator(refrId: number): boolean;
 }

--- a/skymp5-functions-lib/src/logic/SweetPieGameModeListener.test.ts
+++ b/skymp5-functions-lib/src/logic/SweetPieGameModeListener.test.ts
@@ -10,8 +10,8 @@ describe("SweetPieGameModeListener: Activation default", () => {
     const listener = new SweetPieGameModeListener(controller);
 
     const res = [
-      listener.onPlayerActivateObject(1, "2beef", false),
-      listener.onPlayerActivateObject(1, "1beef", true)
+      listener.onPlayerActivateObject(1, "2beef", 666),
+      listener.onPlayerActivateObject(1, "1beef", 666)
     ];
     expect(res).toEqual(['continue', 'continue']);
   });
@@ -23,7 +23,7 @@ describe("SweetPieGameModeListener: DeathMatch", () => {
     const maps: SweetPieMap[] = [{ safePointName: 'whiterun:safePlace' }];
     const listener = new SweetPieGameModeListener(controller, maps);
 
-    const res = listener.onPlayerActivateObject(1, listener.neutralPortal, false);
+    const res = listener.onPlayerActivateObject(1, listener.neutralPortal, 666);
     expect(res).toEqual('continue');
 
     // We teleport to the safe place of the round's map
@@ -42,7 +42,7 @@ describe("SweetPieGameModeListener: DeathMatch", () => {
     // Activate one of safePlaceLeaveDoors and leave
     // Players fight outside of safe place
     // Do not check that door teleports the player since teleport doors do this by default
-    expect(listener.onPlayerActivateObject(1, 'bbb', true)).toEqual('continue');
+    expect(listener.onPlayerActivateObject(1, 'bbb', 666)).toEqual('continue');
   });
 
   test("Player should not be able to go back to the safe place", () => {
@@ -51,7 +51,7 @@ describe("SweetPieGameModeListener: DeathMatch", () => {
     const listener = new SweetPieGameModeListener(controller, maps);
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
 
-    const res = listener.onPlayerActivateObject(1, 'bbb', true);
+    const res = listener.onPlayerActivateObject(1, 'bbb', 666);
     expect(controller.sendChatMessage).toBeCalledWith(1, ...listener.noEnterSafePlaceMessage);
     expect(res).toEqual('blockActivation');
   });
@@ -65,15 +65,15 @@ describe("SweetPieGameModeListener: DeathMatch", () => {
     listener.getRounds()[0].state = 'running';
 
     // Player clicks Yes. Now it was removed from the round
-    expect(listener.onPlayerActivateObject(1, 'bbb', true)).toEqual('continue');
+    expect(listener.onPlayerActivateObject(1, 'bbb', 666)).toEqual('continue');
     expect(controller.teleport).toBeCalledWith(1, 'hall:spawnPoint');
     expect(controller.setSpawnPoint).toBeCalledWith(1, 'hall:spawnPoint');
     expect(getPlayerCurrentRound(listener.getRounds(), 1)).toEqual(undefined);
-    expect(listener.getRounds()[0].state).toEqual('warmup');
+    expect(listener.getRounds()[0].state).toEqual('wait');
 
     // Teleport even if the player isn't in any round
     resetMocks(controller);
-    expect(listener.onPlayerActivateObject(1, 'bbb', true)).toEqual('continue');
+    expect(listener.onPlayerActivateObject(1, 'bbb', 666)).toEqual('continue');
     expect(controller.teleport).toBeCalledWith(1, 'hall:spawnPoint');
     expect(controller.setSpawnPoint).toBeCalledWith(1, 'hall:spawnPoint');
   });
@@ -84,7 +84,7 @@ describe("SweetPieGameModeListener: DeathMatch", () => {
     const listener = new SweetPieGameModeListener(controller, maps);
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
 
-    const res = listener.onPlayerActivateObject(1, "beb", true);
+    const res = listener.onPlayerActivateObject(1, "beb", 666);
     expect(controller.sendChatMessage).toBeCalledWith(1, ...listener.interiorsBlockedMessage);
     expect(res).toEqual('blockActivation');
   });
@@ -143,8 +143,9 @@ describe("SweetPieGameModeListener: Round clock", () => {
     const listener = new SweetPieGameModeListener(controller, maps, 2);
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 2);
-    resetMocks(controller);
     listener.getRounds()[0].secondsPassed = listener.warmupTimerMaximum;
+    listener.getRounds()[0].state = 'warmup';
+    resetMocks(controller);
 
     listener.everySecond();
     expect(listener.getRounds()[0].secondsPassed).toBe(0);
@@ -164,40 +165,42 @@ describe("SweetPieGameModeListener: Round clock", () => {
     const listener = new SweetPieGameModeListener(controller, maps, 2);
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
     resetMocks(controller);
-    listener.getRounds()[0].secondsPassed = listener.warmupTimerMaximum;
+    listener.getRounds()[0].secondsPassed = -1;
 
     listener.everySecond();
-    expect(listener.getRounds()[0].secondsPassed).toBe(listener.warmupTimerMaximum + 1);
-    expect(listener.getRounds()[0].state).toBe('warmup');
-    expect(controller.sendChatMessage).toBeCalledWith(1, "Too few players, the warmup will end when 1 more join");
+    expect(listener.getRounds()[0].secondsPassed).toBe(0);
+    expect(listener.getRounds()[0].state).toBe('wait');
+    expect(controller.sendChatMessage).toBeCalledWith(1, "Too few players, the warmup will start when 1 more join");
   });
 
-  test("Round warmup must finish if there are enough players and timer reaches maximum", () => {
+  test("Round warmup must start if there are enough players", () => {
     const controller = makePlayerController();
     const maps: SweetPieMap[] = [{ safePointName: 'whiterun:safePlace', mainSpawnPointName: 'whiterun:spawnPoint' }];
     const listener = new SweetPieGameModeListener(controller, maps, 2);
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
     resetMocks(controller);
-    listener.getRounds()[0].secondsPassed = listener.warmupTimerMaximum;
+    listener.getRounds()[0].secondsPassed = 9;
 
     listener.everySecond();
-    expect(listener.getRounds()[0].secondsPassed).toBe(listener.warmupTimerMaximum + 1);
-    expect(listener.getRounds()[0].state).toBe('warmup');
-    expect(controller.sendChatMessage).toBeCalledWith(1, "Too few players, the warmup will end when 1 more join");
+    expect(listener.getRounds()[0].secondsPassed).toBe(0);
+    expect(listener.getRounds()[0].state).toBe('wait');
+    expect(controller.sendChatMessage).toBeCalledWith(1, "Too few players, the warmup will start when 1 more join");
 
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 2);
     listener.everySecond();
     expect(listener.getRounds()[0].secondsPassed).toBe(0);
-    expect(listener.getRounds()[0].state).toBe('running');
+    expect(listener.getRounds()[0].state).toBe('warmup');
+    expect(controller.sendChatMessage).toBeCalledWith(1, "Starting round in 60 seconds");
   });
 
   test("Round warmup must output messages about remaining seconds", () => {
     const controller = makePlayerController();
     const maps: SweetPieMap[] = [{ safePointName: 'whiterun:safePlace' }];
-    const listener = new SweetPieGameModeListener(controller, maps);
+    const listener = new SweetPieGameModeListener(controller, maps, 2);
     listener.warmupTimerMaximum = 30;
 
     forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
+    forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 2);
 
     for (let i = 0; i < 30; i++) {
       listener.everySecond();
@@ -216,6 +219,24 @@ describe("SweetPieGameModeListener: Round clock", () => {
     expect(controller.sendChatMessage).toBeCalledWith(1, "Starting round in 1 seconds");
   });
 
+  test("Round warmup should stop if there are not enough players after player leaves", () => {
+    const controller = makePlayerController();
+    const maps: SweetPieMap[] = [{ safePointName: 'whiterun:safePlace', mainSpawnPointName: 'whiterun:spawnPoint' }];
+    const listener = new SweetPieGameModeListener(controller, maps, 2);
+    forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 1);
+    forceJoinRound(controller, listener.getRounds(), listener.getRounds()[0], 2);
+    listener.getRounds()[0].state = 'warmup';
+    resetMocks(controller);
+    listener.getRounds()[0].secondsPassed = 9;
+    listener.everySecond();
+    expect(controller.sendChatMessage).toBeCalledWith(2, "Starting round in 50 seconds");
+
+    forceLeaveRound(controller, listener.getRounds(), 1);
+    listener.everySecond()
+    expect(controller.sendChatMessage).toBeCalledWith(2, "Too few players, the warmup will start when 1 more join");
+    expect(listener.getRounds()[0].state).toBe('wait');
+  });
+
   test("Fight must finish once timer reaches maximum", () => {
     const controller = makePlayerController();
     const maps: SweetPieMap[] = [{ safePointName: 'whiterun:safePlace' }];
@@ -229,7 +250,7 @@ describe("SweetPieGameModeListener: Round clock", () => {
 
     expect(listener.getRounds()[0].secondsPassed).toBe(0);
     expect(listener.getRounds()[0].players).toBe(undefined);
-    expect(listener.getRounds()[0].state).toBe('warmup');
+    expect(listener.getRounds()[0].state).toBe('wait');
     expect(controller.teleport).toBeCalledWith(1, 'hall:spawnPoint');
     expect(controller.setSpawnPoint).toBeCalledWith(1, 'hall:spawnPoint');
   });

--- a/skymp5-functions-lib/src/logic/SweetPieGameModeListener.ts
+++ b/skymp5-functions-lib/src/logic/SweetPieGameModeListener.ts
@@ -22,8 +22,10 @@ export class SweetPieGameModeListener implements GameModeListener {
   readonly noWinnerMessage: [string] = ["There is no winner! Thanks for playing"];
   readonly multipleWinnersMessage: [string] = ["We have multiple winners!"];
   readonly deathMessage: [string] = ["%s was slain by %s. %s now has %d points (the best is %d)"];
+  readonly restoreMessage: [string] = ["Restored"];
+  readonly restoreDeniedMessage: [string] = ["Wait for %d seconds to restore again"];
 
-  readonly cantStartMessage: [string] = ["Too few players, the warmup will end when %s more join"];
+  readonly cantStartMessage: [string] = ["Too few players, the warmup will start when %s more join"];
 
   warmupTimerMaximum = 60;
   runningTimerMaximum = 300;
@@ -34,8 +36,10 @@ export class SweetPieGameModeListener implements GameModeListener {
   constructor(private controller: PlayerController, private maps: SweetPieMap[] = [], private minimumPlayersToStart: number = 5) {
     this.rounds = this.controller.getRoundsArray();
     if (this.rounds.length === 0) {
-      maps.forEach(map => this.rounds.push({ state: 'warmup', map: map }));
+      maps.forEach(map => this.rounds.push({ state: 'wait', map: map }));
       this.rounds.forEach((round, index) => this.resetRound(index));
+    } else {
+      maps.forEach((map, index) => this.rounds[index].map = map);
     }
   }
 
@@ -46,7 +50,7 @@ export class SweetPieGameModeListener implements GameModeListener {
         forceLeaveRound(this.controller, this.rounds, player);
       }
     }
-    this.rounds[roundIndex] = { state: 'warmup', map: this.rounds[roundIndex].map, hallPointName: this.hallSpawnPointName, secondsPassed: 0 }
+    this.rounds[roundIndex] = { state: 'wait', map: this.rounds[roundIndex].map, hallPointName: this.hallSpawnPointName, secondsPassed: 0 }
     this.controller.setRoundsArray(this.rounds);
   }
 
@@ -54,7 +58,7 @@ export class SweetPieGameModeListener implements GameModeListener {
     return this.rounds;
   }
 
-  onPlayerActivateObject(casterActorId: number, targetObjectDesc: string, isTeleportDoor: boolean): 'continue' | 'blockActivation' {
+  onPlayerActivateObject(casterActorId: number, targetObjectDesc: string, targetActorId: number): 'continue' | 'blockActivation' {
     if (targetObjectDesc === this.quitGamePortal) {
       this.controller.quitGame(casterActorId);
       return 'continue';
@@ -78,6 +82,17 @@ export class SweetPieGameModeListener implements GameModeListener {
           this.controller.teleport(casterActorId, round.hallPointName);
           return 'continue';
         }
+        const rx = RegExp("^sweet.*(Eat|Drink|Soup)", "i"); // TODO: Make this configurable
+        if (rx.test(this.controller.getScriptName(targetActorId))) {
+          const percentages = this.controller.getPercentages(casterActorId);
+          this.controller.setPercentages(
+            casterActorId, {
+              health: percentages.health! + .5,
+              magicka: percentages.magicka! + .5,
+              stamina: percentages.stamina! + .5
+          });
+          return 'continue';
+        }
       }
       if (round && round.map) {
         if (round.map.safePlaceEnterDoors?.includes(targetObjectDesc)) {
@@ -96,7 +111,20 @@ export class SweetPieGameModeListener implements GameModeListener {
         if (round.map.safePlaceLeaveDoors?.includes(targetObjectDesc)) {
           return 'continue';
         }
-        if (isTeleportDoor) {
+        if (round.map.playerRestoreActivators?.includes(targetObjectDesc)) {
+          const now = Date.now();
+          const elapsed = now - (round.players?.get(casterActorId)?.restored || now);
+          const waitTime = round.map.playerRestoreWaitTime || 30000;
+          if (elapsed >= 0) {
+            round.players!.get(casterActorId)!.restored = now + waitTime;
+            this.controller.setPercentages(casterActorId, {});
+            this.controller.sendChatMessage(casterActorId, ...this.restoreMessage);
+            return 'continue';
+          }
+          this.controller.sendChatMessage(casterActorId, sprintf(this.restoreDeniedMessage[0], -elapsed / 1000));
+          return 'continue';
+          }
+        if (this.controller.isTeleportActivator(targetActorId)) {
           this.controller.sendChatMessage(casterActorId, ...this.interiorsBlockedMessage);
           return 'blockActivation';
         }
@@ -123,8 +151,8 @@ export class SweetPieGameModeListener implements GameModeListener {
   everySecond() {
     for (const round of this.rounds) {
       if (round.players && round.players.size) {
-        round.secondsPassed = (round.secondsPassed || 0) + 1;
-        if (round.state === 'warmup') {
+        round.secondsPassed = (round.secondsPassed ?? -1) + 1;
+        if (round.state === 'warmup' || round.state === 'wait') {
           const onlinePlayers: number[] = this.controller.getOnlinePlayers();
           const playersToRemove: number[] = [];
           for (const player of round.players.keys()) {
@@ -139,17 +167,25 @@ export class SweetPieGameModeListener implements GameModeListener {
             this.resetRound(this.rounds.indexOf(round));
             continue;
           }
+          if (round.players.size < this.minimumPlayersToStart) {
+            if (round.state === 'warmup') {
+              round.state = 'wait';
+              round.secondsPassed = 0;
+            }
+            if (this.sendMessageNeeded(this.warmupTimerMaximum - round.secondsPassed)) {
+              this.sendRoundChatMessage(round, sprintf(this.cantStartMessage[0], this.minimumPlayersToStart - round.players.size));
+              round.secondsPassed = 0;
+            }
+            continue;
+          } else if (round.state === 'wait') {
+            round.state = 'warmup';
+            round.secondsPassed = 0;
+          }
           const secondsRemaining = this.warmupTimerMaximum - round.secondsPassed;
           if (secondsRemaining > 0 && this.sendMessageNeeded(secondsRemaining)) {
             this.sendRoundChatMessage(round, sprintf(this.startingRoundInMessage[0], secondsRemaining));
           }
           if (round.secondsPassed > this.warmupTimerMaximum) {
-            if (round.players.size < this.minimumPlayersToStart) {
-              if (this.sendMessageNeeded(round.secondsPassed - this.warmupTimerMaximum)) {
-                this.sendRoundChatMessage(round, sprintf(this.cantStartMessage[0], this.minimumPlayersToStart - round.players.size));
-              }
-              continue;
-            }
             round.secondsPassed = 0;
             round.state = 'running';
             this.sendRoundChatMessage(round, sprintf(this.warmupFinishedMessage[0], this.runningTimerMaximum));

--- a/skymp5-functions-lib/src/logic/SweetPieMap.ts
+++ b/skymp5-functions-lib/src/logic/SweetPieMap.ts
@@ -4,4 +4,6 @@ export type SweetPieMap = {
   safePlaceLeaveDoors?: string[];
   safePlaceEnterDoors?: string[];
   leaveRoundDoors?: string[];
+  playerRestoreActivators?: string[];
+  playerRestoreWaitTime?: number;
 }

--- a/skymp5-functions-lib/src/logic/SweetPieRound.ts
+++ b/skymp5-functions-lib/src/logic/SweetPieRound.ts
@@ -2,8 +2,8 @@ import { PlayerController } from "./PlayerController";
 import { SweetPieMap } from "./SweetPieMap";
 
 export type SweetPieRound = {
-  state: 'running' | 'warmup';
-  players?: Map<number, { kills?: number }>;
+  state: 'running' | 'warmup' | 'wait';
+  players?: Map<number, { kills?: number, restored?: number }>;
   map?: SweetPieMap;
   hallPointName?: string;
   secondsPassed?: number;

--- a/skymp5-functions-lib/src/logic/TestUtils.ts
+++ b/skymp5-functions-lib/src/logic/TestUtils.ts
@@ -14,6 +14,10 @@ export const makePlayerController = (): PlayerController => {
     getRoundsArray: jest.fn().mockReturnValue([]),
     setRoundsArray: jest.fn(),
     getOnlinePlayers: jest.fn().mockReturnValue([1, 2]),
+    setPercentages: jest.fn(),
+    getPercentages: jest.fn(),
+    getScriptName: jest.fn(),
+    isTeleportActivator: jest.fn().mockReturnValue(true),
   };
 };
 

--- a/skymp5-functions-lib/src/mpApiInteractor.ts
+++ b/skymp5-functions-lib/src/mpApiInteractor.ts
@@ -1,5 +1,5 @@
 import { GameModeListener } from "./logic/GameModeListener";
-import { PlayerController } from "./logic/PlayerController";
+import { Percentages, PlayerController } from "./logic/PlayerController";
 import { SweetPieRound } from "./logic/SweetPieRound";
 import { ChatProperty } from "./props/chatProperty";
 import { DialogProperty } from "./props/dialogProperty";
@@ -11,6 +11,23 @@ import { Timer } from "./utils/timer";
 
 declare const mp: Mp;
 declare const ctx: Ctx;
+
+const scriptName = (refrId: number) => {
+  const lookupRes = mp.lookupEspmRecordById(refrId);
+  if (lookupRes.record) {
+    const vmadIndex = lookupRes.record.fields.findIndex((field) => field.type === 'VMAD');
+    if (vmadIndex >= 0) {
+      const vmadData = lookupRes.record.fields[vmadIndex].data;
+      const strLength = vmadData[6] + (vmadData[7] << 8);
+      var strData: string = '';
+      for (var i = 0; i < strLength; i++) {
+        strData += String.fromCharCode(vmadData[8+i]).valueOf();
+      }
+      return strData;
+    }
+  }
+  return '';
+}
 
 const isTeleportDoor = (refrId: number) => {
   const lookupRes = mp.lookupEspmRecordById(refrId);
@@ -50,8 +67,7 @@ export class MpApiInteractor {
         return true;
       }
 
-      const isTeleport = isTeleportDoor(target);
-      const res = listener.onPlayerActivateObject(caster, targetDesc, isTeleport);
+      const res = listener.onPlayerActivateObject(caster, targetDesc, target);
       if (res === 'continue') {
         return true;
       }
@@ -185,6 +201,25 @@ export class MpApiInteractor {
       },
       getOnlinePlayers(): number[] {
         return PersistentStorage.getSingleton().onlinePlayers;
+      },
+      setPercentages(actorId: number, percentages: Percentages): void {
+        mp.set(
+          actorId,
+          'percentages',
+          {
+            health: percentages.health ?? 1.0,
+            magicka: percentages.magicka ?? 1.0,
+            stamina: percentages.stamina ?? 1.0
+          });
+      },
+      getPercentages(actorId: number): Percentages {
+        return mp.get(actorId, 'percentages');
+      },
+      getScriptName(refrId: number): string {
+        return scriptName(refrId);
+      },
+      isTeleportActivator(refrId: number): boolean {
+        return isTeleportDoor(refrId);
       },
     }
   }

--- a/skymp5-functions-lib/src/types/mp.d.ts
+++ b/skymp5-functions-lib/src/types/mp.d.ts
@@ -113,6 +113,7 @@ export interface Mp {
   get(formId: 0, propertyName: 'onlinePlayers'): number[];
   get(formId: number, propertyName: 'isDead'): boolean;
   get(formId: number, propertyName: 'worldOrCellDesc'): string;
+  get(formId: number, propertyName: 'percentages'): { health: number, magicka: number, stamina: number };
 
   /**
    * Modifies value of the specified property.
@@ -125,6 +126,7 @@ export interface Mp {
   set(formId: number, propertyName: 'locationalData', newValue: LocationalData): void;
   set(formId: number, propertyName: 'spawnPoint', newValue: LocationalData): void;
   set(formId: number, propertyName: 'isDead', newValue: boolean): void;
+  set(formId: number, propertyName: 'percentages', newValue: { health: number, magicka: number, stamina: number }): void;
 
   /**
    * Creates a new property that would be attached to all instances of

--- a/skymp5-server/cpp/addon/main.cc
+++ b/skymp5-server/cpp/addon/main.cc
@@ -1274,6 +1274,14 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
         if (auto actor = dynamic_cast<MpActor*>(&refr)) {
           res = JsValue::Bool(actor->IsDead());
         }
+      } else if (propertyName == "percentages") {
+        if (auto actor = dynamic_cast<MpActor*>(&refr)) {
+          auto chForm = actor->GetChangeForm();
+          res = JsValue::Object();
+          res.SetProperty("health", chForm.healthPercentage);
+          res.SetProperty("magicka", chForm.magickaPercentage);
+          res.SetProperty("stamina", chForm.staminaPercentage);
+        }
       } else {
         EnsurePropertyExists(gamemodeApiState, propertyName);
         res = refr.GetDynamicFields().Get(propertyName);
@@ -1348,6 +1356,12 @@ void ScampServer::RegisterChakraApi(std::shared_ptr<JsEngine> chakraEngine)
       } else if (propertyName == "isDead") {
         if (auto actor = dynamic_cast<MpActor*>(&refr)) {
           actor->SetIsDead(newValue.get<bool>());
+        }
+      } else if (propertyName == "percentages") {
+        if (auto actor = dynamic_cast<MpActor*>(&refr)) {
+          actor->NetSetPercentages(newValue["health"].get<float>(),
+                                   newValue["magicka"].get<float>(),
+                                   newValue["stamina"].get<float>());
         }
       } else {
 

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -701,24 +701,11 @@ void ActionListener::OnHit(const RawMessageData& rawMsgData_,
   currentHealthPercentage =
     currentHealthPercentage < 0.f ? 0.f : currentHealthPercentage;
 
-  targetActor.SetPercentages(currentHealthPercentage, magickaPercentage,
-                             staminaPercentage, aggressor);
   auto now = std::chrono::steady_clock::now();
-  targetActor.SetLastAttributesPercentagesUpdate(now);
+  targetActor.NetSetPercentages(currentHealthPercentage, magickaPercentage,
+                                staminaPercentage, now, aggressor);
   targetActor.SetLastHitTime(now);
 
-  targetForm = targetActor.GetChangeForm();
-
-  std::string s;
-  s += Networking::MinPacketId;
-  s += nlohmann::json{
-    { "t", MsgType::ChangeValues },
-    { "data",
-      { { "health", targetForm.healthPercentage },
-        { "magicka", targetForm.magickaPercentage },
-        { "stamina", targetForm.staminaPercentage } } }
-  }.dump();
-  targetActor.SendToUser(s.data(), s.size(), true);
   spdlog::debug("Target {0:x} is hitted by {1} damage. Current health "
                 "percentage: {2}. Last "
                 "health percentage: {3}. (Last: {3} => Current: {2})",

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -225,6 +225,25 @@ void MpActor::SetPercentages(float healthPercentage, float magickaPercentage,
   });
 }
 
+void MpActor::NetSetPercentages(
+  float healthPercentage, float magickaPercentage, float staminaPercentage,
+  std::chrono::steady_clock::time_point timePoint, MpActor* aggressor)
+{
+  std::string s;
+  s += Networking::MinPacketId;
+  s += nlohmann::json{
+    { "t", MsgType::ChangeValues },
+    { "data",
+      { { "health", healthPercentage },
+        { "magicka", magickaPercentage },
+        { "stamina", staminaPercentage } } }
+  }.dump();
+  SendToUser(s.data(), s.size(), true);
+  SetPercentages(healthPercentage, magickaPercentage, staminaPercentage,
+                 aggressor);
+  SetLastAttributesPercentagesUpdate(timePoint);
+}
+
 std::chrono::steady_clock::time_point
 MpActor::GetLastAttributesPercentagesUpdate()
 {

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -59,6 +59,11 @@ public:
   void ResolveSnippet(uint32_t snippetIdx, VarValue v);
   void SetPercentages(float healthPercentage, float magickaPercentage,
                       float staminaPercentage, MpActor* aggressor = nullptr);
+  void NetSetPercentages(float healthPercentage, float magickaPercentage,
+                         float staminaPercentage,
+                         std::chrono::steady_clock::time_point timePoint =
+                           std::chrono::steady_clock::now(),
+                         MpActor* aggressor = nullptr);
 
   std::chrono::steady_clock::time_point GetLastAttributesPercentagesUpdate();
   std::chrono::steady_clock::time_point GetLastHitTime();


### PR DESCRIPTION
Added Restorer objects support.
This also introduces new API calls to get/set hp, mp and stamina for other gamemodes.
SweetPieMap description object now contains array for Restorer objects references and default time player should wait before using restorer again.
Updated round stages to start warmup counter only when player count reaches required minimum.
Also tuned other map-related logic for SweetPie game mode.