### PR TITLE
fix(skymp5-server): relax workbench base type check

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -449,7 +449,7 @@ void ActionListener::OnCraftItem(const RawMessageData& rawMsgData,
   spdlog::debug("User {} tries to craft {:#x} on workbench {:#x}",
                 rawMsgData.userId, resultObjectId, workbenchId);
 
-  if (base.rec->GetType() != "FURN") {
+  if (base.rec->GetType() != "FURN" && base.rec->GetType() != "ACTI") {
     throw std::runtime_error("Unable to use " +
                              base.rec->GetType().ToString() + " as workbench");
   }


### PR DESCRIPTION
"Это касается мельниц, воспроизвести лекго, идем в мельницу Вайтрана и пытаемся скрафтить муку, она не скрафтится и зерно вернется в инвентарь"