### PR TITLE
fix(skymp5-server): fix endless FURN enter loop

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -170,6 +170,9 @@ void PartOne::SetUserActor(Networking::UserId userId, uint32_t actorFormId)
       actor.RespawnWithDelay();
     }
 
+    // This is not currently saved client-side, so reset
+    actor.SetLastAnimEvent(std::nullopt);
+
   } else {
     serverState.actorsMap.Erase(userId);
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f87fb0d402b7bca44434198115a72290e05e592c  | 
|--------|--------|

### Summary:
Fixes endless FURN enter loop in `MpObjectReference::ProcessActivate` and resets last animation event in `PartOne::SetUserActor`.

**Key points**:
- Fixes endless loop when entering FURN objects in `MpObjectReference::ProcessActivate`.
- Adds checks for occupant's position, cell/world, and disabled state before setting occupant.
- Resets last animation event in `PartOne::SetUserActor` to handle client-side state.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->