### PR TITLE
fix(skymp5-server): make MigrationDatabase::Upsert return 0 if terminate does nothing

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
@@ -114,6 +114,7 @@ size_t MigrationDatabase::Upsert(const std::vector<MpChangeForm>& changeForms)
 {
   spdlog::error("MigrationDatabase::Upsert - should never be reached");
   pImpl->terminate();
+  return 0;
 }
 
 void MigrationDatabase::Iterate(const IterateCallback& iterateCallback)


### PR DESCRIPTION
doesn't make much sense. however better fix warning so devs will not be annoyed 