### PR TITLE
refact(skymp5-client): introduce a few refactors

### DIFF
--- a/skymp5-client/src/features/authModel.ts
+++ b/skymp5-client/src/features/authModel.ts
@@ -1,16 +1,18 @@
-export class RemoteAuthGameData {
-  public constructor(
-    public session: string,
-    public masterApiId: number,
-    public discordUsername: string | null,
-    public discordDiscriminator: string | null,
-    public discordAvatar: string | null,
-  ) { }
-}
+export interface RemoteAuthGameData {
+  session: string;
+  masterApiId: number;
+  discordUsername: string | null;
+  discordDiscriminator: string | null;
+  discordAvatar: string | null;
+};
 
-export class AuthGameData {
-  public static readonly storageKey = "authGameData";
+export interface LocalAuthGameData {
+  profileId: number;
+};
 
-  public remote?: RemoteAuthGameData;
-  public local?: { profileId: number };
-}
+export interface AuthGameData {
+  remote?: RemoteAuthGameData;
+  local?: LocalAuthGameData;
+};
+
+export const authGameDataStorageKey = "authGameData";

--- a/skymp5-client/src/services/messages_http/serverManifest.ts
+++ b/skymp5-client/src/services/messages_http/serverManifest.ts
@@ -1,0 +1,11 @@
+export interface Mod {
+    filename: string;
+    size: number;
+    crc32: number;
+};
+
+export interface ServerManifest {
+    versionMajor: number;
+    mods: Mod[];
+    loadOrder: string[];
+};

--- a/skymp5-client/src/services/services/frontHotReloadService.ts
+++ b/skymp5-client/src/services/services/frontHotReloadService.ts
@@ -1,4 +1,4 @@
-import { AuthGameData } from "../../features/authModel";
+import { AuthGameData, authGameDataStorageKey } from "../../features/authModel";
 import { AuthEvent } from "../events/authEvent";
 import { ClientListener, Sp, CombinedController } from "./clientListener";
 
@@ -15,7 +15,7 @@ export class FrontHotReloadService extends ClientListener {
         }
 
         // TODO: refactor out very similar code in skympClient.ts
-        const authGameData = this.sp.storage[AuthGameData.storageKey] as AuthGameData | undefined;
+        const authGameData = this.sp.storage[authGameDataStorageKey] as AuthGameData | undefined;
 
         const storageHasValidAuthGameData = authGameData?.local || authGameData?.remote;
 

--- a/skymp5-client/src/services/services/loadOrderVerificationService.ts
+++ b/skymp5-client/src/services/services/loadOrderVerificationService.ts
@@ -2,18 +2,7 @@ import { Game, Utility, HttpClient, printConsole, createText } from "skyrimPlatf
 import { getServerIp, getServerUiPort } from "./skympClient";
 import { getScreenResolution } from "../../view/formView";
 import { ClientListener, CombinedController, Sp } from "./clientListener";
-
-interface Mod {
-  filename: string;
-  size: number;
-  crc32: number;
-};
-
-interface ServerManifest {
-  versionMajor: number;
-  mods: Mod[];
-  loadOrder: string[];
-};
+import { Mod, ServerManifest } from "../messages_http/serverManifest";
 
 const STATE_KEY = 'loadOrderCheckState';
 

--- a/skymp5-client/src/services/services/remoteServer.ts
+++ b/skymp5-client/src/services/services/remoteServer.ts
@@ -20,7 +20,7 @@ import * as messages from '../../messages';
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { ObjectReferenceEx } from '../../extensions/objectReferenceEx';
-import { AuthGameData } from '../../features/authModel';
+import { AuthGameData, authGameDataStorageKey } from '../../features/authModel';
 import { IdManager } from '../../lib/idManager';
 import { nameof } from '../../lib/nameof';
 import { setActorValuePercentage } from '../../sync/actorvalues';
@@ -954,7 +954,7 @@ export class RemoteServer extends ClientListener {
   private loginWithSkympIoCredentials() {
     this.loggingStartMoment = Date.now();
 
-    const authData = storage[AuthGameData.storageKey] as AuthGameData | undefined;
+    const authData = storage[authGameDataStorageKey] as AuthGameData | undefined;
     if (authData?.local) {
       this.logTrace(
         `Logging in offline mode, profileId = ${authData.local.profileId}`,

--- a/skymp5-client/src/services/services/skympClient.ts
+++ b/skymp5-client/src/services/services/skympClient.ts
@@ -11,7 +11,7 @@ import { RemoteServer } from './remoteServer';
 import { setupHooks } from '../../sync/animation';
 import { WorldView } from '../../view/worldView';
 import { SinglePlayerService } from './singlePlayerService';
-import { AuthGameData } from '../../features/authModel';
+import { AuthGameData, authGameDataStorageKey } from '../../features/authModel';
 import { ClientListener, CombinedController, Sp } from './clientListener';
 import { ConnectionFailed } from '../events/connectionFailed';
 import { ConnectionDenied } from '../events/connectionDenied';
@@ -43,7 +43,7 @@ export class SkympClient extends ClientListener {
     this.controller.emitter.on("createActorMessage", (e) => this.onActorCreateMessage(e));
 
     // TODO: refactor out very similar code in frontHotReloadService.ts
-    const authGameData = storage[AuthGameData.storageKey] as AuthGameData | undefined;
+    const authGameData = storage[authGameDataStorageKey] as AuthGameData | undefined;
 
     const storageHasValidAuthGameData = authGameData?.local || authGameData?.remote;
 
@@ -64,7 +64,7 @@ export class SkympClient extends ClientListener {
   private onAuth(e: AuthEvent) {
     this.logTrace(`Caught auth event`);
 
-    storage[AuthGameData.storageKey] = e.authGameData;
+    storage[authGameDataStorageKey] = e.authGameData;
 
     this.startClient();
 

--- a/skymp5-client/src/services/spApiInteractor.ts
+++ b/skymp5-client/src/services/spApiInteractor.ts
@@ -4,7 +4,7 @@ import * as sp from "skyrimPlatform";
 
 export class SpApiInteractor {
     static setup(listeners: ClientListener[]) {
-        listeners.forEach(listener => SpApiInteractor.registerListenerForLookup(listener.constructor.name, listener));
+        listeners.forEach(listener => SpApiInteractor.registerListenerForLookup(listener.constructor, listener));
     }
 
     static getControllerInstance(): CombinedController {
@@ -17,7 +17,7 @@ export class SpApiInteractor {
             once: sp.once,
             emitter: EventEmitterFactory.makeEventEmitter(),
             lookupListener<T extends ClientListener>(constructor: ClientListenerConstructor<T>): T {
-                const listener = SpApiInteractor.listenersForLookupByName.get(constructor.name);
+                const listener = SpApiInteractor.listenersForLookupByName.get(constructor);
                 if (listener === undefined) {
                     throw new Error(`listener not found for name '${constructor.name}'`);
                 }
@@ -30,14 +30,14 @@ export class SpApiInteractor {
         return SpApiInteractor.controller;
     }
 
-    private static registerListenerForLookup(listenerName: string, listener: ClientListener): void {
-        if (SpApiInteractor.listenersForLookupByName.has(listenerName)) {
-            throw new Error(`listener re-registration for name '${listenerName}'`);
+    private static registerListenerForLookup(constructor: Function, listener: ClientListener): void {
+        if (SpApiInteractor.listenersForLookupByName.has(constructor)) {
+            throw new Error(`listener re-registration for name '${constructor}'`);
         }
-        SpApiInteractor.listenersForLookupByName.set(listenerName, listener);
+        SpApiInteractor.listenersForLookupByName.set(constructor, listener);
     }
 
-    private static listenersForLookupByName = new Map<string, ClientListener>();
+    private static listenersForLookupByName = new Map<Function, ClientListener>();
 
     private static controller?: CombinedController;
 }


### PR DESCRIPTION
- RemoteAuthGameData should be an interface, not a class. because it's being casted from plain object in code 
- We should store listeners by contsturctor itself, instead of constructor.name because in theory names can collide
- Put serverManifest in messages_http to make the contract obvious. further refactors should be done.
