### PR TITLE
internal: start switching libraries to dynamic linkage (PoC)

### DIFF
--- a/overlay_triplets/x64-windows-sp.cmake
+++ b/overlay_triplets/x64-windows-sp.cmake
@@ -3,7 +3,8 @@ set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
 
-if(${PORT} MATCHES "chakracore")
+# Keep in sync with skyrim-platform\tools\dev_service\index.js, requiredVcpkgDlls constant
+if(${PORT} MATCHES "spdlog|fmt|chakracore")
   set(VCPKG_CRT_LINKAGE static) # VCPKG_CRT_LINKAGE should be the same for all ports
   set(VCPKG_LIBRARY_LINKAGE dynamic)
 endif()

--- a/skyrim-platform/tools/dev_service/index.js
+++ b/skyrim-platform/tools/dev_service/index.js
@@ -3,6 +3,13 @@ let path = require("path");
 let childProcess = require("child_process");
 let game = require("./game");
 
+// Keep this in sync with triplet file overlay_triplets\x64-windows-sp.cmake or similar
+const requiredVcpkgDlls = [
+  "spdlog.dll",
+  "fmt.dll",
+  "ChakraCore.dll"
+];
+
 function writeFileSyncRecursive(filename, content, charset) {
   filename
     .split(path.sep)
@@ -134,10 +141,12 @@ const watchCallback = (_eventType, fileName) => {
 
         cp(binPath("SkyrimPlatform.pdb"), distDir);
         cp(binPath("SkyrimPlatformImpl.pdb"), distDir);
-        cp(
-          binPath("ChakraCore.dll"),
-          path.join(distDir, "Data/Platform/Distribution/RuntimeDependencies")
-        );
+        requiredVcpkgDlls.forEach((dll) => {
+          cp(
+            binPath(dll),
+            path.join(distDir, "Data/Platform/Distribution/RuntimeDependencies")
+          );
+        });
         cp(
           binPath("SkyrimPlatformCEF.exe.hidden"),
           path.join(distDir, "Data/Platform/Distribution/RuntimeDependencies")

--- a/unit/DistContentsExpected.json
+++ b/unit/DistContentsExpected.json
@@ -90,7 +90,9 @@
       "client/Data/Platform/UI/fb344395b65fad4dc9b2b4dbecaaf9ae.svg",
       "client/Data/Platform/UI/ffb48dba84edac2a01a89b25c3ba270e.mp3",
       "client/Data/Platform/UI/24f47c642fc63bf9f479df7cb8e4746a.wav",
-      "client/Data/Platform/UI/4c9effcbaeeb2d8ca70ae680ac1e3b9a.wav"
+      "client/Data/Platform/UI/4c9effcbaeeb2d8ca70ae680ac1e3b9a.wav",
+      "server/fmt.dll",
+      "server/spdlog.dll"
     ]
   },
   {
@@ -283,6 +285,7 @@
       "client/Data/Platform/Distribution/RuntimeDependencies/ChakraCore.dll",
       "client/Data/Platform/Distribution/RuntimeDependencies/chrome_elf.dll",
       "client/Data/Platform/Distribution/RuntimeDependencies/d3dcompiler_47.dll",
+      "client/Data/Platform/Distribution/RuntimeDependencies/fmt.dll",
       "client/Data/Platform/Distribution/RuntimeDependencies/icudtl.dat",
       "client/Data/Platform/Distribution/RuntimeDependencies/libcef.dll",
       "client/Data/Platform/Distribution/RuntimeDependencies/libEGL.dll",
@@ -291,6 +294,7 @@
       "client/Data/Platform/Distribution/RuntimeDependencies/libGLESv2.dll",
       "client/Data/Platform/Distribution/RuntimeDependencies/SkyrimPlatformCEF.exe.hidden",
       "client/Data/Platform/Distribution/RuntimeDependencies/SkyrimPlatformImpl.dll",
+      "client/Data/Platform/Distribution/RuntimeDependencies/spdlog.dll",
       "client/Data/Platform/Distribution/RuntimeDependencies/snapshot_blob.bin",
       "client/Data/Platform/Distribution/RuntimeDependencies/v8_context_snapshot.bin",
       "client/Data/Platform/Distribution/___systemPolyfill.js",


### PR DESCRIPTION
This is a proof of concept that forces some libs to be built and linked as DLLs instead of static libraries

In the future SP could support running embedded skymp server. In this case we wouldn't want to double-distribute the same libraries twice in the binaries.

Same for our current binaries. There is some place for skymp bundle size optimizations.