### PR TITLE
internal: update vcpkg & fix compilation error

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/GetBaseActorValues.cpp
+++ b/skymp5-server/cpp/server_guest_lib/GetBaseActorValues.cpp
@@ -48,7 +48,7 @@ float BaseActorValues::GetValue(espm::ActorValue av)
       return staminaRateMult;
     default:
       throw std::runtime_error(
-        fmt::format("Unsupported actor value type {:}", av));
+        fmt::format("Unsupported actor value type {:}", (int32_t)av));
   }
 }
 


### PR DESCRIPTION
Closes #895.

Cast should probably be replaced with `fmt::underlying()` later, at the moment it is still in dev.
https://fmt.dev/dev/api.html#_CPPv4I0EN3fmt10underlyingENSt15underlying_typeI4EnumE4typeE4Enum