### PR TITLE
fix(skymp5-server): fix Papyrus properties fill

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
@@ -48,9 +48,9 @@ void ScriptVariablesHolder::FillProperties()
   auto baseScript = GetScript(baseRecordWithScripts);
   auto refrScript = GetScript(refrRecordWithScripts);
 
-  for (auto script : { baseScript, refrScript }) {
-    const char* varName = script == baseScript ? "base" : "refr";
-
+  const char* varName = "base";
+  
+  for (auto &script : { baseScript, refrScript }) {
     if (script) {
       for (auto& prop : script->properties) {
         VarValue out;
@@ -63,6 +63,8 @@ void ScriptVariablesHolder::FillProperties()
         // spdlog::info("{} - Setting {} property value from {} properties", myScriptName, fullVarName.c_str(), varName);
       }
     }
+
+    varName = "refr";
   }
 }
 

--- a/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
@@ -3,8 +3,6 @@
 #include "EspmGameObject.h"
 #include "Utils.h"
 
-// #include <spdlog.h>
-
 ScriptVariablesHolder::ScriptVariablesHolder(
   const std::string& myScriptName_, espm::RecordHeader* baseRecordWithScripts_,
   espm::RecordHeader* refrRecordWithScripts_,
@@ -47,8 +45,6 @@ void ScriptVariablesHolder::FillProperties()
 {
   auto baseScript = GetScript(baseRecordWithScripts);
   auto refrScript = GetScript(refrRecordWithScripts);
-
-  const char* varName = "base";
   
   for (auto &script : { baseScript, refrScript }) {
     if (script) {
@@ -60,11 +56,8 @@ void ScriptVariablesHolder::FillProperties()
         fullVarName += prop.propertyName.data();
         fullVarName += "_var";
         (*vars)[fullVarName] = out;
-        // spdlog::info("{} - Setting {} property value from {} properties", myScriptName, fullVarName.c_str(), varName);
       }
     }
-
-    varName = "refr";
   }
 }
 
@@ -107,28 +100,6 @@ std::optional<espm::Script> ScriptVariablesHolder::GetScript(espm::RecordHeader 
     return std::move(*matchingScriptData);
   }
   return std::nullopt;
-
-  // std::vector<espm::Script> scripts;
-
-  // Scripts on REFR is in priority due to property values override
-  // for (auto rec : { refrRecordWithScripts, baseRecordWithScripts }) {
-  //   if (!rec) {
-  //     continue;
-  //   }
-  //   espm::ScriptData scriptData;
-  //   rec->GetScriptData(&scriptData, *compressedFieldsCache);
-  //   auto matchingScriptData = std::find_if(
-  //     scriptData.scripts.begin(), scriptData.scripts.end(),
-  //     [&](const espm::Script& script) {
-  //       return !Utils::stricmp(script.scriptName.data(), myScriptName.data());
-  //     });
-  //   if (matchingScriptData != scriptData.scripts.end()) {
-  //     //return std::move(*matchingScriptData);
-  //     scripts.push_back(*matchingScriptData);
-  //   }
-  // }
-  // throw std::runtime_error("ScriptData doesn't contain script with name '" +
-  //                          myScriptName + "'");
 }
 
 VarValue ScriptVariablesHolder::CastPrimitivePropertyValue(

--- a/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
@@ -45,8 +45,8 @@ void ScriptVariablesHolder::FillProperties()
 {
   auto baseScript = GetScript(baseRecordWithScripts);
   auto refrScript = GetScript(refrRecordWithScripts);
-  
-  for (auto &script : { baseScript, refrScript }) {
+
+  for (auto& script : { baseScript, refrScript }) {
     if (script) {
       for (auto& prop : script->properties) {
         VarValue out;
@@ -83,7 +83,8 @@ void ScriptVariablesHolder::FillState(const PexScript& pex)
   state = VarValue(pex.objectTable[0].autoStateName.data());
 }
 
-std::optional<espm::Script> ScriptVariablesHolder::GetScript(espm::RecordHeader *const record)
+std::optional<espm::Script> ScriptVariablesHolder::GetScript(
+  espm::RecordHeader* const record)
 {
   if (!record) {
     return std::nullopt;

--- a/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.cpp
@@ -3,7 +3,7 @@
 #include "EspmGameObject.h"
 #include "Utils.h"
 
-#include <spdlog.h>
+// #include <spdlog.h>
 
 ScriptVariablesHolder::ScriptVariablesHolder(
   const std::string& myScriptName_, espm::RecordHeader* baseRecordWithScripts_,
@@ -60,7 +60,7 @@ void ScriptVariablesHolder::FillProperties()
         fullVarName += prop.propertyName.data();
         fullVarName += "_var";
         (*vars)[fullVarName] = out;
-        spdlog::info("{} - Setting {} property value from {} properties", myScriptName, fullVarName.c_str(), varName);
+        // spdlog::info("{} - Setting {} property value from {} properties", myScriptName, fullVarName.c_str(), varName);
       }
     }
   }

--- a/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.h
+++ b/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.h
@@ -21,8 +21,8 @@ private:
   void FillProperties();
   void FillNormalVariables(const PexScript& pex);
   void FillState(const PexScript& pex);
-  
-  std::optional<espm::Script> GetScript(espm::RecordHeader *const record);
+
+  std::optional<espm::Script> GetScript(espm::RecordHeader* const record);
 
   using VarsMap = CIMap<VarValue>;
   using EspmObjectsHolder =

--- a/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.h
+++ b/skymp5-server/cpp/server_guest_lib/ScriptVariablesHolder.h
@@ -2,6 +2,7 @@
 #include "CIString.h"
 #include "Loader.h"
 #include "VirtualMachine.h"
+#include <optional>
 
 class EspmGameObject;
 
@@ -17,10 +18,11 @@ public:
   VarValue* GetVariableByName(const char* name, const PexScript& pex) override;
 
 private:
-  void FillProperties(const espm::Script& script);
+  void FillProperties();
   void FillNormalVariables(const PexScript& pex);
   void FillState(const PexScript& pex);
-  espm::Script GetScript();
+  
+  std::optional<espm::Script> GetScript(espm::RecordHeader *const record);
 
   using VarsMap = CIMap<VarValue>;
   using EspmObjectsHolder =


### PR DESCRIPTION
now refr properties merge with base properties correctly

before: refr properties override base properties, removing all that was set in base but not in refr