### PR TITLE
refact(skymp5-client): avoid unnamed types in messages

### DIFF
--- a/skymp5-client/src/services/events/sendMessageWithRefrIdEvent.ts
+++ b/skymp5-client/src/services/events/sendMessageWithRefrIdEvent.ts
@@ -1,8 +1,9 @@
+import { RefrIdMessageBase } from "../messages/refrIdMessageBase";
 import { SendMessageEvent } from "./sendMessageEvent";
 
 // This was created for sending UpdateMovement and other updates for hosted NPCs
 // '_refrId' will be turned into 'idx' before sending to the server
 // In case of undefined '_refrId', we treat message as related to the local player, not an NPC
-export type MessageWithRefrId<Message> = Omit<Message, "idx"> & { _refrId: number | undefined };
+export type MessageWithRefrId<Message> = Omit<Message, "idx"> & RefrIdMessageBase;
 
 export type SendMessageWithRefrIdEvent<Message> = SendMessageEvent<MessageWithRefrId<Message>>;

--- a/skymp5-client/src/services/messages/activateMessage.ts
+++ b/skymp5-client/src/services/messages/activateMessage.ts
@@ -2,8 +2,10 @@ import { MsgType } from "../../messages";
 
 export interface ActivateMessage {
     t: MsgType.Activate,
-    data: {
-        caster: number,
-        target: number
-    }
+    data: ActivateMessageData
+}
+
+interface ActivateMessageData {
+    caster: number;
+    target: number;
 }

--- a/skymp5-client/src/services/messages/consoleCommandMessage.ts
+++ b/skymp5-client/src/services/messages/consoleCommandMessage.ts
@@ -1,9 +1,11 @@
 import { MsgType } from "../../messages";
 
-export interface ConsoleCommandMessage { 
-    t: MsgType.ConsoleCommand, 
-    data: { 
-        commandName: string, 
-        args: unknown[]
-    } 
+export interface ConsoleCommandMessage {
+    t: MsgType.ConsoleCommand,
+    data: ConsoleCommandMessageData
+}
+
+interface ConsoleCommandMessageData {
+    commandName: string;
+    args: unknown[];
 }

--- a/skymp5-client/src/services/messages/craftItemMessage.ts
+++ b/skymp5-client/src/services/messages/craftItemMessage.ts
@@ -3,9 +3,11 @@ import { MsgType } from "../../messages";
 
 export interface CraftItemMessage {
     t: MsgType.CraftItem,
-    data: { 
-        workbench: number, 
-        craftInputObjects: Inventory, 
-        resultObjectId: number
-    }
+    data: CraftItemMessageData
+}
+
+interface CraftItemMessageData {
+    workbench: number;
+    craftInputObjects: Inventory;
+    resultObjectId: number;
 }

--- a/skymp5-client/src/services/messages/customPacketMessage.ts
+++ b/skymp5-client/src/services/messages/customPacketMessage.ts
@@ -2,8 +2,10 @@ import { MsgType } from "../../messages";
 
 export interface CustomPacketMessage {
     t: MsgType.CustomPacket,
-    content: {
-        customPacketType: string,
-        gameData: Record<string, unknown>
-    }
+    content: CustomPacketMessageContent
+}
+
+interface CustomPacketMessageContent {
+    customPacketType: string,
+    gameData: Record<string, unknown>
 }

--- a/skymp5-client/src/services/messages/refrIdMessageBase.ts
+++ b/skymp5-client/src/services/messages/refrIdMessageBase.ts
@@ -1,0 +1,3 @@
+export interface RefrIdMessageBase {
+    _refrId: number | undefined;
+}

--- a/skymp5-client/src/services/services/consoleCommandsService.ts
+++ b/skymp5-client/src/services/services/consoleCommandsService.ts
@@ -44,7 +44,9 @@ export class ConsoleCommandsService extends ClientListener {
     }
 
     private setupVanilaCommands() {
+        logTrace(this, `Setting up vanila commands`);
         this.schemas.forEach((_, commandName) => {
+            logTrace(this, `Setting up command`, commandName);
             const command = this.sp.findConsoleCommand(commandName);
             if (command === null) {
                 logError(this, `command`, commandName, `was null in setupVanilaCommands`);
@@ -56,6 +58,7 @@ export class ConsoleCommandsService extends ClientListener {
             }
             command.execute = this.getCommandExecutor(commandName);
         });
+        logTrace(this, `Vanila commands set up`);
     }
 
     private getCommandExecutor(commandName: CmdName): (...args: unknown[]) => boolean {


### PR DESCRIPTION
to simplify parsing for tooling that expects `interface`