### PR TITLE
fix: improve setDisplayName security & optimize

### DIFF
--- a/skymp5-client/src/services/services/remoteServer.ts
+++ b/skymp5-client/src/services/services/remoteServer.ts
@@ -310,11 +310,8 @@ export class RemoteServer extends ClientListener {
 
               const replaceValue = refr.getBaseObject()?.getName();
 
-              if (replaceValue !== undefined && replaceValue !== "%original_name%") {
-                // SP doesn't support String.replaceAll because Chakracore doesn't
-                while (displayName.includes("%original_name%")) {
-                  displayName = displayName.replace("%original_name%", replaceValue);
-                }
+              if (replaceValue !== undefined) {
+                displayName = displayName.replace(/%original_name%/g, replaceValue);
               }
               else {
                 logError(this, "Couldn't get a replaceValue for SetDisplayName, refr.getFormID() was", refr.getFormID().toString(16));

--- a/skymp5-client/src/services/services/spSnippetService.ts
+++ b/skymp5-client/src/services/services/spSnippetService.ts
@@ -62,11 +62,8 @@ export class SpSnippetService extends ClientListener {
 
                     const replaceValue = self?.getBaseObject()?.getName();
 
-                    if (replaceValue !== undefined && replaceValue !== "%original_name%") {
-                        // SP doesn't support String.replaceAll because Chakracore doesn't
-                        while (newName.includes("%original_name%")) {
-                            newName = newName.replace("%original_name%", replaceValue);
-                        }
+                    if (replaceValue !== undefined) {
+                        newName = newName.replace(/%original_name%/g, replaceValue);
                         snippet.arguments[0] = newName;
                     }
                     else {

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -998,7 +998,8 @@ void MpObjectReference::SetNodeScale(const std::string& node, float scale,
   });
 }
 
-void MpObjectReference::SetDisplayName(const std::optional<std::string>& newName)
+void MpObjectReference::SetDisplayName(
+  const std::optional<std::string>& newName)
 {
   EditChangeForm(
     [&](MpChangeForm& changeForm) { changeForm.displayName = newName; });

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -998,7 +998,7 @@ void MpObjectReference::SetNodeScale(const std::string& node, float scale,
   });
 }
 
-void MpObjectReference::SetDisplayName(const std::string& newName)
+void MpObjectReference::SetDisplayName(const std::optional<std::string>& newName)
 {
   EditChangeForm(
     [&](MpChangeForm& changeForm) { changeForm.displayName = newName; });

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -150,7 +150,7 @@ public:
                          const espm::LookupResult& textureSet,
                          bool firstPerson);
   void SetNodeScale(const std::string& node, float scale, bool firstPerson);
-  void SetDisplayName(const std::string& newName);
+  void SetDisplayName(const std::optional<std::string>& newName);
 
   const std::set<MpObjectReference*>& GetListeners() const;
   const std::set<MpObjectReference*>& GetEmitters() const;

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -859,8 +859,7 @@ VarValue PapyrusObjectReference::SetDisplayName(
 
     if (!strcmp(displayName, kOriginalNameExpression)) {
       selfRefr->SetDisplayName(std::nullopt);
-    }
-    else {
+    } else {
       selfRefr->SetDisplayName(displayName);
     }
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -856,7 +856,13 @@ VarValue PapyrusObjectReference::SetDisplayName(
       throw std::runtime_error("SetDisplayName requires at least 2 arguments");
     }
     const char* displayName = static_cast<const char*>(arguments[0]);
-    selfRefr->SetDisplayName(displayName);
+
+    if (!strcmp(displayName, kOriginalNameExpression)) {
+      selfRefr->SetDisplayName(std::nullopt);
+    }
+    else {
+      selfRefr->SetDisplayName(displayName);
+    }
 
     bool force = static_cast<bool>(arguments[1]);
     std::ignore = force;

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.h
@@ -69,6 +69,8 @@ public:
   VarValue IsContainerEmpty(VarValue self,
                             const std::vector<VarValue>& arguments);
 
+  static constexpr auto kOriginalNameExpression = R"(%original_name%)";
+
   // %original_name% will be replaced with the original localized name
   // client-side
   VarValue SetDisplayName(VarValue self,


### PR DESCRIPTION
- malformed base object name like "%original_name%foo" won't freeze client anymore
- setDisplayName("%original_name%") will clear display name in the server/db resulting in less traffic and less setDisplayName calls