### PR TITLE
internal: fix operator == and operator != compile error

### DIFF
--- a/libespm/include/libespm/Type.h
+++ b/libespm/include/libespm/Type.h
@@ -13,7 +13,6 @@ public:
   explicit Type(const char* type_) noexcept;
 
   bool operator==(const char* rhs) const noexcept;
-  bool operator!=(const char* rhs) const noexcept;
   std::string ToString() const noexcept;
   uint32_t ToUint32() const noexcept;
 

--- a/libespm/src/Type.cpp
+++ b/libespm/src/Type.cpp
@@ -13,11 +13,6 @@ bool Type::operator==(const char* rhs) const noexcept
   return !std::memcmp(type, rhs, 4);
 }
 
-bool Type::operator!=(const char* rhs) const noexcept
-{
-  return !(*this == rhs);
-}
-
 std::string Type::ToString() const noexcept
 {
   return std::string{ type, 4 };


### PR DESCRIPTION
Compile error when building on release branch. Removed code causing the compile error. Project now compiles successfully.