### PR TITLE
internal: use version-semver instead of version-string in cef-prebuilt port

### DIFF
--- a/overlay_ports/cef-prebuilt/vcpkg.json
+++ b/overlay_ports/cef-prebuilt/vcpkg.json
@@ -1,5 +1,5 @@
 {
     "name": "cef-prebuilt",
-    "version-string": "107.1.9",
+    "version-semver": "107.1.9",
     "supports": "windows & x64"
 }


### PR DESCRIPTION
they usually use version-semver for that 
https://github.com/microsoft/vcpkg/search?q=version-semver