### PR TITLE
perf(skymp5-server): optimize CropRegeneration

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/CropRegeneration.cpp
+++ b/skymp5-server/cpp/server_guest_lib/CropRegeneration.cpp
@@ -68,14 +68,13 @@ float CropRegeneration(float newAttributeValue, float secondsAfterLastRegen,
 float CropHealthRegeneration(float newAttributeValue,
                              float secondsAfterLastRegen, MpActor* actor)
 {
-  MpChangeForm changeForm = actor->GetChangeForm();
   const BaseActorValues baseValues = GetValues(actor);
-  const ActorValues& actorValues = actor->GetChangeForm().actorValues;
+  const ActorValues& actorValues = actor->GetActorValues();
   const float rate = std::max(baseValues.healRate, actorValues.healRate);
   const float rateMult =
     std::max(baseValues.healRateMult, actorValues.healRateMult);
   const float oldPercentage = actorValues.healthPercentage;
-  const bool hasActiveMagicEffects = !changeForm.activeMagicEffects.Empty();
+  const bool hasActiveMagicEffects = !actor->GetActiveMagicEffects().Empty();
   return CropRegeneration(newAttributeValue, secondsAfterLastRegen, rate,
                           rateMult, oldPercentage, hasActiveMagicEffects);
 }
@@ -83,14 +82,13 @@ float CropHealthRegeneration(float newAttributeValue,
 float CropMagickaRegeneration(float newAttributeValue,
                               float secondsAfterLastRegen, MpActor* actor)
 {
-  MpChangeForm changeForm = actor->GetChangeForm();
   const BaseActorValues baseValues = GetValues(actor);
-  const ActorValues& actorValues = changeForm.actorValues;
+  const ActorValues& actorValues = actor->GetActorValues();
   const float rate = std::max(baseValues.magickaRate, actorValues.magickaRate);
   const float rateMult =
     std::max(baseValues.magickaRateMult, actorValues.magickaRateMult);
   const float oldPercentage = actorValues.magickaPercentage;
-  const bool hasActiveMagicEffects = !changeForm.activeMagicEffects.Empty();
+  const bool hasActiveMagicEffects = !actor->GetActiveMagicEffects().Empty();
   return CropRegeneration(newAttributeValue, secondsAfterLastRegen, rate,
                           rateMult, oldPercentage, hasActiveMagicEffects);
 }
@@ -98,16 +96,15 @@ float CropMagickaRegeneration(float newAttributeValue,
 float CropStaminaRegeneration(float newAttributeValue,
                               float secondsAfterLastRegen, MpActor* actor)
 {
-  const MpChangeForm changeForm = actor->GetChangeForm();
   const BaseActorValues baseValues = GetValues(actor);
-  const ActorValues& actorValues = changeForm.actorValues;
+  const ActorValues& actorValues = actor->GetActorValues();
   const float rate = actor->IsBlockActive()
     ? actorValues.staminaRate
     : std::max(baseValues.staminaRate, actorValues.staminaRate);
   const float rateMult =
     std::max(baseValues.staminaRateMult, actorValues.staminaRateMult);
   const float oldPercentage = actorValues.staminaPercentage;
-  const bool hasActiveMagicEffects = !changeForm.activeMagicEffects.Empty();
+  const bool hasActiveMagicEffects = !actor->GetActiveMagicEffects().Empty();
   return CropRegeneration(newAttributeValue, secondsAfterLastRegen, rate,
                           rateMult, oldPercentage, hasActiveMagicEffects);
 }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -791,6 +791,11 @@ const ActorValues& MpActor::GetActorValues() const
   return ChangeForm().actorValues;
 }
 
+const ActiveMagicEffectsMap& MpActor::GetActiveMagicEffects() const
+{
+  return ChangeForm().activeMagicEffects;
+}
+
 int32_t MpActor::GetProfileId() const
 {
   return ChangeForm().profileId;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -14,6 +14,7 @@
 class WorldState;
 struct ActorValues;
 class RespawnEvent;
+class ActiveMagicEffectsMap;
 
 class MpActor : public MpObjectReference
 {
@@ -45,6 +46,7 @@ public:
   const std::vector<FormDesc>& GetTemplateChain() const;
   bool IsCreatedAsPlayer() const;
   const ActorValues& GetActorValues() const;
+  const ActiveMagicEffectsMap& GetActiveMagicEffects() const;
   int32_t GetProfileId() const;
 
   bool ShouldSkipRestoration() const noexcept;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 426b28cce61735b0d0a03ace156d5d1141baa8ee  | 
|--------|--------|

### Summary:
Optimized `CropRegeneration` functions by accessing `actorValues` and `activeMagicEffects` directly through new methods in `MpActor`, reducing unnecessary object creation and function calls.

**Key points**:
- Optimized `CropHealthRegeneration`, `CropMagickaRegeneration`, and `CropStaminaRegeneration` in `skymp5-server/cpp/server_guest_lib/CropRegeneration.cpp`.
- Replaced `actor->GetChangeForm().actorValues` with `actor->GetActorValues()`.
- Replaced `!changeForm.activeMagicEffects.Empty()` with `!actor->GetActiveMagicEffects().Empty()`.
- Added `MpActor::GetActiveMagicEffects()` in `skymp5-server/cpp/server_guest_lib/MpActor.cpp` and `MpActor.h` to access `activeMagicEffects` directly.
- Removed redundant `MpChangeForm` object creation in regeneration functions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->