### PR TITLE
fix(skymp5-client): fix swimming anim after respawn

### DIFF
--- a/skymp5-client/src/sync/deathSystem.ts
+++ b/skymp5-client/src/sync/deathSystem.ts
@@ -120,6 +120,7 @@ const ressurectWithPushKill = (act: Actor): void => {
   safeRemoveRagdollFromWorld(act, () => {
     const actor = Actor.from(Game.getFormEx(formId));
     if (!actor) return;
+    Game.getPlayer()!.setAnimationVariableInt("iGetUpType", 1);
     Debug.sendAnimationEvent(actor, AnimationEventName.GetUpBegin);
   });
 };


### PR DESCRIPTION
closes #1596
This causes the player to run underwater if the spawn point is underwater