### PR TITLE
perf(skyrim-platform): optimize settings API

### DIFF
--- a/docs/release/dev/sp-optimize-settings.md
+++ b/docs/release/dev/sp-optimize-settings.md
@@ -1,0 +1,1 @@
+Significantly optimized settings API.


### PR DESCRIPTION
```js

var sp = skyrimPlatform;

sp.on("tick", () => {
    var time = Date.now();
    for (var i = 0; i < 1000; i++) {
        var settings = sp.settings["skymp5-client"];
    }
    var timeNow = Date.now();
    sp.printConsole("time passed", timeNow - time);
});

```

This benchamark now shows time passed 2-3 instead of 30-50 before