### PR TITLE
fix(skymp5-client): fix queryKeyCodeBindings logic

### DIFF
--- a/skymp5-client/src/services/services/keyboardEventsService.ts
+++ b/skymp5-client/src/services/services/keyboardEventsService.ts
@@ -14,16 +14,16 @@ export class KeyboardEventsService extends ClientListener {
 
         if (this.lastNumKeys !== numKeys) {
             this.lastNumKeys = numKeys;
-        }
 
-        this.controller.emitter.emit("queryKeyCodeBindings", {
-            isDown: (binding: DxScanCode[]) => {
-                if (binding.every((key) => this.sp.Input.isKeyPressed(key))) {
-                    return true;
+            this.controller.emitter.emit("queryKeyCodeBindings", {
+                isDown: (binding: DxScanCode[]) => {
+                    if (binding.every((key) => this.sp.Input.isKeyPressed(key))) {
+                        return true;
+                    }
+                    return false;
                 }
-                return false;
-            }
-        });
+            });
+        }
     }
 
     private lastNumKeys = 0;


### PR DESCRIPTION
@ellipsis-dev please review
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0c8ffe123f90d9210bf31f6d12319f5c5bfe6104  | 
|--------|--------|

### Summary:
Fixes `queryKeyCodeBindings` logic in `KeyboardEventsService` to emit only when the number of keys pressed changes.

**Key points**:
- Fixes `queryKeyCodeBindings` logic in `skymp5-client/src/services/services/keyboardEventsService.ts`.
- Moves `emit` call inside the `if` block to prevent unnecessary emissions.
- Ensures `queryKeyCodeBindings` is emitted only when `numKeys` changes.
- Retains logic for checking if all keys in a binding are pressed.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->