### PR TITLE
feat(skymp5-functions-lib): disable modAV

### DIFF
--- a/skymp5-functions-lib/src/props/disableCheats.ts
+++ b/skymp5-functions-lib/src/props/disableCheats.ts
@@ -18,15 +18,17 @@ export class DisableCheats {
         ctx.sp.storage["disableCtrlPrtScnHotkeyCalled"] = true;
         ctx.sp.disableCtrlPrtScnHotkey();
       }
-      
-      // Disable setav
-      ctx.sp.findConsoleCommand("setAV").execute = () => false;
 
-      // Disable tcl
-      ctx.sp.findConsoleCommand("ToggleCollision").execute = () => false;
+      const commandsToDisable: string[] = [
+        "setAV",
+        "ToggleCollision",
+        "ToggleGodMode"
+      ]
 
-      // Disable tgm
-      ctx.sp.findConsoleCommand("ToggleGodMode").execute = () => false;
+      // Disable commands from commandsToDisable
+      commandsToDisable.forEach((command) => {
+        ctx.sp.findConsoleCommand(command).execute = () => false;
+      })
     };
   }
 }

--- a/skymp5-functions-lib/src/props/disableCheats.ts
+++ b/skymp5-functions-lib/src/props/disableCheats.ts
@@ -20,9 +20,11 @@ export class DisableCheats {
       }
 
       const commandsToDisable: string[] = [
+        "modAV",
+        "forceAV",
         "setAV",
         "ToggleCollision",
-        "ToggleGodMode"
+        "ToggleGodMode" // Disable unlimited carry weight
       ]
 
       // Disable commands from commandsToDisable


### PR DESCRIPTION
The code for disabling console commands has been slightly refactored. The commands `modAV`, `forceAV` and `ToggleGodMode` are also disabled.