### PR TITLE
fix(skyrim-platform): fix backward compatibility for "agressor" typo

### DIFF
--- a/docs/release/dev/sp-fix-agressor-compat.md
+++ b/docs/release/dev/sp-fix-agressor-compat.md
@@ -1,0 +1,1 @@
+Added back the "a**g**ressor" field of hit event. It should be still there for backward compatibility of compiled plugins. Only the 2.6 version was affected by the bug. This typo will be completely removed from the project in 3.0.0.

--- a/skyrim-platform/src/platform_se/skyrim_platform/EventHandler.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/EventHandler.cpp
@@ -455,8 +455,11 @@ EventResult EventHandler::ProcessEvent(const RE::TESHitEvent* event,
     auto sourceForm = RE::TESForm::LookupByID(e->source);
     auto projectileForm = RE::TESForm::LookupByID(e->projectile);
 
-    AddObjProperty(&obj, "target", e->target.get(), "ObjectReference");
+    // TODO(#336): drop old name "agressor" on next major release of SP
+    // Again: Until we release 3.0.0 we do not remove this line.
+    AddObjProperty(&obj, "agressor", e->cause.get(), "ObjectReference");
     AddObjProperty(&obj, "aggressor", e->cause.get(), "ObjectReference");
+    AddObjProperty(&obj, "target", e->target.get(), "ObjectReference");
     AddObjProperty(&obj, "source", sourceForm, "Form");
     AddObjProperty(&obj, "projectile", projectileForm, "Form");
     AddObjProperty(&obj, "isPowerAttack",


### PR DESCRIPTION
We need to keep "agressor" version for compatibility.

This tweak was introduced in https://github.com/skyrim-multiplayer/skymp/commit/407c3c70630bc143d18a5fb9c6c49f93bc9e774e

And mistakenly removed in https://github.com/skyrim-multiplayer/skymp/commit/674e77a7efa2fb6c682f2ea861e77873a52ba791

I have no idea why one decided to do this...