### PR TITLE
feat(skyrim-platform): extend texts API

### DIFF
--- a/docs/skyrim_platform/texts.md
+++ b/docs/skyrim_platform/texts.md
@@ -9,7 +9,7 @@ provided by DirectXTK. See [Compiling Font](#compiling-font) for details.
 
 ## Example
 ```typescript
-skyrimPlatform.createText(0, 0, "Hello", [1,1,0,1]); // 0,0 is top left. Non-ASCII character are not yet supported.
+skyrimPlatform.createText(0, 0, "Hello World!", [1, 1, 1, 1], "Data/Platform/Fonts/Tavern.spritefont"),; // 0,0 is top left. Non-ASCII character are not yet supported.
 skyrimPlatform.browser.setVisible(true); // Texts API takes visibility flag from the browser
 ```
 
@@ -28,26 +28,53 @@ const white = [1,1,1,1];
 
 ## API methods
 
-1) ```skyrimPlatform.createText(xpos, ypos, "string", ["array of RGBA colors"])``` - create a text.
+- ```skyrimPlatform.createText(xpos, ypos, "string", ["array of RGBA colors"])``` - create a text.
 Returns id.
 
-2) ```skyrimPlatform.destroyText(textId)``` - delete text by id.
+- ```skyrimPlatform.destroyText(textId)``` - delete text by id. 
+- ```skyrimPlatform.destroyAllTexts()``` - delete all texts.
 
-3) ```skyrimPlatform.setTextPos(textId, xpos, ypos)``` - set the position of the text by id.
+### Setters
 
-4) ```skyrimPlatform.setTextString(textId, "string")``` - set text by id.
+- ```skyrimPlatform.setTextPos(textId, xpos: float, ypos: float)``` - set the position of the text by id.
 
-5) ```skyrimPlatform.setTextColor(textId, ["array of RBGA colors"])``` - set text color.
+- ```skyrimPlatform.setTextString(textId, text: string)``` - set text by id.
 
-6) ```skyrimPlatform.destroyAllTexts()``` - delete all texts.
+- ```skyrimPlatform.setTextColor(textId, ["array of RBGA colors"])``` - set text color.
 
-7) ```skyrimPlatform.getTextPos(textId)``` - returns the coordinates(position) of the next as an array.
+- ```skyrimPlatform.setTextSize(textId: number, size: float)``` - set text (not font) size.
 
-8) ```skyrimPlatform.getTextString(textId)``` - returns a string.
+- ```skyrimPlatform.setTextRotation(textId, rotation: float)``` - set text rotation.
 
-9) ```skyrimPlatform.getTextColor(textId)``` - returns an array of colors in RGBA.
+- ```skyrimPlatform.setTextFont(textId, path: string)``` - set text font from relative path "Data/Platform/Fonts/Tavern.spritefont".
 
-10) ```skyrimPlatform.getNumCreatedTexts()``` - returns the number of created texts.
+- ```skyrimPlatform.setTextDepth(textId, depth: int)``` - set text z-index of the text.
+
+- ```skyrimPlatform.setTextEffect(textId, effect: int)``` - set sprite effect [None = 0, FlipHorizontally = 1, FlipVertically = 2]
+
+- ```skyrimPlatform.setTextOrigin(textId, origin [x,y])``` - set text pivot (center point).
+
+### Getters
+
+- ```skyrimPlatform.getTextPos(textId)``` - returns the coordinates(position) of the next as an array.
+
+- ```skyrimPlatform.getTextString(textId)``` - returns a string.
+
+- ```skyrimPlatform.getTextColor(textId)``` - returns an array of colors in RGBA.
+
+- ```skyrimPlatform.getTextSize(textId)``` - returns the size of the text
+
+- ```skyrimPlatform.getTextRotation(textId)``` - returns the rotation of the text
+
+- ```skyrimPlatform.getTextFont(textId)``` - returns the path to the font
+
+- ```skyrimPlatform.getTextDepth(textId)``` - returns z-index of the text
+
+- ```skyrimPlatform.getTextEffect(textId)``` - returns effect enum.
+
+- ```skyrimPlatform.getTextOrigin(textId)``` - returns pivot (center point) of the text
+
+- ```skyrimPlatform.skyrimPlatform.getNumCreatedTexts()``` - returns the number of created texts.
 
 
 ## Compiling Font

--- a/skymp5-client/src/features/loadOrder.ts
+++ b/skymp5-client/src/features/loadOrder.ts
@@ -153,7 +153,7 @@ export const verifyLoadOrder = () => {
       }
       updateText(
         'LOAD ORDER ERROR!\nCheck console for details.',
-        [255, 0, 0, 1], "Data/Platform/Fonts/DINPro.spritefont",
+        [255, 0, 0, 1], "Data/Platform/Fonts/Tavern.spritefont",
       );
       sp.browser.loadUrl('about:blank');
     });

--- a/skymp5-client/src/features/loadOrder.ts
+++ b/skymp5-client/src/features/loadOrder.ts
@@ -32,10 +32,10 @@ const resetText = () => {
   }
 };
 
-const updateText = (text: string, color: [number, number, number, number], clearDelay?: number) => {
+const updateText = (text: string, color: [number, number, number, number], font: string, clearDelay?: number) => {
   const { width, height } = getScreenResolution();
   resetText();
-  const statusTextId = createText(width / 2, height / 2, text, color);
+  const statusTextId = createText(width / 2, height / 2, text, color, font);
   setState({ statusTextId });
   if (clearDelay) {
     Utility.wait(clearDelay).then(resetText);
@@ -95,6 +95,10 @@ const getClientMods = () => {
   return enumerateClientMods(Game.getModCount, Game.getModName);
 };
 
+const getDefaultFont = (): string => {
+  return "Data/Platform/Fonts/Tavern.spritefont";
+};
+
 const printModOrder = (header: string, order: Mod[]) => {
   printConsole(header);
   for (const [i, mod] of Object.entries(order)) {
@@ -115,7 +119,7 @@ export const verifyLoadOrder = () => {
       if (clientMods.length > serverMods.length) {
         updateText(
           'LOAD ORDER WARNING: you have more mods than server!\n(or could not receive server mod list)\nCheck console for details.',
-          [255, 255, 0, 1], 5,
+          [255, 255, 0, 1], getDefaultFont(), 5,
         );
       }
       let fail = [];
@@ -143,13 +147,13 @@ export const verifyLoadOrder = () => {
           'LOAD ORDER ERROR!\nHowever, ignoring it because of ignoreLoadOrderMismatch being set.' +
           '\nExpect EVERYTHING BREAK, unless you know what you are doing.\nCheck console for details.' +
           '\nThis message will disappear after 30 seconds.',
-          [255, 0, 0, 1], 30,
+          [255, 0, 0, 1], getDefaultFont(), 30,
         );
         return;
       }
       updateText(
         'LOAD ORDER ERROR!\nCheck console for details.',
-        [255, 0, 0, 1],
+        [255, 0, 0, 1], "Data/Platform/Fonts/DINPro.spritefont",
       );
       sp.browser.loadUrl('about:blank');
     });

--- a/skymp5-client/src/features/netInfoSystem.ts
+++ b/skymp5-client/src/features/netInfoSystem.ts
@@ -43,14 +43,14 @@ class NetInfoTexts {
   public static readonly Name = "netInfoTexts";
 
   constructor(
-    public readonly connectionStaticTextId = sp.createText(100, 350, "connection:", [255, 255, 255, 1]),
+    public readonly connectionStaticTextId = sp.createText(100, 350, "connection:", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
     public readonly connectionStateTextId = sp.createText(220, 350, "", [255, 255, 255, 1]),
-    public readonly receivedPacketStaticTextId = sp.createText(120, 390, "incoming (p/s):", [255, 255, 255, 1]),
+    public readonly receivedPacketStaticTextId = sp.createText(120, 390, "incoming (p/s):", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
     public readonly receivedPacketAmountTextId = sp.createText(250, 390, "", [255, 255, 255, 1]),
-    public readonly sentPacketStaticTextId = sp.createText(120, 430, "outgoing (p/s):", [255, 255, 255, 1]),
+    public readonly sentPacketStaticTextId = sp.createText(120, 430, "outgoing (p/s):", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
     public readonly sentPacketAmountTextId = sp.createText(250, 430, "", [255, 255, 255, 1]),
-    public readonly localPositionLagStaticTextId = sp.createText(90, 470, "local lag:", [255, 255, 255, 1]),
-    public readonly localPositionLagAmountTextId = sp.createText(250, 470, "", [255, 255, 255, 1]),
+    public readonly localPositionLagStaticTextId = sp.createText(90, 470, "local lag:", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
+    public readonly localPositionLagAmountTextId = sp.createText(250, 470, "", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
   ) { }
 
   public clear(): void {

--- a/skymp5-client/src/features/netInfoSystem.ts
+++ b/skymp5-client/src/features/netInfoSystem.ts
@@ -43,14 +43,14 @@ class NetInfoTexts {
   public static readonly Name = "netInfoTexts";
 
   constructor(
-    public readonly connectionStaticTextId = sp.createText(100, 350, "connection:", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
-    public readonly connectionStateTextId = sp.createText(220, 350, "", [255, 255, 255, 1]),
-    public readonly receivedPacketStaticTextId = sp.createText(120, 390, "incoming (p/s):", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
-    public readonly receivedPacketAmountTextId = sp.createText(250, 390, "", [255, 255, 255, 1]),
-    public readonly sentPacketStaticTextId = sp.createText(120, 430, "outgoing (p/s):", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
-    public readonly sentPacketAmountTextId = sp.createText(250, 430, "", [255, 255, 255, 1]),
-    public readonly localPositionLagStaticTextId = sp.createText(90, 470, "local lag:", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
-    public readonly localPositionLagAmountTextId = sp.createText(250, 470, "", [255, 255, 255, 1], "Data/Platform/Fonts/DINPro.spritefont"),
+    public readonly connectionStaticTextId = sp.createText(100, 350, "connection:", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly connectionStateTextId = sp.createText(220, 350, "", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly receivedPacketStaticTextId = sp.createText(120, 390, "incoming (p/s):", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly receivedPacketAmountTextId = sp.createText(250, 390, "", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly sentPacketStaticTextId = sp.createText(120, 430, "outgoing (p/s):", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly sentPacketAmountTextId = sp.createText(250, 430, "", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly localPositionLagStaticTextId = sp.createText(90, 470, "local lag:", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
+    public readonly localPositionLagAmountTextId = sp.createText(250, 470, "", [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont"),
   ) { }
 
   public clear(): void {

--- a/skymp5-client/src/view/formView.ts
+++ b/skymp5-client/src/view/formView.ts
@@ -426,7 +426,7 @@ export class FormView implements View<FormModel> {
         const textYPos = Math.round((1 - headScreenPos[1]) * resolution.height);
 
         if (!this.textNameId) {
-          this.textNameId = createText(textXPos, textYPos, model.appearance.name, [255, 255, 255, 1]);
+          this.textNameId = createText(textXPos, textYPos, model.appearance.name, [255, 255, 255, 1], "Data/Platform/Fonts/Tavern.spritefont");
         } else {
           setTextString(this.textNameId, headScreenPos[2] >= 0 ? model.appearance.name : "");
           setTextPos(this.textNameId, textXPos, textYPos);

--- a/skyrim-platform/src/platform_se/codegen/convert-files/Definitions.txt
+++ b/skyrim-platform/src/platform_se/codegen/convert-files/Definitions.txt
@@ -1525,15 +1525,29 @@ export declare class HttpClient {
     post(path: string, options: { body: string, contentType: string, headers?: HttpHeaders }): Promise<HttpResponse>;
 }
 
-export declare function createText(xPos: number, yPos: number, text: string, color: number[]): number;
+export declare function createText(xPos: number, yPos: number, text: string, color: number[], name: string): number;
+
 export declare function destroyText(textId: number): void;
+export declare function destroyAllTexts(): void;
+
 export declare function setTextPos(textId: number, xPos: number, yPos: number): void;
 export declare function setTextString(textId: number, text: string): void;
 export declare function setTextColor(textId: number, color: number[]): void;
-export declare function destroyAllTexts(): void;
+export declare function setTextSize(textId: number, size: number): void;
+export declare function setTextRotation(textId: number, rotation: number): void;
+export declare function setTextFont(textId: number, name: string): void;
+export declare function setTextDepth(textId: number, depth: number): void;
+export declare function setTextEffect(textId: number, effect: number): void;
+export declare function setTextOrigin(textId: number, origin: number[]): void;
+
 export declare function getTextPos(textId: number): number[];
 export declare function getTextString(textId: number): string;
 export declare function getTextColor(textId: number): number[];
-export declare function getNumCreatedTexts(): number;
+export declare function getTextSize(textId: number): number;
+export declare function getTextRotation(textId: number): number;
+export declare function getTextFont(textId: number): string;
+export declare function getTextDepth(textId: number): number;
+export declare function getTextEffect(textId: number): number;
+export declare function getTextOrigin(textId: number): number[];
 
 export declare function getFileInfo(filename: string): { crc32: number, size: number };

--- a/skyrim-platform/src/platform_se/codegen/convert-files/skyrimPlatform.ts
+++ b/skyrim-platform/src/platform_se/codegen/convert-files/skyrimPlatform.ts
@@ -1530,16 +1530,30 @@ export declare class HttpClient {
     post(path: string, options: { body: string, contentType: string, headers?: HttpHeaders }): Promise<HttpResponse>;
 }
 
-export declare function createText(xPos: number, yPos: number, text: string, color: number[]): number;
+export declare function createText(xPos: number, yPos: number, text: string, color: number[], name: string): number;
+
 export declare function destroyText(textId: number): void;
+export declare function destroyAllTexts(): void;
+
 export declare function setTextPos(textId: number, xPos: number, yPos: number): void;
 export declare function setTextString(textId: number, text: string): void;
 export declare function setTextColor(textId: number, color: number[]): void;
-export declare function destroyAllTexts(): void;
+export declare function setTextSize(textId: number, size: number): void;
+export declare function setTextRotation(textId: number, rotation: number): void;
+export declare function setTextFont(textId: number, name: string): void;
+export declare function setTextDepth(textId: number, depth: number): void;
+export declare function setTextEffect(textId: number, effect: number): void;
+export declare function setTextOrigin(textId: number, origin: number[]): void;
+
 export declare function getTextPos(textId: number): number[];
 export declare function getTextString(textId: number): string;
 export declare function getTextColor(textId: number): number[];
-export declare function getNumCreatedTexts(): number;
+export declare function getTextSize(textId: number): number;
+export declare function getTextRotation(textId: number): number;
+export declare function getTextFont(textId: number): string;
+export declare function getTextDepth(textId: number): number;
+export declare function getTextEffect(textId: number): number;
+export declare function getTextOrigin(textId: number): number[];
 
 export declare function getFileInfo(filename: string): { crc32: number, size: number };
 

--- a/skyrim-platform/src/platform_se/skyrim_platform/TextApi.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/TextApi.cpp
@@ -11,13 +11,14 @@ JsValue TextApi::CreateText(const JsFunctionArguments& args)
 
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   auto argString = converter.from_bytes(static_cast<std::string>(args[3]));
+  auto argFontName = static_cast<std::string>(args[5]);
 
   for (int i = 0; i < 4; i++) {
     argColor[i] = args[4].GetProperty(i);
   }
 
   return JsValue(TextsCollection::GetSingleton().CreateText(
-    argPosX, argPosY, argString, argColor));
+    argPosX, argPosY, argString, argColor, argFontName));
 }
 
 JsValue TextApi::DestroyText(const JsFunctionArguments& args)
@@ -57,6 +58,72 @@ JsValue TextApi::SetTextColor_(const JsFunctionArguments& args)
 
   TextsCollection::GetSingleton().SetTextColor(static_cast<int>(args[1]),
                                                std::move(argColor));
+  return JsValue::Undefined();
+}
+
+JsValue TextApi::SetTextSize(const JsFunctionArguments& args)
+{
+  auto textId = static_cast<int>(args[1]);
+
+  auto size = static_cast<double>(args[2]);
+
+  TextsCollection::GetSingleton().SetTextSize(textId, size);
+  return JsValue::Undefined();
+}
+
+JsValue TextApi::SetTextRotation(const JsFunctionArguments& args)
+{
+  auto textId = static_cast<int>(args[1]);
+
+  auto rot = static_cast<double>(args[2]);
+
+  TextsCollection::GetSingleton().SetTextRotation(textId, rot);
+  return JsValue::Undefined();
+}
+
+JsValue TextApi::SetTextFont(const JsFunctionArguments& args)
+{
+  auto textId = static_cast<int>(args[1]);
+
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+  auto argString = converter.from_bytes(static_cast<std::string>(args[2]));
+
+  std::wstring widestr = std::wstring(argString.begin(), argString.end()) ;
+
+  TextsCollection::GetSingleton().SetTextFont(textId, static_cast<std::string>(args[2]));
+  return JsValue::Undefined();
+}
+
+JsValue TextApi::SetTextDepth(const JsFunctionArguments& args)
+{
+  auto textId = static_cast<int>(args[1]);
+
+  auto depth = static_cast<double>(args[2]);
+
+  TextsCollection::GetSingleton().SetTextDepth(textId, depth);
+  return JsValue::Undefined();
+}
+
+JsValue TextApi::SetTextEffect(const JsFunctionArguments& args)
+{
+  auto textId = static_cast<int>(args[1]);
+
+  int eff = static_cast<int>(args[2]);
+
+  TextsCollection::GetSingleton().SetTextEffect(textId, eff);
+  return JsValue::Undefined();
+}
+
+JsValue TextApi::SetTextOrigin(const JsFunctionArguments& args)
+{
+  std::array<double, 2> argOrigin;
+
+  for (int i = 0; i < 2; i++) {
+    argOrigin[i] = args[2].GetProperty(i);
+  }
+
+  TextsCollection::GetSingleton().SetTextOrigin(static_cast<int>(args[1]),
+                                                std::move(argOrigin));
   return JsValue::Undefined();
 }
 
@@ -100,6 +167,60 @@ JsValue TextApi::GetTextColor(const JsFunctionArguments& args)
   return jsArray;
 }
 
+JsValue TextApi::GetTextSize(const JsFunctionArguments& args)
+{
+  const auto& size =
+    TextsCollection::GetSingleton().GetTextSize(static_cast<double>(args[1]));
+
+  return JsValue(size);
+}
+
+JsValue TextApi::GetTextRotation(const JsFunctionArguments& args)
+{
+  const auto& rot = TextsCollection::GetSingleton().GetTextRotation(
+    static_cast<double>(args[1]));
+
+  return JsValue(rot);
+}
+
+JsValue TextApi::GetTextFont(const JsFunctionArguments& args)
+{
+  const auto& font =
+    TextsCollection::GetSingleton().GetTextName(static_cast<int>(args[1]));
+
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+  return JsValue(font);
+}
+
+JsValue TextApi::GetTextDepth(const JsFunctionArguments& args)
+{
+  const auto& z =
+    TextsCollection::GetSingleton().GetTextDepth(static_cast<int>(args[1]));
+
+  return JsValue(z);
+}
+
+JsValue TextApi::GetTextEffect(const JsFunctionArguments& args)
+{
+  const int& i =
+    TextsCollection::GetSingleton().GetTextEffect(static_cast<int>(args[1]));
+
+  return JsValue(i);
+}
+
+JsValue TextApi::GetTextOrigin(const JsFunctionArguments& args)
+{
+  auto argArray =
+    TextsCollection::GetSingleton().GetTextColor(static_cast<double>(args[1]));
+  auto jsArray = JsValue::Array(2);
+
+  for (int i = 0; i < 2; i++) {
+    jsArray.SetProperty(i, argArray.at(i));
+  }
+
+  return jsArray;
+}
+
 JsValue TextApi::GetNumCreatedTexts(const JsFunctionArguments& args)
 {
   return JsValue(TextsCollection::GetSingleton().GetNumCreatedTexts());
@@ -117,6 +238,18 @@ void Register(JsValue& exports)
 
   exports.SetProperty("setTextColor", JsValue::Function(SetTextColor_));
 
+  exports.SetProperty("setTextSize", JsValue::Function(SetTextSize));
+
+  exports.SetProperty("setTextRotation", JsValue::Function(SetTextRotation));
+
+  exports.SetProperty("setTextFont", JsValue::Function(SetTextFont));
+
+  exports.SetProperty("setTextDepth", JsValue::Function(SetTextDepth));
+
+  exports.SetProperty("setTextEffect", JsValue::Function(SetTextEffect));
+
+  exports.SetProperty("setTextOrigin", JsValue::Function(SetTextOrigin));
+
   exports.SetProperty("destroyAllTexts", JsValue::Function(DestroyAllTexts));
 
   exports.SetProperty("getTextPos", JsValue::Function(GetTextPos));
@@ -124,6 +257,18 @@ void Register(JsValue& exports)
   exports.SetProperty("getTextString", JsValue::Function(GetTextString));
 
   exports.SetProperty("getTextColor", JsValue::Function(GetTextColor));
+
+  exports.SetProperty("getTextSize", JsValue::Function(GetTextSize));
+
+  exports.SetProperty("getTextRotation", JsValue::Function(GetTextRotation));
+
+  exports.SetProperty("getTextFont", JsValue::Function(GetTextFont));
+
+  exports.SetProperty("getTextDepth", JsValue::Function(GetTextDepth));
+
+  exports.SetProperty("getTextEffect", JsValue::Function(GetTextEffect));
+
+  exports.SetProperty("getTextOrigin", JsValue::Function(GetTextOrigin));
 
   exports.SetProperty("getNumCreatedTexts",
                       JsValue::Function(GetNumCreatedTexts));

--- a/skyrim-platform/src/platform_se/skyrim_platform/TextApi.h
+++ b/skyrim-platform/src/platform_se/skyrim_platform/TextApi.h
@@ -14,6 +14,13 @@ JsValue SetTextString(const JsFunctionArguments& args);
 
 JsValue SetTextColor_(const JsFunctionArguments& args);
 
+JsValue SetTextSize(const JsFunctionArguments& args);
+JsValue SetTextRotation(const JsFunctionArguments& args);
+JsValue SetTextFont(const JsFunctionArguments& args);
+JsValue SetTextDepth(const JsFunctionArguments& args);
+JsValue SetTextEffect(const JsFunctionArguments& args);
+JsValue SetTextOrigin(const JsFunctionArguments& args);
+
 JsValue DestroyAllTexts(const JsFunctionArguments& args);
 
 JsValue GetTextPos(const JsFunctionArguments& args);
@@ -21,6 +28,13 @@ JsValue GetTextPos(const JsFunctionArguments& args);
 JsValue GetTextString(const JsFunctionArguments& args);
 
 JsValue GetTextColor(const JsFunctionArguments& args);
+
+JsValue GetTextSize(const JsFunctionArguments& args);
+JsValue GetTextRotation(const JsFunctionArguments& args);
+JsValue GetTextFont(const JsFunctionArguments& args);
+JsValue GetTextDepth(const JsFunctionArguments& args);
+JsValue GetTextEffect(const JsFunctionArguments& args);
+JsValue GetTextOrigin(const JsFunctionArguments& args);
 
 JsValue GetNumCreatedTexts(const JsFunctionArguments& args);
 }

--- a/skyrim-platform/src/platform_se/skyrim_platform/TextsCollection.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/TextsCollection.cpp
@@ -12,7 +12,7 @@ TextsCollection::~TextsCollection()
 
 int TextsCollection::CreateText(double xPos, double yPos, std::wstring string,
                                 std::array<double, 4> color = { 0.f, 0.f, 1.f,1.f }, 
-                                std::string name = "Data/Platform/Fonts/DINPro.spritefont" )
+                                std::string name = "Data/Platform/Fonts/Tavern.spritefont" )
 {
   TextToDraw text{ name, xPos, yPos, std::move(string), std::move(color) };
 

--- a/skyrim-platform/src/platform_se/skyrim_platform/TextsCollection.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/TextsCollection.cpp
@@ -1,4 +1,5 @@
 #include "TextsCollection.h"
+#include <DirectXTK/SpriteBatch.h>
 
 TextsCollection::TextsCollection()
   : textCount(0)
@@ -9,11 +10,11 @@ TextsCollection::~TextsCollection()
 {
 }
 
-int TextsCollection::CreateText(double xPos, double yPos, std::wstring str,
-                                std::array<double, 4> color = { 0.f, 0.f, 1.f,
-                                                                1.f })
+int TextsCollection::CreateText(double xPos, double yPos, std::wstring string,
+                                std::array<double, 4> color = { 0.f, 0.f, 1.f,1.f }, 
+                                std::string name = "Data/Platform/Fonts/DINPro.spritefont" )
 {
-  TextToDraw text{ xPos, yPos, std::move(str), std::move(color) };
+  TextToDraw text{ name, xPos, yPos, std::move(string), std::move(color) };
 
   textCount++;
   std::pair<int, TextToDraw> arg = { textCount, text };
@@ -42,6 +43,36 @@ void TextsCollection::SetTextString(int textId, std::wstring str)
 void TextsCollection::SetTextColor(int textId, std::array<double, 4> color)
 {
   texts.at(textId).color = color;
+}
+
+void TextsCollection::SetTextFont(int textId, std::string name)
+{
+  texts.at(textId).fontName = name;
+}
+
+void TextsCollection::SetTextRotation(int textId, float rotation)
+{
+  texts.at(textId).rotation = rotation;
+}
+
+void TextsCollection::SetTextSize(int textId, float size)
+{
+  texts.at(textId).size = size;
+}
+
+void TextsCollection::SetTextEffect(int textId, int effect)
+{
+  texts.at(textId).effects = static_cast<DirectX::SpriteEffects>(effect);
+}
+
+void TextsCollection::SetTextDepth(int textId, float Depth)
+{
+  texts.at(textId).layerDepth = Depth;
+}
+
+void TextsCollection::SetTextOrigin(int textId, std::array<double, 2> origin)
+{
+  texts.at(textId).origin = origin;
 }
 
 void TextsCollection::DestroyAllTexts()
@@ -74,6 +105,38 @@ const std::wstring& TextsCollection::GetTextString(int textId) const
 std::array<double, 4> TextsCollection::GetTextColor(int textId) const
 {
   return texts.at(textId).color;
+}
+
+std::string TextsCollection::GetTextName(int textId) const
+{
+  std::string txt = texts.at(textId).fontName;
+
+  return txt;
+}
+
+float TextsCollection::GetTextRotation(int textId) const
+{
+  return texts.at(textId).rotation;
+}
+
+float TextsCollection::GetTextSize(int textId) const
+{
+  return texts.at(textId).size;
+}
+
+int TextsCollection::GetTextEffect(int textId) const
+{
+  return texts.at(textId).effects;
+}
+
+int TextsCollection::GetTextDepth(int textId) const
+{
+  return texts.at(textId).layerDepth;
+}
+
+std::array<double, 2> TextsCollection::GetTextOrigin(int textId) const
+{
+  return std::array<double, 2>();
 }
 
 const std::unordered_map<int, TextToDraw>& TextsCollection::GetCreatedTexts()

--- a/skyrim-platform/src/platform_se/skyrim_platform/TextsCollection.h
+++ b/skyrim-platform/src/platform_se/skyrim_platform/TextsCollection.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <DirectXTK/SpriteBatch.h>
 
 class TextsCollection
 {
@@ -6,7 +7,7 @@ public:
   ~TextsCollection();
 
   int CreateText(double xPos, double yPos, std::wstring string,
-                 std::array<double, 4> color);
+                 std::array<double, 4> color, std::string name);
 
   void DestroyText(int textId);
 
@@ -15,6 +16,14 @@ public:
   void SetTextString(int textId, std::wstring str);
 
   void SetTextColor(int textId, std::array<double, 4> color);
+
+
+  void SetTextFont(int textId, std::string name);
+  void SetTextRotation(int textId, float rotation);
+  void SetTextSize(int textId, float size);
+  void SetTextEffect(int textId, int effect);
+  void SetTextDepth(int textId, float Depth);
+  void SetTextOrigin(int textId, std::array<double, 2> origin);
 
   void DestroyAllTexts();
 
@@ -33,6 +42,18 @@ public:
   const std::wstring& GetTextString(int textId) const;
 
   std::array<double, 4> GetTextColor(int textId) const;
+
+  std::string GetTextName(int textId) const;
+
+  float GetTextRotation(int textId) const;
+
+  float GetTextSize(int textId) const;
+
+  int GetTextEffect(int textId) const;
+
+  int GetTextDepth(int textId) const;
+
+  std::array<double, 2> GetTextOrigin(int textId) const;
 
   const std::unordered_map<int, TextToDraw>& GetCreatedTexts() const;
 

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.cpp
@@ -13,6 +13,8 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <filesystem>
+
 
 CMRC_DECLARE(skyrim_plugin_resources);
 
@@ -72,17 +74,31 @@ void DX11RenderHandler::Render(
       static_assert(
         std::is_same_v<std::decay_t<decltype(textToDraw.string.c_str()[0])>,
                        wchar_t>);
-      auto origin = DirectX::SimpleMath::Vector2(m_pSpriteFont->MeasureString(
-                      textToDraw.string.c_str())) /
-        2;
 
-      DirectX::XMVECTORF32 color = { static_cast<float>(textToDraw.color[0]),
-                                     static_cast<float>(textToDraw.color[1]),
-                                     static_cast<float>(textToDraw.color[2]),
-                                     static_cast<float>(textToDraw.color[3]) };
-      m_pSpriteFont->DrawString(
-        m_pSpriteBatch.get(), textToDraw.string.c_str(),
-        DirectX::XMFLOAT2(textToDraw.x, textToDraw.y), color, 0.f, origin);
+      std::wstring widestrFontName =
+        std::wstring(textToDraw.fontName.begin(), textToDraw.fontName.end());
+      
+      const wchar_t* fontPath = widestrFontName.c_str();
+
+      DirectX::SpriteFont m_pSpriteFont =
+        DirectX::SpriteFont(m_pDevice.Get(), fontPath);
+        
+      auto origin = DirectX::SimpleMath::Vector2(m_pSpriteFont.MeasureString(textToDraw.string.c_str())) / 2;
+
+      DirectX::XMVECTORF32 color =  { static_cast<float>(textToDraw.color[0]),
+                                      static_cast<float>(textToDraw.color[1]),
+                                      static_cast<float>(textToDraw.color[2]),
+                                      static_cast<float>(textToDraw.color[3]) };
+      m_pSpriteFont.DrawString(
+        m_pSpriteBatch.get(), 
+        textToDraw.string.c_str(), 
+        DirectX::XMFLOAT2(textToDraw.x, textToDraw.y), 
+        color,
+        textToDraw.rotation,
+        origin,
+        textToDraw.size, 
+        textToDraw.effects,
+        textToDraw.layerDepth);
     });
   }
 
@@ -130,9 +146,6 @@ void DX11RenderHandler::Create()
     std::make_unique<DirectX::SpriteBatch>(m_pImmediateContext.Get());
 
   m_pStates = std::make_unique<DirectX::CommonStates>(m_pDevice.Get());
-
-  m_pSpriteFont = std::make_unique<DirectX::SpriteFont>(
-    m_pDevice.Get(), L"Data/Platform/Fonts/Tavern.spritefont");
 
   if (FAILED(DirectX::CreateWICTextureFromFile(
         m_pDevice.Get(), m_pParent->GetCursorPathPNG().c_str(), nullptr,

--- a/skyrim-platform/src/tilted/ui/DX11RenderHandler.h
+++ b/skyrim-platform/src/tilted/ui/DX11RenderHandler.h
@@ -74,7 +74,6 @@ private:
   Microsoft::WRL::ComPtr<ID3D11DeviceContext> m_pImmediateContext;
 
   std::unique_ptr<::DirectX::SpriteBatch> m_pSpriteBatch;
-  std::unique_ptr<::DirectX::SpriteFont> m_pSpriteFont;
 
   std::unique_ptr<::DirectX::CommonStates> m_pStates;
 };

--- a/skyrim-platform/src/tilted/ui/TextToDraw.h
+++ b/skyrim-platform/src/tilted/ui/TextToDraw.h
@@ -3,13 +3,19 @@
 #include <array>
 #include <functional>
 #include <string>
-
+#include <DirectXTK/SpriteBatch.h>
 struct TextToDraw
 {
+  std::string fontName = "Data/Platform/Fonts/Tavern.spritefont";
   double x = 0.f;
   double y = 0.f;
   std::wstring string;
   std::array<double, 4> color = { 0.f, 0.f, 1.f, 1.f };
+  float rotation = 0.f;
+  float size = 1; 
+  DirectX::SpriteEffects effects = DirectX::SpriteEffects_None;
+  float layerDepth = 0.f;
+  std::array<double, 2> origin = { 0.f, 0.f};
 };
 
 using TextToDrawCallback = std::function<void(const TextToDraw& textToDraw)>;


### PR DESCRIPTION
# Add some new stuff

### Setters

- ```skyrimPlatform.setTextSize(textId: number, size: float)``` - set text (not font) size.

- ```skyrimPlatform.setTextRotation(textId, rotation: float)``` - set text rotation.

- ```skyrimPlatform.setTextFont(textId, path: string)``` - set text font from relative path "Data/Platform/Fonts/Tavern.spritefont".

- ```skyrimPlatform.setTextDepth(textId, depth: int)``` - set text z-index of the text.

- ```skyrimPlatform.setTextEffect(textId, effect: int)``` - set sprite effect [None = 0, FlipHorizontally = 1, FlipVertically = 2]

- ```skyrimPlatform.setTextOrigin(textId, origin [x,y])``` - set text pivot (center point).

### Getters

- ```skyrimPlatform.getTextSize(textId)``` - returns the size of the text

- ```skyrimPlatform.getTextRotation(textId)``` - returns the rotation of the text

- ```skyrimPlatform.getTextFont(textId)``` - returns the path to the font

- ```skyrimPlatform.getTextDepth(textId)``` - returns z-index of the text

- ```skyrimPlatform.getTextEffect(textId)``` - returns effect enum.

- ```skyrimPlatform.getTextOrigin(textId)``` - returns pivot (center point) of the text

- ```skyrimPlatform.getNumCreatedTexts()``` - returns the number of created texts.