### PR TITLE
internal: remove skymp5-client target dependency on skyrim-platform target

### DIFF
--- a/skymp5-client/CMakeLists.txt
+++ b/skymp5-client/CMakeLists.txt
@@ -22,8 +22,6 @@ add_custom_target(skymp5-client ALL
   SOURCES ${sources}
 )
 
-add_dependencies(skymp5-client skyrim-platform)
-
 add_custom_command(
   TARGET skymp5-client POST_BUILD
   COMMAND ${CMAKE_COMMAND} -DCLIENT_SETTINGS_JSON_PATH=${CMAKE_BINARY_DIR}/dist/client/Data/Platform/Plugins/skymp5-client-settings.txt -DOFFLINE_MODE=${OFFLINE_MODE} -P ${CMAKE_SOURCE_DIR}/cmake/scripts/generate_client_settings.cmake


### PR DESCRIPTION
since https://github.com/skyrim-multiplayer/skymp/pull/1831 building skyrimPlatform.ts is not required for skymp5-client build