### PR TITLE
internal: use vcpkg from submodule in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,6 @@ endif()
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_LIST_DIR}/overlay_triplets")
 set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/overlay_ports")
 
-macro(set_from_environment VARIABLE)
-  if(NOT DEFINED ${VARIABLE} AND DEFINED ENV{${VARIABLE}})
-    set(${VARIABLE} $ENV{${VARIABLE}})
-  endif()
-endmacro()
-
-set_from_environment(VCPKG_ROOT)
-# for github actions
-set_from_environment(VCPKG_INSTALLATION_ROOT)
-
 # Use installed VCPKG if exists
 if(USE_SYSTEM_VCPKG AND DEFINED VCPKG_ROOT AND EXISTS ${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
   set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")


### PR DESCRIPTION
I have no idea why one would want to de-sync vcpkg revision in GH actions and locally.
I had a nasty bug because of this behavior. CI may just stop working randomly when vcpkg updates in github's image!!!