### PR TITLE
refact(skymp5-server): remove unnecessary worldState argument passed in papyrus classes & use policy to retrieve it instead

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/IPapyrusClass.h
+++ b/skymp5-server/cpp/server_guest_lib/IPapyrusClass.h
@@ -9,8 +9,7 @@ public:
 
   virtual void Register(
     VirtualMachine& vm,
-    std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy,
-    WorldState* worldState) = 0;
+    std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy) = 0;
 
   virtual ~IPapyrusClassBase() = default;
 };

--- a/skymp5-server/cpp/server_guest_lib/PapyrusActor.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusActor.h
@@ -3,7 +3,7 @@
 #include "IPapyrusClass.h"
 #include "SpSnippetFunctionGen.h"
 
-class PapyrusActor : public IPapyrusClass<PapyrusActor>
+class PapyrusActor final : public IPapyrusClass<PapyrusActor>
 {
 public:
   const char* GetName() override { return "actor"; }
@@ -32,8 +32,7 @@ public:
   VarValue SetDontMove(VarValue self, const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     compatibilityPolicy = policy;
 

--- a/skymp5-server/cpp/server_guest_lib/PapyrusDebug.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusDebug.h
@@ -2,7 +2,7 @@
 #include "IPapyrusClass.h"
 #include "SpSnippetFunctionGen.h"
 
-class PapyrusDebug : public IPapyrusClass<PapyrusDebug>
+class PapyrusDebug final : public IPapyrusClass<PapyrusDebug>
 {
 public:
   const char* GetName() override { return "debug"; }
@@ -14,8 +14,7 @@ public:
                               const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     compatibilityPolicy = policy;
 

--- a/skymp5-server/cpp/server_guest_lib/PapyrusEffectShader.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusEffectShader.h
@@ -2,7 +2,7 @@
 #include "IPapyrusClass.h"
 #include "SpSnippetFunctionGen.h"
 
-class PapyrusEffectShader : public IPapyrusClass<PapyrusEffectShader>
+class PapyrusEffectShader final : public IPapyrusClass<PapyrusEffectShader>
 {
 public:
   const char* GetName() override { return "effectshader"; }
@@ -10,8 +10,7 @@ public:
   VarValue Stop(VarValue self, const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     AddMethod(vm, "Play", &PapyrusEffectShader::Play);
     AddMethod(vm, "Stop", &PapyrusEffectShader::Stop);

--- a/skymp5-server/cpp/server_guest_lib/PapyrusForm.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusForm.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "IPapyrusClass.h"
 
-class PapyrusForm : public IPapyrusClass<PapyrusForm>
+class PapyrusForm final : public IPapyrusClass<PapyrusForm>
 {
 public:
   const char* GetName() override { return "form"; }
@@ -14,8 +14,7 @@ public:
   VarValue HasKeyword(VarValue self, const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     AddMethod(vm, "RegisterForSingleUpdate",
               &PapyrusForm::RegisterForSingleUpdate);

--- a/skymp5-server/cpp/server_guest_lib/PapyrusFormList.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusFormList.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "IPapyrusClass.h"
 
-class PapyrusFormList : public IPapyrusClass<PapyrusFormList>
+class PapyrusFormList final : public IPapyrusClass<PapyrusFormList>
 {
 public:
   const char* GetName() override { return "formlist"; }
@@ -11,8 +11,7 @@ public:
   VarValue Find(VarValue self, const std::vector<VarValue>& arguments) const;
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     AddMethod(vm, "GetSize", &PapyrusFormList::GetSize);
     AddMethod(vm, "GetAt", &PapyrusFormList::GetAt);

--- a/skymp5-server/cpp/server_guest_lib/PapyrusGame.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusGame.h
@@ -2,7 +2,7 @@
 #include "IPapyrusClass.h"
 #include "SpSnippetFunctionGen.h"
 
-class PapyrusGame : public IPapyrusClass<PapyrusGame>
+class PapyrusGame final : public IPapyrusClass<PapyrusGame>
 {
 public:
   const char* GetName() override { return "game"; }
@@ -23,8 +23,7 @@ public:
                           const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     compatibilityPolicy = policy;
 

--- a/skymp5-server/cpp/server_guest_lib/PapyrusKeyword.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusKeyword.cpp
@@ -16,6 +16,7 @@ VarValue PapyrusKeyword::GetKeyword(VarValue self,
     for (auto itKeyword = (*it)->begin(); itKeyword != (*it)->end();
          ++itKeyword) {
       auto keyword = reinterpret_cast<espm::KYWD*>(*itKeyword);
+      WorldState* worldState = compatibilityPolicy->GetWorldState();
       CIString otherName =
         keyword->GetData(worldState->GetEspmCache()).editorId;
 

--- a/skymp5-server/cpp/server_guest_lib/PapyrusKeyword.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusKeyword.h
@@ -3,7 +3,7 @@
 #include "IPapyrusClass.h"
 #include "WorldState.h"
 
-class PapyrusKeyword : public IPapyrusClass<PapyrusKeyword>
+class PapyrusKeyword final : public IPapyrusClass<PapyrusKeyword>
 {
 public:
   const char* GetName() override { return "keyword"; }
@@ -11,18 +11,18 @@ public:
   VarValue GetKeyword(VarValue self, const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     compatibilityPolicy = policy;
-    worldState = world;
 
-    keywords = world->GetEspm().GetBrowser().GetRecordsByType("KYWD");
+    keywords = compatibilityPolicy->GetWorldState()
+                 ->GetEspm()
+                 .GetBrowser()
+                 .GetRecordsByType("KYWD");
 
     AddStatic(vm, "GetKeyword", &PapyrusKeyword::GetKeyword);
   }
 
   std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy;
-  WorldState* worldState;
   std::vector<const std::vector<espm::RecordHeader*>*> keywords;
 };

--- a/skymp5-server/cpp/server_guest_lib/PapyrusMessage.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusMessage.h
@@ -2,7 +2,7 @@
 #include "IPapyrusClass.h"
 #include "SpSnippetFunctionGen.h"
 
-class PapyrusMessage : public IPapyrusClass<PapyrusMessage>
+class PapyrusMessage final : public IPapyrusClass<PapyrusMessage>
 {
 public:
   const char* GetName() override { return "message"; }
@@ -10,8 +10,7 @@ public:
   DEFINE_METHOD_SPSNIPPET(Show);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     compatibilityPolicy = policy;
 

--- a/skymp5-server/cpp/server_guest_lib/PapyrusObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusObjectReference.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "IPapyrusClass.h"
 
-class PapyrusObjectReference : public IPapyrusClass<PapyrusObjectReference>
+class PapyrusObjectReference final
+  : public IPapyrusClass<PapyrusObjectReference>
 {
 public:
   const char* GetName() override { return "objectreference"; }
@@ -41,8 +42,7 @@ public:
                                  const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     AddMethod(vm, "IsHarvested", &PapyrusObjectReference::IsHarvested);
     AddMethod(vm, "IsDisabled", &PapyrusObjectReference::IsDisabled);

--- a/skymp5-server/cpp/server_guest_lib/PapyrusSkymp.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusSkymp.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "IPapyrusClass.h"
 
-class PapyrusSkymp : public IPapyrusClass<PapyrusSkymp>
+class PapyrusSkymp final : public IPapyrusClass<PapyrusSkymp>
 {
 public:
   const char* GetName() override { return "skymp"; }
@@ -11,8 +11,7 @@ public:
 
   void Register(
     VirtualMachine& vm,
-    std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy,
-    WorldState* world) override
+    std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy) override
   {
     policy = compatibilityPolicy;
 

--- a/skymp5-server/cpp/server_guest_lib/PapyrusUtility.h
+++ b/skymp5-server/cpp/server_guest_lib/PapyrusUtility.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "IPapyrusClass.h"
 
-class PapyrusUtility : public IPapyrusClass<PapyrusUtility>
+class PapyrusUtility final : public IPapyrusClass<PapyrusUtility>
 {
 public:
   const char* GetName() override { return "utility"; }
@@ -9,8 +9,7 @@ public:
   VarValue Wait(VarValue self, const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
-                std::shared_ptr<IPapyrusCompatibilityPolicy> policy,
-                WorldState* world) override
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override
   {
     compatibilityPolicy = policy;
 

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -612,7 +612,7 @@ VirtualMachine& WorldState::GetPapyrusVm()
       pImpl->classes.emplace_back(std::make_unique<PapyrusEffectShader>());
       pImpl->classes.emplace_back(std::make_unique<PapyrusKeyword>());
       for (auto& cl : pImpl->classes) {
-        cl->Register(*pImpl->vm, pImpl->policy, this);
+        cl->Register(*pImpl->vm, pImpl->policy);
       }
     }
   }


### PR DESCRIPTION
closes #1569