### PR TITLE
feat(skymp5-server): prevent players from using attribute regeneration potions very often 

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
@@ -58,13 +58,6 @@ void AnimationSystem::InitAnimationCallbacks()
       },
     },
     {
-      "attackStartLeftHand",
-      [](MpActor* actor) {
-        constexpr float modifier = 7.f;
-        actor->DamageActorValue(espm::ActorValue::Stamina, modifier);
-      },
-    },
-    {
       "AttackStartH2HRight",
       [](MpActor* actor) {
         constexpr float modifier = 4.f;

--- a/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
@@ -58,6 +58,13 @@ void AnimationSystem::InitAnimationCallbacks()
       },
     },
     {
+      "attackStartLeftHand",
+      [](MpActor* actor) {
+        constexpr float modifier = 7.f;
+        actor->DamageActorValue(espm::ActorValue::Stamina, modifier);
+      },
+    },
+    {
       "AttackStartH2HRight",
       [](MpActor* actor) {
         constexpr float modifier = 4.f;
@@ -91,7 +98,7 @@ void AnimationSystem::InitAnimationCallbacks()
     },
     {
       "attackRelease",
-      [&](MpActor* actor) {
+      [this](MpActor* actor) {
         std::chrono::duration<float> elapsedTime =
           std::chrono::steady_clock::now() -
           GetLastAttackReleaseAnimationTime();

--- a/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
@@ -91,7 +91,7 @@ void AnimationSystem::InitAnimationCallbacks()
     },
     {
       "attackRelease",
-      [this](MpActor* actor) {
+      [&](MpActor* actor) {
         std::chrono::duration<float> elapsedTime =
           std::chrono::steady_clock::now() -
           GetLastAttackReleaseAnimationTime();

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -419,7 +419,7 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
           // this coefficient (workaround) has been added for sake of game
           // balance and because of disability to restrict players use potions
           // often on client side
-          constexpr float kMagnitudeCoeff = 10.f;
+          constexpr float kMagnitudeCoeff = 100.f;
           RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
         }
       } else {

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -409,23 +409,25 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
   } else {
     return;
   }
-
+  std::unordered_set<std::string> modFiles = { GetParent()->espmFiles.begin(),
+                                               GetParent()->espmFiles.end() };
+  bool hasSweetpie = modFiles.count("SweetPie.esp");
   for (const auto& effect : effects) {
     espm::ActorValue av =
       espm::GetData<espm::MGEF>(effect.effectId, espmProvider).data.primaryAV;
     if (av == espm::ActorValue::Health || av == espm::ActorValue::Stamina ||
         av == espm::ActorValue::Magicka) { // other types is unsupported
-#ifdef SWEETPIE
-      if (CanActorValueBeRestored(av)) {
-        // this coefficient (workaround) has been added for sake of game
-        // balance and because of disability to restrict players use potions
-        // often on client side
-        constexpr float kMagnitudeCoeff = 100.f;
-        RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
+      if (hasSweetpie) {
+        if (CanActorValueBeRestored(av)) {
+          // this coefficient (workaround) has been added for sake of game
+          // balance and because of disability to restrict players use potions
+          // often on client side
+          constexpr float kMagnitudeCoeff = 100.f;
+          RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
+        }
+      } else {
+        RestoreActorValue(av, effect.magnitude);
       }
-#else
-      RestoreActorValue(av, effect.magnitude);
-#endif
     }
   }
 }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -390,7 +390,7 @@ void MpActor::MpApiDeath(MpActor* killer)
 void MpActor::EatItem(uint32_t baseId, espm::Type t)
 {
   std::unordered_set<std::string> modFiles{ GetParent()->espmFiles.begin(),
-                                     GetParent()->espmFiles.end() };
+                                            GetParent()->espmFiles.end() };
   bool hasSweetpie = modFiles.count("SweetPie.esp");
   if (std::chrono::steady_clock::now() - GetLastConsumedTime() <
         std::chrono::minutes(1) &&

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -445,7 +445,7 @@ std::chrono::steady_clock::time_point MpActor::GetLastRestorationTime(
 void MpActor::SetLastRestorationTime(
   espm::ActorValue av, std::chrono::steady_clock::time_point timePoint)
 {
-  pImpl->restorationTimePoints.insert({ av, timePoint });
+  pImpl->restorationTimePoints[av] = timePoint;
 }
 
 void MpActor::ModifyActorValuePercentage(espm::ActorValue av,

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -420,7 +420,7 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
         // this coefficient (workaround) has been added for sake of game
         // balance and because of disability to restrict players use potions
         // often on client side
-        constexpr float kMagnitudeCoeff = 5.f;
+        constexpr float kMagnitudeCoeff = 100.f;
         RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
       }
 #else

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -21,7 +21,7 @@ struct MpActor::Impl
   uint32_t snippetIndex = 0;
   bool isRespawning = false;
   std::chrono::steady_clock::time_point lastAttributesUpdateTimePoint,
-    lastHitTimePoint, lastConsumedTime;
+    lastHitTimePoint;
   using RestorationTimePoints =
     std::unordered_map<espm::ActorValue,
                        std::chrono::steady_clock::time_point>;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -13,8 +13,6 @@
 #include <random>
 #include <string>
 
-using namespace std::chrono_literals;
-
 struct MpActor::Impl
 {
   std::map<uint32_t, Viet::Promise<VarValue>> snippetPromises;
@@ -391,7 +389,12 @@ void MpActor::MpApiDeath(MpActor* killer)
 
 void MpActor::EatItem(uint32_t baseId, espm::Type t)
 {
-  if (std::chrono::steady_clock::now() - GetLastConsumedTime() < 3s) {
+  std::unordered_set<std::string> modFiles{ GetParent()->espmFiles.begin(),
+                                     GetParent()->espmFiles.end() };
+  bool hasSweetpie = modFiles.count("SweetPie.esp");
+  if (std::chrono::steady_clock::now() - GetLastConsumedTime() <
+        std::chrono::minutes(1) &&
+      hasSweetpie) {
     SetLastConsumedTime();
     return;
   }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -422,7 +422,7 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
           // this coefficient (workaround) has been added for sake of game
           // balance and because of disability to restrict players use potions
           // often on client side
-          constexpr float kMagnitudeCoeff = 100.f;
+          constexpr float kMagnitudeCoeff = 10.f;
           RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
         }
       } else {

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -24,12 +24,9 @@ struct MpActor::Impl
     std::unordered_map<espm::ActorValue,
                        std::chrono::steady_clock::time_point>;
   RestorationTimePoints restorationTimePoints = {
-    { espm::ActorValue::Health,
-      std::chrono::time_point<std::chrono::steady_clock>::min() },
-    { espm::ActorValue::Stamina,
-      std::chrono::time_point<std::chrono::steady_clock>::min() },
-    { espm::ActorValue::Magicka,
-      std::chrono::time_point<std::chrono::steady_clock>::min() },
+    { espm::ActorValue::Health, std::chrono::steady_clock::time_point{} },
+    { espm::ActorValue::Stamina, std::chrono::steady_clock::time_point{} },
+    { espm::ActorValue::Magicka, std::chrono::steady_clock::time_point{} },
   };
 };
 

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -417,7 +417,10 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
         av == espm::ActorValue::Magicka) { // other types is unsupported
       if (hasSweetpie) {
         if (CanActorValueBeRestored(av)) {
-          RestoreActorValue(av, effect.magnitude * 5);
+          // this coefficient (workaround) has been added for sake of game balance
+          // and because of disability to restrict player use potions often on client side
+          constexpr float kMagnitudeCoeff = 5.f;
+          RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
         }
       } else {
         RestoreActorValue(av, effect.magnitude);

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -417,8 +417,9 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
         av == espm::ActorValue::Magicka) { // other types is unsupported
       if (hasSweetpie) {
         if (CanActorValueBeRestored(av)) {
-          // this coefficient (workaround) has been added for sake of game balance
-          // and because of disability to restrict player use potions often on client side
+          // this coefficient (workaround) has been added for sake of game
+          // balance and because of disability to restrict player use potions
+          // often on client side
           constexpr float kMagnitudeCoeff = 5.f;
           RestoreActorValue(av, effect.magnitude * kMagnitudeCoeff);
         }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -417,7 +417,7 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
         av == espm::ActorValue::Magicka) { // other types is unsupported
       if (hasSweetpie) {
         if (CanActorValueBeRestored(av)) {
-          RestoreActorValue(av, effect.magnitude);
+          RestoreActorValue(av, effect.magnitude * 5);
         }
       } else {
         RestoreActorValue(av, effect.magnitude);

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -13,8 +13,6 @@
 #include <random>
 #include <string>
 
-const std::chrono::steady_clock::time_point initialTimePoint;
-
 struct MpActor::Impl
 {
   std::map<uint32_t, Viet::Promise<VarValue>> snippetPromises;
@@ -26,9 +24,12 @@ struct MpActor::Impl
     std::unordered_map<espm::ActorValue,
                        std::chrono::steady_clock::time_point>;
   RestorationTimePoints restorationTimePoints = {
-    { espm::ActorValue::Health, initialTimePoint },
-    { espm::ActorValue::Stamina, initialTimePoint },
-    { espm::ActorValue::Magicka, initialTimePoint },
+    { espm::ActorValue::Health,
+      std::chrono::time_point<std::chrono::steady_clock>::min() },
+    { espm::ActorValue::Stamina,
+      std::chrono::time_point<std::chrono::steady_clock>::min() },
+    { espm::ActorValue::Magicka,
+      std::chrono::time_point<std::chrono::steady_clock>::min() },
   };
 };
 

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -112,6 +112,9 @@ private:
   void EatItem(uint32_t baseId, espm::Type t);
 
   void ModifyActorValuePercentage(espm::ActorValue av, float percentageDelta);
+  std::chrono::steady_clock::time_point GetLastConsumedTime() const;
+  void SetLastConsumedTime(std::chrono::steady_clock::time_point timePoint =
+                             std::chrono::steady_clock::now());
 
   bool isBlockActive;
 

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -112,9 +112,12 @@ private:
   void EatItem(uint32_t baseId, espm::Type t);
 
   void ModifyActorValuePercentage(espm::ActorValue av, float percentageDelta);
-  std::chrono::steady_clock::time_point GetLastConsumedTime() const;
-  void SetLastConsumedTime(std::chrono::steady_clock::time_point timePoint =
-                             std::chrono::steady_clock::now());
+  std::chrono::steady_clock::time_point GetLastRestorationTime(
+    espm::ActorValue av) const;
+  void SetLastRestorationTime(espm::ActorValue av,
+                              std::chrono::steady_clock::time_point timePoint =
+                                std::chrono::steady_clock::now());
+  bool CanActorValueBeRestored(espm::ActorValue av);
 
   bool isBlockActive;
 

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -115,8 +115,7 @@ private:
   std::chrono::steady_clock::time_point GetLastRestorationTime(
     espm::ActorValue av) const;
   void SetLastRestorationTime(espm::ActorValue av,
-                              std::chrono::steady_clock::time_point timePoint =
-                                std::chrono::steady_clock::now());
+                              std::chrono::steady_clock::time_point timePoint);
   bool CanActorValueBeRestored(espm::ActorValue av);
 
   bool isBlockActive;


### PR DESCRIPTION
Closes #1278