### PR TITLE
feat(libespm): switch return type of GetDistinctRecordsByType to vector<LookupResult>

### DIFF
--- a/libespm/include/libespm/CombineBrowser.h
+++ b/libespm/include/libespm/CombineBrowser.h
@@ -27,8 +27,7 @@ public:
   std::vector<const std::vector<const RecordHeader*>*> GetRecordsByType(
     const char* type) const;
 
-  const std::vector<const RecordHeader*> GetDistinctRecordsByType(
-    const char* type) const;
+  std::vector<LookupResult> GetDistinctRecordsByType(const char* type) const;
 
   std::vector<const std::vector<const RecordHeader*>*> GetRecordsAtPos(
     uint32_t cellOrWorld, int16_t cellX, int16_t cellY) const;

--- a/libespm/src/CombineBrowser.cpp
+++ b/libespm/src/CombineBrowser.cpp
@@ -84,26 +84,25 @@ CombineBrowser::GetRecordsByType(const char* type) const
   return res;
 }
 
-const std::vector<const RecordHeader*>
-CombineBrowser::GetDistinctRecordsByType(const char* type) const
+std::vector<LookupResult> CombineBrowser::GetDistinctRecordsByType(
+  const char* type) const
 {
   if (pImpl->numSources == 0) {
     return {};
   }
 
   spp::sparse_hash_set<formId> formSet;
-  std::vector<const RecordHeader*> result;
+  std::vector<LookupResult> result;
   for (size_t i = pImpl->numSources - 1; i != static_cast<size_t>(-1); --i) {
     const auto& records = pImpl->sources[i].br->GetRecordsByType(type);
     formSet.reserve(records.size());
     result.reserve(records.size());
 
     for (auto record : records) {
-      if (formSet
-            .insert(
-              utils::GetMappedId(record->GetId(), *pImpl->sources[i].toComb))
-            .second) {
-        result.push_back(record);
+      auto mappedId =
+        utils::GetMappedId(record->GetId(), *pImpl->sources[i].toComb);
+      if (formSet.insert(mappedId).second) {
+        result.push_back(LookupResult(this, record, static_cast<uint8_t>(i)));
       }
     }
   }


### PR DESCRIPTION
Now we're able to extract global ids from records (`ToGlobalId(record->GetId()`) and record fields like FormLists, ObjectReferences with base object ids, etc