### PR TITLE
feat(skymp5-server): experimentally expose spawnAllowed listener

### DIFF
--- a/skymp5-server/ts/systems/spawn.ts
+++ b/skymp5-server/ts/systems/spawn.ts
@@ -10,11 +10,11 @@ function randomInteger(min: number, max: number) {
 
 export class Spawn implements System {
   systemName = "Spawn";
-  constructor(private log: Log) {}
+  constructor(private log: Log) { }
 
   async initAsync(ctx: SystemContext): Promise<void> {
     const settingsObject = await Settings.get();
-    ctx.gm.on("spawnAllowed", (userId: number, userProfileId: number, discordRoleIds: string[], discordId: string | undefined) => {
+    const listenerFn = (userId: number, userProfileId: number, discordRoleIds: string[], discordId: string | undefined) => {
       const { startPoints } = settingsObject;
       // TODO: Show race menu if character is not created after relogging
       let actorId = ctx.svr.getActorsByProfileId(userProfileId)[0];
@@ -48,7 +48,9 @@ export class Spawn implements System {
         const forms = mp.findFormsByPropertyValue("private.indexed.discordId", discordId) as number[];
         console.log(`Found forms ${forms}`);
       }
-    });
+    };
+    ctx.gm.on("spawnAllowed", listenerFn);
+    (ctx.svr as any)._onSpawnAllowed = listenerFn;
   }
 
   disconnect(userId: number, ctx: SystemContext): void {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 71c49111c03f14303633f14a711b0aa8e8fe96c7  | 
|--------|--------|

### Summary:
Refactored `spawnAllowed` event listener in `skymp5-server/ts/systems/spawn.ts` to use a variable and added `_onSpawnAllowed` property for external access.

**Key points**:
- Refactored `spawnAllowed` event listener in `skymp5-server/ts/systems/spawn.ts`.
- Assigned listener function to `listenerFn` variable.
- Added `_onSpawnAllowed` property to `ctx.svr` for listener function access.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->