### PR TITLE
fix(skymp5-server): do not throw on baseId anomaly

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -812,7 +812,7 @@ void MpObjectReference::ApplyChangeForm(const MpChangeForm& changeForm)
   const auto currentBaseId = GetBaseId();
   const auto newBaseId = changeForm.baseDesc.ToFormId(GetParent()->espmFiles);
   if (currentBaseId != newBaseId) {
-    spdlog::error("Anomally, baseId should never change ({:x} => {:x})",
+    spdlog::error("Anomaly, baseId should never change ({:x} => {:x})",
                   currentBaseId, newBaseId);
   }
 

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -812,10 +812,8 @@ void MpObjectReference::ApplyChangeForm(const MpChangeForm& changeForm)
   const auto currentBaseId = GetBaseId();
   const auto newBaseId = changeForm.baseDesc.ToFormId(GetParent()->espmFiles);
   if (currentBaseId != newBaseId) {
-    std::stringstream ss;
-    ss << "Anomally, baseId should never change (";
-    ss << std::hex << currentBaseId << " => " << newBaseId << ")";
-    throw std::runtime_error(ss.str());
+    spdlog::error("Anomally, baseId should never change ({:x} => {:x})",
+                  currentBaseId, newBaseId);
   }
 
   if (ChangeForm().formDesc != changeForm.formDesc) {

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -401,7 +401,7 @@ bool WorldState::AttachEspmRecord(const espm::CombineBrowser& br,
 
   } else {
     if (!locationalData) {
-      logger->error("Anomally: refr without locationalData");
+      logger->error("Anomaly: refr without locationalData");
       return false;
     }
 

--- a/unit/WorldStateTest.cpp
+++ b/unit/WorldStateTest.cpp
@@ -139,7 +139,8 @@ TEST_CASE("Load ChangeForm of modified object with changed baseType",
 
   // REQUIRE_THROWS_WITH(
   //   worldState.LoadChangeForm(changeForm, FormCallbacks::DoNothing()),
-  //   ContainsSubstring("Anomally, baseId should never change (ded0 => abcd)"));
+  //   ContainsSubstring("Anomally, baseId should never change (ded0 =>
+  //   abcd)"));
 }
 
 extern PartOne& GetPartOne();

--- a/unit/WorldStateTest.cpp
+++ b/unit/WorldStateTest.cpp
@@ -132,9 +132,14 @@ TEST_CASE("Load ChangeForm of modified object with changed baseType",
   changeForm.formDesc = { 0xeeee, "Skyrim.esm" };
   changeForm.baseDesc = { 0xabcd, "Skyrim.esm" };
 
-  REQUIRE_THROWS_WITH(
-    worldState.LoadChangeForm(changeForm, FormCallbacks::DoNothing()),
-    ContainsSubstring("Anomally, baseId should never change (ded0 => abcd)"));
+  worldState.LoadChangeForm(changeForm, FormCallbacks::DoNothing());
+
+  // Currently, baseId is not changed. I'm not sure if it should be changed.
+  REQUIRE(newRefr->GetBaseId() == 0x0000ded0);
+
+  // REQUIRE_THROWS_WITH(
+  //   worldState.LoadChangeForm(changeForm, FormCallbacks::DoNothing()),
+  //   ContainsSubstring("Anomally, baseId should never change (ded0 => abcd)"));
 }
 
 extern PartOne& GetPartOne();


### PR DESCRIPTION
Related to ESP update.

This error prevented some users from entering the server.