### PR TITLE
perf(skymp5-server): improve perf

### DIFF
--- a/skymp5-server/cpp/addon/property_bindings/ActorNeighborsBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/ActorNeighborsBinding.cpp
@@ -9,13 +9,11 @@ Napi::Value ActorNeighborsBinding::Get(Napi::Env env, ScampServer& scampServer,
 
   std::set<MpActor*> neighbors;
 
-  for (auto listener : refr.GetListeners()) {
-    if (auto actor = dynamic_cast<MpActor*>(listener)) {
-      neighbors.insert(actor);
-    }
+  for (auto listener : refr.GetActorListeners()) {
+    neighbors.insert(actor);
   }
   for (auto emitter : refr.GetEmitters()) {
-    if (auto actor = dynamic_cast<MpActor*>(emitter)) {
+    if (MpActor* actor = emitter->AsActor()) {
       neighbors.insert(actor);
     }
   }

--- a/skymp5-server/cpp/addon/property_bindings/ActorNeighborsBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/ActorNeighborsBinding.cpp
@@ -10,7 +10,7 @@ Napi::Value ActorNeighborsBinding::Get(Napi::Env env, ScampServer& scampServer,
   std::set<MpActor*> neighbors;
 
   for (auto listener : refr.GetActorListeners()) {
-    neighbors.insert(actor);
+    neighbors.insert(listener);
   }
   for (auto emitter : refr.GetEmitters()) {
     if (MpActor* actor = emitter->AsActor()) {

--- a/skymp5-server/cpp/addon/property_bindings/AppearanceBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/AppearanceBinding.cpp
@@ -44,12 +44,9 @@ void AppearanceBinding::Set(Napi::Env env, ScampServer& scampServer,
     { "t", MsgType::UpdateAppearance }
   }.dump();
 
-  for (auto listener : actor.GetListeners()) {
-    auto listenerActor = dynamic_cast<MpActor*>(listener);
-    if (listenerActor) {
-      // TODO: change to SendToUser
-      listenerActor->SendToUserDeferred(msg.data(), msg.size(), true,
-                                        kChannelAppearance, false);
-    }
+  for (auto listener : actor.GetActorListeners()) {
+    // TODO: change to SendToUser
+    listener->SendToUserDeferred(msg.data(), msg.size(), true,
+                                 kChannelAppearance, false);
   }
 }

--- a/skymp5-server/cpp/addon/property_bindings/IsOnlineBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/IsOnlineBinding.cpp
@@ -5,7 +5,7 @@ Napi::Value IsOnlineBinding::Get(Napi::Env env, ScampServer& scampServer,
 {
   auto& partOne = scampServer.GetPartOne();
   auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
-  if (auto actor = dynamic_cast<MpActor*>(&refr)) {
+  if (auto actor = refr.AsActor()) {
     auto userId = partOne->serverState.UserByActor(actor);
     if (userId != Networking::InvalidUserId) {
       return Napi::Boolean::New(env, true);

--- a/skymp5-server/cpp/addon/property_bindings/LocationalDataBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/LocationalDataBinding.cpp
@@ -49,7 +49,7 @@ void LocationalDataBinding::Set(Napi::Env, ScampServer& scampServer,
   locationalData.rot = NapiHelper::ExtractNiPoint3(
     newLocationalData.Get("rot"), "newLocationalData.rot");
 
-  if (auto actor = dynamic_cast<MpActor*>(&refr)) {
+  if (auto actor = refr.AsActor()) {
     Apply(*actor, locationalData);
   } else {
     throw std::runtime_error("mp.set can only change '" + GetPropertyName() +

--- a/skymp5-server/cpp/addon/property_bindings/PercentagesBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/PercentagesBinding.cpp
@@ -7,7 +7,7 @@ Napi::Value PercentagesBinding::Get(Napi::Env env, ScampServer& scampServer,
   auto& partOne = scampServer.GetPartOne();
 
   auto& actor = partOne->worldState.GetFormAt<MpActor>(formId);
-  auto actorValues = actor.GetChangeForm().actorValues;
+  auto& actorValues = actor.GetActorValues();
   auto percentages = Napi::Object::New(env);
   percentages.Set("health",
                   Napi::Number::New(env, actorValues.healthPercentage));
@@ -26,7 +26,7 @@ void PercentagesBinding::Set(Napi::Env env, ScampServer& scampServer,
   auto newPercentages = NapiHelper::ExtractObject(newValue, "newPercentages");
 
   auto& actor = partOne->worldState.GetFormAt<MpActor>(formId);
-  ActorValues actorValues = actor.GetChangeForm().actorValues;
+  ActorValues actorValues = actor.GetActorValues();
   actorValues.healthPercentage = NapiHelper::ExtractFloat(
     newPercentages.Get("health"), "newPercentages.health");
   actorValues.magickaPercentage = NapiHelper::ExtractFloat(

--- a/skymp5-server/cpp/addon/property_bindings/ProfileIdBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/ProfileIdBinding.cpp
@@ -9,9 +9,8 @@ Napi::Value ProfileIdBinding::Get(Napi::Env env, ScampServer& scampServer,
 
   auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
 
-  if (auto actor = dynamic_cast<MpActor*>(&refr)) {
-    auto chForm = actor->GetChangeForm();
-    return Napi::Number::New(env, chForm.profileId);
+  if (auto actor = refr.AsActor()) {
+    return Napi::Number::New(env, actor->GetProfileId());
   }
 
   return env.Undefined();

--- a/skymp5-server/cpp/addon/property_bindings/ProfileIdBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/ProfileIdBinding.cpp
@@ -25,7 +25,7 @@ void ProfileIdBinding::Set(Napi::Env env, ScampServer& scampServer,
   auto newProfileId = NapiHelper::ExtractUInt32(newValue, "newProfileId");
 
   auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
-  if (auto actor = dynamic_cast<MpActor*>(&refr)) {
+  if (auto actor = refr.AsActor()) {
     actor->RegisterProfileId(static_cast<int32_t>(newProfileId));
   }
 }

--- a/skymp5-server/cpp/addon/property_bindings/TemplateChainBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/TemplateChainBinding.cpp
@@ -7,14 +7,13 @@ Napi::Value TemplateChainBinding::Get(Napi::Env env, ScampServer& scampServer,
 
   auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
 
-  if (auto actor = dynamic_cast<MpActor*>(&refr)) {
-    auto chForm = actor->GetChangeForm();
+  if (auto actor = refr.AsActor()) {
+    auto& templateChain = actor->GetTemplateChain();
 
-    auto array = Napi::Array::New(env, chForm.templateChain.size());
+    auto array = Napi::Array::New(env, templateChain.size());
 
-    for (int i = 0; i < static_cast<int>(chForm.templateChain.size()); ++i) {
-      auto formId =
-        chForm.templateChain[i].ToFormId(partOne->worldState.espmFiles);
+    for (int i = 0; i < static_cast<int>(templateChain.size()); ++i) {
+      auto formId = templateChain[i].ToFormId(partOne->worldState.espmFiles);
       array.Set(i, Napi::Number::New(env, formId));
     }
 

--- a/skymp5-server/cpp/addon/property_bindings/TypeBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/TypeBinding.cpp
@@ -7,7 +7,7 @@ Napi::Value TypeBinding::Get(Napi::Env env, ScampServer& scampServer,
 
   auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
 
-  if (dynamic_cast<MpActor*>(&refr)) {
+  if (refr.AsActor()) {
     return Napi::String::New(env, "MpActor");
   } else {
     return Napi::String::New(env, "MpObjectReference");

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -653,7 +653,7 @@ void ActionListener::OnChangeValues(const RawMessageData& rawMsgData,
   float timeAfterRegeneration = CropPeriodAfterLastRegen(
     actor->GetDurationOfAttributesPercentagesUpdate(now).count());
 
-  const ActorValues& currentActorValues = actor->GetActorValues();
+  ActorValues currentActorValues = actor->GetActorValues();
   float health = newActorValues.healthPercentage;
   float magicka = newActorValues.magickaPercentage;
   float stamina = newActorValues.staminaPercentage;

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -653,7 +653,7 @@ void ActionListener::OnChangeValues(const RawMessageData& rawMsgData,
   float timeAfterRegeneration = CropPeriodAfterLastRegen(
     actor->GetDurationOfAttributesPercentagesUpdate(now).count());
 
-  ActorValues currentActorValues = actor->GetChangeForm().actorValues;
+  const ActorValues& currentActorValues = actor->GetActorValues();
   float health = newActorValues.healthPercentage;
   float magicka = newActorValues.magickaPercentage;
   float stamina = newActorValues.staminaPercentage;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -751,6 +751,11 @@ const ActorValues& MpActor::GetActorValues() const
   return ChangeForm().actorValues;
 }
 
+int32_t MpActor::GetProfileId() const
+{
+  return ChangeForm().profileId;
+}
+
 void MpActor::SendAndSetDeathState(bool isDead, bool shouldTeleport)
 {
   spdlog::trace(

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -746,6 +746,11 @@ bool MpActor::IsCreatedAsPlayer() const
   return GetFormId() >= 0xff000000 && GetBaseId() <= 0x7;
 }
 
+const ActorValues& MpActor::GetActorValues() const
+{
+  return ChangeForm().actorValues;
+}
+
 void MpActor::SendAndSetDeathState(bool isDead, bool shouldTeleport)
 {
   spdlog::trace(

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -173,15 +173,11 @@ void MpActor::EquipBestWeapon()
   }
 
   SetEquipment(newEq.ToJson().dump());
-  for (auto listener : GetListeners()) {
-    auto actor = dynamic_cast<MpActor*>(listener);
-    if (!actor) {
-      continue;
-    }
+  for (auto listener : GetActorListeners()) {
     UpdateEquipmentMessage msg;
     msg.data = newEq.ToJson();
     msg.idx = GetIdx();
-    actor->SendToUser(msg, true);
+    listener->SendToUser(msg, true);
   }
 }
 
@@ -434,7 +430,7 @@ bool MpActor::OnEquip(uint32_t baseId)
   }
 
   const bool hasItem = isSpell
-    ? GetChangeForm().learnedSpells.IsSpellLearned(baseId)
+    ? ChangeForm().learnedSpells.IsSpellLearned(baseId)
     : GetInventory().GetItemCount(baseId) > 0;
 
   if (!hasItem) {
@@ -453,11 +449,10 @@ bool MpActor::OnEquip(uint32_t baseId)
     j.push_back(false);
 
     std::string serializedArgs = j.dump();
-    for (auto listener : GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr && targetRefr != this) {
+    for (auto listener : GetActorListeners()) {
+      if (listener != this) {
         SpSnippet("Actor", "EquipItem", serializedArgs.data(), GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
+          .Execute(listener, SpSnippetMode::kNoReturnResult);
       }
     }
   } else if (isBook) {

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -40,6 +40,7 @@ public:
   const std::vector<FormDesc>& GetTemplateChain() const;
   bool IsCreatedAsPlayer() const;
   const ActorValues &GetActorValues() const;
+  int32_t GetProfileId() const;
 
   bool ShouldSkipRestoration() const noexcept;
   void UpdateNextRestorationTime(std::chrono::seconds duration) noexcept;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -39,7 +39,7 @@ public:
   espm::ObjectBounds GetBounds() const;
   const std::vector<FormDesc>& GetTemplateChain() const;
   bool IsCreatedAsPlayer() const;
-  const& ActorValues GetActorValues() const;
+  const ActorValues &GetActorValues() const;
 
   bool ShouldSkipRestoration() const noexcept;
   void UpdateNextRestorationTime(std::chrono::seconds duration) noexcept;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -39,6 +39,7 @@ public:
   espm::ObjectBounds GetBounds() const;
   const std::vector<FormDesc>& GetTemplateChain() const;
   bool IsCreatedAsPlayer() const;
+  const& ActorValues GetActorValues() const;
 
   bool ShouldSkipRestoration() const noexcept;
   void UpdateNextRestorationTime(std::chrono::seconds duration) noexcept;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -39,7 +39,7 @@ public:
   espm::ObjectBounds GetBounds() const;
   const std::vector<FormDesc>& GetTemplateChain() const;
   bool IsCreatedAsPlayer() const;
-  const ActorValues &GetActorValues() const;
+  const ActorValues& GetActorValues() const;
   int32_t GetProfileId() const;
 
   bool ShouldSkipRestoration() const noexcept;

--- a/skymp5-server/cpp/server_guest_lib/MpForm.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpForm.cpp
@@ -9,6 +9,11 @@ MpForm::MpForm()
 {
 }
 
+MpObjectReference* MpForm::AsObjectReference() const noexcept
+{
+  return asObjectReference;
+}
+
 MpActor* MpForm::AsActor() const noexcept
 {
   return asActor;

--- a/skymp5-server/cpp/server_guest_lib/MpForm.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpForm.cpp
@@ -79,7 +79,7 @@ bool MpForm::IsEspmForm() const noexcept
 
 float MpForm::GetWeight() const
 {
-  const auto* objectReference = dynamic_cast<const MpObjectReference*>(this);
+  auto objectReference = AsObjectReference();
   if (!objectReference) {
     return 0.f;
   }
@@ -88,7 +88,7 @@ float MpForm::GetWeight() const
   const auto& espm = GetParent()->GetEspm();
   const auto* record = espm.GetBrowser().LookupById(baseId).rec;
   if (!record) {
-    spdlog::trace("Record of form ({}) is nullptr", baseId);
+    spdlog::warn("MpForm::GetWeight - Record of form ({}) is nullptr", baseId);
     return 0.f;
   }
 

--- a/skymp5-server/cpp/server_guest_lib/MpForm.h
+++ b/skymp5-server/cpp/server_guest_lib/MpForm.h
@@ -10,6 +10,7 @@ class WorldState;
 class IGameObject;
 class ActivePexInstance;
 struct VarValue;
+class MpObjectReference;
 class MpActor;
 
 class MpForm
@@ -21,6 +22,7 @@ public:
   MpForm();
 
   // Fast dynamic_cast replacement
+  MpObjectReference* AsObjectReference() const noexcept;
   MpActor* AsActor() const noexcept;
 
   static const char* Type() { return "Form"; }
@@ -87,5 +89,6 @@ protected:
 
   void AddScript(const std::shared_ptr<ActivePexInstance>& script) noexcept;
 
+  MpObjectReference* asObjectReference = nullptr;
   MpActor* asActor = nullptr;
 };

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -173,6 +173,7 @@ MpObjectReference::MpObjectReference(
   , ChangeFormGuard(MakeChangeForm(locationalData_), this)
 {
   pImpl.reset(new Impl);
+  asObjectReference = this;
 
   if (primitiveBoundsDiv2)
     SetPrimitive(*primitiveBoundsDiv2);
@@ -471,8 +472,8 @@ void MpObjectReference::SetPos(const NiPoint3& newPos, SetPosMode setPosMode)
 
       for (auto& [emitterId, wasInside] : *emittersWithPrimitives) {
         auto& emitter = GetParent()->LookupFormById(emitterId);
-        auto emitterRefr =
-          std::dynamic_pointer_cast<MpObjectReference>(emitter);
+        MpObjectReference* emitterRefr =
+          emitter ? emitter->AsObjectReference() : nullptr;
         if (!emitterRefr) {
           GetParent()->logger->error("Emitter not found ({0:x})", emitterId);
           continue;
@@ -491,10 +492,9 @@ void MpObjectReference::SetPos(const NiPoint3& newPos, SetPosMode setPosMode)
                 wst->logger->error("Refr pointer expired", id);
                 return;
               }
-
               auto& emitter = wst->LookupFormById(id);
-              auto emitterRefr =
-                std::dynamic_pointer_cast<MpObjectReference>(emitter);
+              MpObjectReference* emitterRefr =
+                emitter ? emitter->AsObjectReference() : nullptr;
               if (!emitterRefr) {
                 wst->logger->error("Emitter not found in timer ({0:x})", id);
                 return;

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -1046,7 +1046,7 @@ std::optional<std::chrono::system_clock::duration> WorldState::GetRelootTime(
   if (it == pImpl->relootTimeForTypes.end()) {
     return std::nullopt;
   }
-  return it->second;
+  return it->time;
 }
 
 bool WorldState::HasKeyword(uint32_t baseId, const char* keyword)

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -246,7 +246,7 @@ void WorldState::RequestReloot(MpObjectReference& ref,
   for (auto& entry : pImpl->relootTimeForTypes) {
     auto diff = entry.time - time;
     if (diff < kEpsilon && diff > -kEpsilon) {
-      timer = entry.timer.SetTimer(time);
+      timer = entry.timer.SetTimer(time, nullptr);
       break;
     }
   }
@@ -1021,11 +1021,11 @@ uint32_t WorldState::GenerateFormId()
 void WorldState::SetRelootTime(const std::string& recordType,
                                std::chrono::system_clock::duration time)
 {
-
-  auto it = pImpl->relootTimeForTypes.find_if(
-    [&recordType](const RelootTimeForTypesEntry& entry) {
-      return entry.recordType == recordType;
-    });
+  auto it = std::find_if(pImpl->relootTimeForTypes.begin(),
+                         pImpl->relootTimeForTypes.end(),
+                         [&recordType](const RelootTimeForTypesEntry& entry) {
+                           return entry.recordType == recordType;
+                         });
 
   if (it != pImpl->relootTimeForTypes.end()) {
     it->time = time;
@@ -1037,10 +1037,11 @@ void WorldState::SetRelootTime(const std::string& recordType,
 std::optional<std::chrono::system_clock::duration> WorldState::GetRelootTime(
   const std::string& recordType) const
 {
-  auto it = pImpl->relootTimeForTypes.find_if(
-    [&recordType](const RelootTimeForTypesEntry& entry) {
-      return entry.recordType == recordType;
-    });
+  auto it = std::find_if(pImpl->relootTimeForTypes.begin(),
+                         pImpl->relootTimeForTypes.end(),
+                         [&recordType](const RelootTimeForTypesEntry& entry) {
+                           return entry.recordType == recordType;
+                         });
 
   if (it == pImpl->relootTimeForTypes.end()) {
     return std::nullopt;

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -23,6 +23,17 @@
 #include <optional>
 #include <unordered_map>
 
+namespace {
+
+struct RelootTimeForTypesEntry
+{
+  std::string recordType;
+  std::chrono::system_clock::duration time;
+
+  Viet::Timer timer;
+};
+}
+
 struct WorldState::Impl
 {
   std::vector<std::optional<MpChangeForm>> changesByIdx;
@@ -36,8 +47,7 @@ struct WorldState::Impl
   std::unordered_map<uint32_t, MpChangeForm> changeFormsForDeferredLoad;
   bool chunkLoadingInProgress = false;
   bool formLoadingInProgress = false;
-  std::map<std::string, std::chrono::system_clock::duration>
-    relootTimeForTypes;
+  std::vector<RelootTimeForTypesEntry> relootTimeForTypes;
   std::set<std::string> forbiddenRelootTypes;
   std::vector<std::unique_ptr<IPapyrusClassBase>> classes;
 };
@@ -120,7 +130,6 @@ void WorldState::AddForm(std::unique_ptr<MpForm> form, uint32_t formId,
 void WorldState::Tick()
 {
   const auto now = std::chrono::system_clock::now();
-  TickReloot(now);
   TickSaveStorage(now);
   TickTimers(now);
 }
@@ -228,8 +237,33 @@ void WorldState::LoadChangeForm(const MpChangeForm& changeForm,
 void WorldState::RequestReloot(MpObjectReference& ref,
                                std::chrono::system_clock::duration time)
 {
-  auto& list = relootTimers[time];
-  list.push_back({ ref.GetFormId(), std::chrono::system_clock::now() + time });
+  auto refPtr = &ref;
+
+  std::optional<Viet::Promise<Viet::Void>> timer;
+
+  constexpr auto kEpsilon = std::chrono::milliseconds(1);
+
+  for (auto& entry : pImpl->relootTimeForTypes) {
+    auto diff = entry.time - time;
+    if (diff < kEpsilon && diff > -kEpsilon) {
+      timer = entry.timer.SetTimer(time);
+      break;
+    }
+  }
+
+  if (timer == std::nullopt) {
+    timer = SetTimer(time);
+  }
+
+  timer->Then([this, refPtr, formId = ref.GetFormId()]() {
+    auto& form = LookupFormById(formId);
+    auto reference = form->AsObjectReference();
+    // Check if the reference is still the same, not re-created with the same
+    // id for example
+    if (reference && reference == refPtr) {
+      reference->DoReloot();
+    }
+  });
 }
 
 void WorldState::RequestSave(MpObjectReference& ref)
@@ -635,36 +669,6 @@ bool WorldState::LoadForm(uint32_t formId, std::stringstream* optionalOutTrace)
   return attached;
 }
 
-void WorldState::TickReloot(const std::chrono::system_clock::time_point& now)
-{
-  std::vector<decltype(relootTimers.begin())> toErase;
-
-  for (auto it = relootTimers.begin(); it != relootTimers.end(); ++it) {
-    auto& list = it->second;
-    while (!list.empty() && list.begin()->second <= now) {
-      uint32_t relootTargetId = list.begin()->first;
-
-      const std::shared_ptr<MpForm>& relootTargetForm =
-        LookupFormById(relootTargetId);
-
-      MpObjectReference* relootTarget =
-        relootTargetForm ? relootTargetForm->AsObjectReference() : nullptr;
-
-      if (relootTarget) {
-        relootTarget->DoReloot();
-      }
-      list.pop_front();
-    }
-    if (list.empty()) {
-      toErase.push_back(it);
-    }
-  }
-
-  for (auto& it : toErase) {
-    relootTimers.erase(it);
-  }
-}
-
 void WorldState::TickSaveStorage(const std::chrono::system_clock::time_point&)
 {
   if (!pImpl->saveStorage) {
@@ -748,6 +752,10 @@ void WorldState::TickTimers(const std::chrono::system_clock::time_point&)
 {
   timerEffects.TickTimers();
   timerRegular.TickTimers();
+
+  for (auto& entry : pImpl->relootTimeForTypes) {
+    entry.timer.TickTimers();
+  }
 }
 
 void WorldState::SendPapyrusEvent(MpForm* form, const char* eventName,
@@ -1010,16 +1018,30 @@ uint32_t WorldState::GenerateFormId()
   return pImpl->nextId++;
 }
 
-void WorldState::SetRelootTime(std::string recordType,
-                               std::chrono::system_clock::duration dur)
+void WorldState::SetRelootTime(const std::string& recordType,
+                               std::chrono::system_clock::duration time)
 {
-  pImpl->relootTimeForTypes[recordType] = dur;
+
+  auto it = pImpl->relootTimeForTypes.find_if(
+    [&recordType](const RelootTimeForTypesEntry& entry) {
+      return entry.recordType == recordType;
+    });
+
+  if (it != pImpl->relootTimeForTypes.end()) {
+    it->time = time;
+  } else {
+    pImpl->relootTimeForTypes.push_back({ recordType, time });
+  }
 }
 
 std::optional<std::chrono::system_clock::duration> WorldState::GetRelootTime(
-  std::string recordType) const
+  const std::string& recordType) const
 {
-  auto it = pImpl->relootTimeForTypes.find(recordType);
+  auto it = pImpl->relootTimeForTypes.find_if(
+    [&recordType](const RelootTimeForTypesEntry& entry) {
+      return entry.recordType == recordType;
+    });
+
   if (it == pImpl->relootTimeForTypes.end()) {
     return std::nullopt;
   }

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -255,7 +255,7 @@ void WorldState::RequestReloot(MpObjectReference& ref,
     timer = SetTimer(time);
   }
 
-  timer->Then([this, refPtr, formId = ref.GetFormId()]() {
+  timer->Then([this, refPtr, formId = ref.GetFormId()](Viet::Void) {
     auto& form = LookupFormById(formId);
     auto reference = form->AsObjectReference();
     // Check if the reference is still the same, not re-created with the same

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -213,10 +213,10 @@ public:
     const std::string& propertyName,
     const std::string& propertyValueStringified);
   uint32_t GenerateFormId();
-  void SetRelootTime(std::string recordType,
-                     std::chrono::system_clock::duration dur);
+  void SetRelootTime(const std::string& recordType,
+                     std::chrono::system_clock::duration time);
   std::optional<std::chrono::system_clock::duration> GetRelootTime(
-    std::string recordType) const;
+    const std::string& recordType) const;
 
   // Utility function to check if the provided baseId has the certain keyword
   bool HasKeyword(uint32_t baseId, const char* keyword);
@@ -272,7 +272,6 @@ private:
 
   bool LoadForm(uint32_t formId,
                 std::stringstream* optionalOutTrace = nullptr);
-  void TickReloot(const std::chrono::system_clock::time_point& now);
   void TickSaveStorage(const std::chrono::system_clock::time_point& now);
   void TickTimers(const std::chrono::system_clock::time_point& now);
   [[nodiscard]] bool NpcSourceFilesOverriden() const noexcept;
@@ -293,10 +292,6 @@ private:
   spp::sparse_hash_map<uint32_t, GridInfo> grids;
   std::unique_ptr<MakeID> formIdxManager;
   std::vector<MpForm*> formByIdxUnreliable;
-  std::map<
-    std::chrono::system_clock::duration,
-    std::list<std::pair<uint32_t, std::chrono::system_clock::time_point>>>
-    relootTimers;
   espm::Loader* espm = nullptr;
   FormCallbacksFactory formCallbacksFactory;
   std::unique_ptr<espm::CompressedFieldsCache> espmCache;

--- a/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.cpp
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.cpp
@@ -119,7 +119,9 @@ void AsyncSaveStorage::Upsert(
   const UpsertCallback& cb)
 {
   std::lock_guard l(pImpl->share3.m);
-  pImpl->share3.upsertTasks.push_back({ changeForms, cb });
+  pImpl->share3.upsertTasks.push_back(AsyncSaveStorage::Impl::UpsertTask());
+  pImpl->share3.upsertTasks.back().changeForms = std::move(changeForms);
+  pImpl->share3.upsertTasks.back().callback = cb;
 }
 
 uint32_t AsyncSaveStorage::GetNumFinishedUpserts() const

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
@@ -167,13 +167,10 @@ VarValue PapyrusActor::SetAlpha(VarValue self,
     // neigbours by sending papyrus functions to them.
     auto funcName = "SetAlpha";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
   return VarValue::None();

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusEffectShader.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusEffectShader.cpp
@@ -29,23 +29,18 @@ void PapyrusEffectShader::Helper(VarValue& self, const char* funcName,
                                " requires at least one argument");
     }
     if (auto actorForm = GetFormPtr<MpObjectReference>(arguments[0])) {
-      for (auto listener : actorForm->GetListeners()) {
-        auto targetRefr = dynamic_cast<MpActor*>(listener);
-        if (targetRefr) {
-          SpSnippet(
-            GetName(), funcName,
-            SpSnippetFunctionGen::SerializeArguments(arguments, targetRefr)
-              .data(),
-            selfRec.ToGlobalId(selfRec.rec->GetId()))
-            .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-          // Workaround to use this function on player clone
-          if (actorForm->GetFormId() == targetRefr->GetFormId()) {
-            SpSnippet(
-              GetName(), funcName,
-              SpSnippetFunctionGen::SerializeArguments(arguments).data(),
-              selfRec.ToGlobalId(selfRec.rec->GetId()))
-              .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-          }
+      for (auto listener : actorForm->GetActorListeners()) {
+        SpSnippet(
+          GetName(), funcName,
+          SpSnippetFunctionGen::SerializeArguments(arguments, listener).data(),
+          selfRec.ToGlobalId(selfRec.rec->GetId()))
+          .Execute(listener, SpSnippetMode::kNoReturnResult);
+        // Workaround to use this function on player clone
+        if (actorForm->GetFormId() == listener->GetFormId()) {
+          SpSnippet(GetName(), funcName,
+                    SpSnippetFunctionGen::SerializeArguments(arguments).data(),
+                    selfRec.ToGlobalId(selfRec.rec->GetId()))
+            .Execute(listener, SpSnippetMode::kNoReturnResult);
         }
       }
     }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusForm.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusForm.cpp
@@ -40,11 +40,11 @@ VarValue PapyrusForm::GetType(VarValue self, const std::vector<VarValue>&)
   }
 
   if (auto form = GetFormPtr<MpForm>(self)) {
-    if (dynamic_cast<MpActor*>(form)) {
+    if (form->AsActor()) {
       constexpr auto kCharacter = 62;
       return VarValue(static_cast<int32_t>(kCharacter));
     }
-    if (dynamic_cast<MpObjectReference*>(form)) {
+    if (form->AsObjectReference()) {
       constexpr auto kReference = 61;
       return VarValue(static_cast<int32_t>(kReference));
     }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -163,7 +163,7 @@ VarValue PapyrusObjectReference::AddItem(
 
   if (runSkympHacks) {
     if (!silent && count > 0) {
-      if (auto actor = dynamic_cast<MpActor*>(selfRefr)) {
+      if (auto actor = selfRefr->AsActor()) {
         auto args = SpSnippetFunctionGen::SerializeArguments(arguments);
         (void)SpSnippet("SkympHacks", "AddItem", args.data())
           .Execute(actor, SpSnippetMode::kNoReturnResult);
@@ -256,7 +256,7 @@ VarValue PapyrusObjectReference::RemoveItem(
 
   if (runSkympHacks) {
     if (!silent && count > 0) {
-      if (auto actor = dynamic_cast<MpActor*>(selfRefr)) {
+      if (auto actor = selfRefr->AsActor()) {
         auto args = SpSnippetFunctionGen::SerializeArguments(arguments);
         (void)SpSnippet("SkympHacks", "RemoveItem", args.data())
           .Execute(actor, SpSnippetMode::kNoReturnResult);
@@ -319,13 +319,10 @@ void PlaceAtMeSpSnippet(MpObjectReference* self,
 {
   auto funcName = "PlaceAtMe";
   auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-  for (auto listener : self->GetListeners()) {
-    auto targetRefr = dynamic_cast<MpActor*>(listener);
-    if (targetRefr) {
-      SpSnippet("ObjectReference", funcName, serializedArgs.data(),
-                self->GetFormId())
-        .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-    }
+  for (auto listener : self->GetActorListeners()) {
+    SpSnippet("ObjectReference", funcName, serializedArgs.data(),
+              self->GetFormId())
+      .Execute(listener, SpSnippetMode::kNoReturnResult);
   }
 }
 }
@@ -414,16 +411,13 @@ VarValue PapyrusObjectReference::Enable(VarValue self,
     selfRefr->Enable();
   }
 
-  if (selfRefr->IsEspmForm() && !dynamic_cast<MpActor*>(selfRefr)) {
+  if (selfRefr->IsEspmForm() && !selfRefr->AsActor()) {
     auto funcName = "Enable";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
 
@@ -438,16 +432,13 @@ VarValue PapyrusObjectReference::Disable(
     selfRefr->Disable();
   }
 
-  if (selfRefr->IsEspmForm() && !dynamic_cast<MpActor*>(selfRefr)) {
+  if (selfRefr->IsEspmForm() && !selfRefr->AsActor()) {
     auto funcName = "Disable";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
     for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
 
@@ -554,13 +545,10 @@ VarValue PapyrusObjectReference::SetPosition(
     selfRefr->ForceSubscriptionsUpdate();
     auto funcName = "SetPosition";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
   return VarValue::None();
@@ -596,13 +584,10 @@ VarValue PapyrusObjectReference::PlayAnimation(
 
     auto funcName = "PlayAnimation";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
   return VarValue::None();
@@ -624,14 +609,11 @@ VarValue PapyrusObjectReference::PlayAnimationAndWait(
 
     std::vector<Viet::Promise<VarValue>> promises;
 
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        auto promise = SpSnippet(GetName(), funcName, serializedArgs.data(),
-                                 selfRefr->GetFormId())
-                         .Execute(targetRefr, SpSnippetMode::kReturnResult);
-        promises.push_back(promise);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      auto promise = SpSnippet(GetName(), funcName, serializedArgs.data(),
+                               selfRefr->GetFormId())
+                       .Execute(listener, SpSnippetMode::kReturnResult);
+      promises.push_back(promise);
     }
 
     if (promises.empty()) {
@@ -666,13 +648,10 @@ VarValue PapyrusObjectReference::PlayGamebryoAnimation(
     }
     auto funcName = "PlayGamebryoAnimation";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
   return VarValue::None();
@@ -871,13 +850,10 @@ VarValue PapyrusObjectReference::SetDisplayName(
 
     auto funcName = "SetDisplayName";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
-      auto targetRefr = dynamic_cast<MpActor*>(listener);
-      if (targetRefr) {
-        SpSnippet(GetName(), funcName, serializedArgs.data(),
-                  selfRefr->GetFormId())
-          .Execute(targetRefr, SpSnippetMode::kNoReturnResult);
-      }
+    for (auto listener : selfRefr->GetActorListeners()) {
+      SpSnippet(GetName(), funcName, serializedArgs.data(),
+                selfRefr->GetFormId())
+        .Execute(listener, SpSnippetMode::kNoReturnResult);
     }
   }
   return VarValue::None();

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -435,7 +435,7 @@ VarValue PapyrusObjectReference::Disable(
   if (selfRefr->IsEspmForm() && !selfRefr->AsActor()) {
     auto funcName = "Disable";
     auto serializedArgs = SpSnippetFunctionGen::SerializeArguments(arguments);
-    for (auto listener : selfRefr->GetListeners()) {
+    for (auto listener : selfRefr->GetActorListeners()) {
       SpSnippet(GetName(), funcName, serializedArgs.data(),
                 selfRefr->GetFormId())
         .Execute(listener, SpSnippetMode::kNoReturnResult);

--- a/skymp5-server/cpp/server_guest_lib/script_compatibility_policies/HeuristicPolicy.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_compatibility_policies/HeuristicPolicy.cpp
@@ -59,7 +59,7 @@ void HeuristicPolicy::BeforeSendPapyrusEvent(MpForm* form,
   } else if (!Utils::stricmp(eventName, "OnObjectEquipped") ||
              !Utils::stricmp(eventName, "OnInit") ||
              !Utils::stricmp(eventName, "OnUpdate")) {
-    actor = dynamic_cast<MpActor*>(form);
+    actor = form->AsActor();
   } else if ((!Utils::stricmp(eventName, "OnTriggerEnter") ||
               !Utils::stricmp(eventName, "OnTriggerLeave") ||
               !Utils::stricmp(eventName, "OnTrigger")) &&


### PR DESCRIPTION
- optimize out copy in AsyncSaveStorage
- get rid of dynamic_cast
- get rid of GetChangeForm
- optimize reloot timers
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4e40b550e4ab9d54bec92a665639a96905d31103  | 
|--------|--------|

### Summary:
This pull request optimizes performance in `skymp5-server` by replacing `dynamic_cast` with `AsActor()`, using direct accessors, and restructuring reloot timers.

**Key points**:
- Replaced `dynamic_cast` with `AsActor()` in multiple files for performance improvement.
- Replaced `GetChangeForm` with direct accessors like `GetActorValues()` in `PercentagesBinding.cpp` and others.
- Optimized reloot timers by restructuring timer management in `WorldState.cpp`.
- Removed redundant function calls and improved type checks across the codebase.
- Changes affect files like `ActorNeighborsBinding.cpp`, `AppearanceBinding.cpp`, `IsOnlineBinding.cpp`, and more.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->