### PR TITLE
perf(skymp5-server): implement changeform buffers recycle

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -38,6 +38,7 @@ struct RelootTimeForTypesEntry
 struct WorldState::Impl
 {
   std::vector<std::optional<MpChangeForm>> changesByIdx;
+  bool changesByIdxEmpty = true;
 
   std::shared_ptr<ISaveStorage> saveStorage;
   std::shared_ptr<IScriptStorage> scriptStorage;
@@ -284,6 +285,7 @@ void WorldState::RequestSave(MpObjectReference& ref)
   }
 
   pImpl->changesByIdx[idx] = ref.GetChangeForm();
+  pImpl->changesByIdxEmpty = false;
 }
 
 const std::shared_ptr<MpForm>& WorldState::LookupFormById(
@@ -730,7 +732,7 @@ void WorldState::TickSaveStorage(const std::chrono::system_clock::time_point&)
     return;
   }
 
-  if (pImpl->changesByIdx.empty()) {
+  if (pImpl->changesByIdxEmpty) {
     return;
   }
 
@@ -743,6 +745,7 @@ void WorldState::TickSaveStorage(const std::chrono::system_clock::time_point&)
   try {
     pImpl->saveStorage->Upsert(std::move(pImpl->changesByIdx),
                                [pImpl_] { pImpl_->saveStorageBusy = false; });
+    pImpl->changesByIdxEmpty = true;
   } catch (std::exception& e) {
     pImpl->saveStorageBusy = false;
     spdlog::error("TickSaveStorage - Upsert failed with {}", e.what());

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -738,6 +738,8 @@ void WorldState::TickSaveStorage(const std::chrono::system_clock::time_point&)
 
   auto pImpl_ = pImpl;
 
+  auto previousSize = pImpl->changesByIdx.size();
+
   try {
     pImpl->saveStorage->Upsert(std::move(pImpl->changesByIdx),
                                [pImpl_] { pImpl_->saveStorageBusy = false; });
@@ -747,6 +749,14 @@ void WorldState::TickSaveStorage(const std::chrono::system_clock::time_point&)
   }
 
   pImpl->changesByIdx.clear();
+
+  bool recycleSuccess =
+    pImpl->saveStorage->GetRecycledChangeFormsBuffer(pImpl->changesByIdx);
+
+  if (!recycleSuccess) {
+    // Just resize to previous size, at least not to resize every RequestSave
+    pImpl->changesByIdx.resize(previousSize);
+  }
 }
 
 void WorldState::TickTimers(const std::chrono::system_clock::time_point&)

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/FileDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/FileDatabase.cpp
@@ -99,15 +99,3 @@ void FileDatabase::Iterate(const IterateCallback& iterateCallback)
     }
   }
 }
-
-bool FileDatabase::GetRecycledChangeFormsBuffer(
-  std::vector<MpChangeForm>& changeForms)
-{
-  if (pImpl->recycledChangeFormsBuffer) {
-    changeForms = std::move(*pImpl->recycledChangeFormsBuffer);
-    pImpl->recycledChangeFormsBuffer.reset();
-    return true;
-  }
-
-  return false;
-}

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/FileDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/FileDatabase.h
@@ -8,11 +8,13 @@ public:
   FileDatabase(std::string directory_,
                std::shared_ptr<spdlog::logger> logger_);
 
-  size_t Upsert(
-    std::vector<std::optional<MpChangeForm>>&& changeForms) override;
   void Iterate(const IterateCallback& iterateCallback) override;
 
 private:
+  std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
+    std::vector<std::optional<MpChangeForm>>&& changeForms,
+    size_t& outNumUpserted) override;
+
   struct Impl;
   std::shared_ptr<Impl> pImpl;
 };

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.cpp
@@ -1,0 +1,27 @@
+#include "IDatabase.h"
+
+size_t IDatabase::Upsert(
+  std::vector<std::optional<MpChangeForm>>&& changeForms)
+{
+  size_t numUpserted = 0;
+
+  recycledChangeFormsBuffer = UpsertImpl(std::move(changeForms), numUpserted);
+
+  return numUpserted;
+}
+
+bool IDatabase::GetRecycledChangeFormsBuffer(
+  std::vector<MpChangeForm>& changeForms)
+{
+  if (recycledChangeFormsBuffer.empty()) {
+    return false;
+  }
+
+  for (auto &value : recycledChangeFormsBuffer) {
+    value = std::nullopt;
+  }
+
+  changeForms = std::move(recycledChangeFormsBuffer);
+  recycledChangeFormsBuffer.clear();
+  return true;
+}

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.cpp
@@ -11,13 +11,13 @@ size_t IDatabase::Upsert(
 }
 
 bool IDatabase::GetRecycledChangeFormsBuffer(
-  std::vector<MpChangeForm>& changeForms)
+  std::vector<std::optional<MpChangeForm>>& changeForms)
 {
   if (recycledChangeFormsBuffer.empty()) {
     return false;
   }
 
-  for (auto &value : recycledChangeFormsBuffer) {
+  for (auto& value : recycledChangeFormsBuffer) {
     value = std::nullopt;
   }
 

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.h
@@ -40,11 +40,13 @@ public:
 
   virtual void Iterate(const IterateCallback& iterateCallback) = 0;
 
-  bool GetRecycledChangeFormsBuffer(std::vector<MpChangeForm>& changeForms);
+  bool GetRecycledChangeFormsBuffer(
+    std::vector<std::optional<MpChangeForm>>& changeForms);
 
 protected:
   virtual std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
-    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) = 0;
+    std::vector<std::optional<MpChangeForm>>&& changeForms,
+    size_t& outNumUpserted) = 0;
 
   std::vector<std::optional<MpChangeForm>> recycledChangeFormsBuffer;
 };

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/IDatabase.h
@@ -36,8 +36,15 @@ public:
   // Returns numbers of change forms inserted or updated successfully (Suitable
   // for logging). In practice, it should be equal to `changeForms.size()` when
   // saving succeed.
-  virtual size_t Upsert(
-    std::vector<std::optional<MpChangeForm>>&& changeForms) = 0;
+  size_t Upsert(std::vector<std::optional<MpChangeForm>>&& changeForms);
 
   virtual void Iterate(const IterateCallback& iterateCallback) = 0;
+
+  bool GetRecycledChangeFormsBuffer(std::vector<MpChangeForm>& changeForms);
+
+protected:
+  virtual std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
+    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) = 0;
+
+  std::vector<std::optional<MpChangeForm>> recycledChangeFormsBuffer;
 };

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
@@ -116,7 +116,9 @@ std::vector<std::optional<MpChangeForm>>&& MigrationDatabase::UpsertImpl(
 {
   spdlog::error("MigrationDatabase::Upsert - should never be reached");
   pImpl->terminate();
-  return std::vector<std::optional<MpChangeForm>>();
+
+  outNumUpserted = 0;
+  return changeForms;
 }
 
 void MigrationDatabase::Iterate(const IterateCallback& iterateCallback)

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
@@ -118,7 +118,7 @@ std::vector<std::optional<MpChangeForm>>&& MigrationDatabase::UpsertImpl(
   pImpl->terminate();
 
   outNumUpserted = 0;
-  return changeForms;
+  return std::move(changeForms);
 }
 
 void MigrationDatabase::Iterate(const IterateCallback& iterateCallback)

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.cpp
@@ -110,12 +110,13 @@ MigrationDatabase::MigrationDatabase(std::shared_ptr<IDatabase> newDatabase,
   pImpl->exit();
 }
 
-size_t MigrationDatabase::Upsert(
-  std::vector<std::optional<MpChangeForm>>&& changeForms)
+std::vector<std::optional<MpChangeForm>>&& MigrationDatabase::UpsertImpl(
+  std::vector<std::optional<MpChangeForm>>&& changeForms,
+  size_t& outNumUpserted)
 {
   spdlog::error("MigrationDatabase::Upsert - should never be reached");
   pImpl->terminate();
-  return 0;
+  return std::vector<std::optional<MpChangeForm>>();
 }
 
 void MigrationDatabase::Iterate(const IterateCallback& iterateCallback)

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.h
@@ -9,11 +9,12 @@ public:
     std::shared_ptr<IDatabase> oldDatabase,
     std::function<void()> exit = [] { std::exit(0); },
     std::function<void()> terminate = [] { std::terminate(); });
-  size_t Upsert(
-    std::vector<std::optional<MpChangeForm>>&& changeForms) override;
   void Iterate(const IterateCallback& iterateCallback) override;
 
 private:
+  std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
+    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) override;
+
   struct Impl;
   std::shared_ptr<Impl> pImpl;
 };

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MigrationDatabase.h
@@ -13,7 +13,8 @@ public:
 
 private:
   std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
-    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) override;
+    std::vector<std::optional<MpChangeForm>>&& changeForms,
+    size_t& outNumUpserted) override;
 
   struct Impl;
   std::shared_ptr<Impl> pImpl;

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
@@ -39,9 +39,12 @@ MongoDatabase::MongoDatabase(std::string uri_, std::string name_)
 {
   throw std::runtime_error("MongoDB is not supported in this build");
 }
-size_t MongoDatabase::UpsertImpl(std::vector<std::optional<MpChangeForm>>&&)
+std::vector<std::optional<MpChangeForm>>&& MongoDatabase::UpsertImpl(
+  std::vector<std::optional<MpChangeForm>>&& changeForms,
+  size_t& outNumUpserted)
 {
-  return 0;
+  outNumUpserted = 0;
+  return changeForms;
 }
 
 void MongoDatabase::Iterate(const IterateCallback&)
@@ -61,7 +64,8 @@ MongoDatabase::MongoDatabase(std::string uri_, std::string name_)
 }
 
 std::vector<std::optional<MpChangeForm>>&& MongoDatabase::UpsertImpl(
-  std::vector<std::optional<MpChangeForm>>&& changeForms, size_t& outNumUpserted)
+  std::vector<std::optional<MpChangeForm>>&& changeForms,
+  size_t& outNumUpserted)
 {
   try {
     mongocxx::v_noabi::pool::entry poolEntry = pImpl->pool->acquire();

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
@@ -44,7 +44,7 @@ std::vector<std::optional<MpChangeForm>>&& MongoDatabase::UpsertImpl(
   size_t& outNumUpserted)
 {
   outNumUpserted = 0;
-  return changeForms;
+  return std::move(changeForms);
 }
 
 void MongoDatabase::Iterate(const IterateCallback&)

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.h
@@ -6,11 +6,12 @@ class MongoDatabase : public IDatabase
 {
 public:
   MongoDatabase(std::string uri_, std::string name_);
-  size_t Upsert(
-    std::vector<std::optional<MpChangeForm>>&& changeForms) override;
   void Iterate(const IterateCallback& iterateCallback) override;
 
 private:
+  std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
+    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) override;
+
   int GetDocumentCount();
   std::optional<std::string> GetCombinedErrorOrNull(
     const std::vector<std::optional<std::string>>& errorList);

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.h
@@ -10,7 +10,8 @@ public:
 
 private:
   std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
-    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) override;
+    std::vector<std::optional<MpChangeForm>>&& changeForms,
+    size_t& outNumUpserted) override;
 
   int GetDocumentCount();
   std::optional<std::string> GetCombinedErrorOrNull(

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/ZipDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/ZipDatabase.h
@@ -12,7 +12,8 @@ public:
 
 private:
   std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
-    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) override;
+    std::vector<std::optional<MpChangeForm>>&& changeForms,
+    size_t& outNumUpserted) override;
 
   struct Impl;
   std::shared_ptr<Impl> pImpl;

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/ZipDatabase.h
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/ZipDatabase.h
@@ -8,11 +8,12 @@ public:
   ZipDatabase(std::string filePath_, std::shared_ptr<spdlog::logger> logger_);
   ~ZipDatabase();
 
-  size_t Upsert(
-    std::vector<std::optional<MpChangeForm>>&& changeForms) override;
   void Iterate(const IterateCallback& iterateCallback) override;
 
 private:
+  std::vector<std::optional<MpChangeForm>>&& UpsertImpl(
+    std::vector<std::optional<MpChangeForm>>&& changeForms, size_t &outNumUpserted) override;
+
   struct Impl;
   std::shared_ptr<Impl> pImpl;
 };

--- a/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.cpp
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.cpp
@@ -166,7 +166,7 @@ void AsyncSaveStorage::Tick()
 }
 
 bool AsyncSaveStorage::GetRecycledChangeFormsBuffer(
-  std::vector<MpChangeForm>& changeForms)
+  std::vector<std::optional<MpChangeForm>>& changeForms)
 {
   std::lock_guard l(pImpl->share4.m);
   if (pImpl->share4.recycledChangeFormsBuffers.empty()) {

--- a/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.cpp
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.cpp
@@ -91,7 +91,7 @@ void AsyncSaveStorage::SaverThreadMain(Impl* pImpl)
           t.changeForms.clear();
           callbacksToFire.push_back(t.callback);
 
-          std::vector<MpChangeForm> tmp;
+          std::vector<std::optional<MpChangeForm>> tmp;
           if (pImpl->share.dbImpl->GetRecycledChangeFormsBuffer(tmp)) {
             recycledChangeFormsBuffers.push_back(std::move(tmp));
           }

--- a/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.h
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.h
@@ -17,6 +17,8 @@ public:
               const UpsertCallback& cb) override;
   uint32_t GetNumFinishedUpserts() const override;
   void Tick() override;
+  bool GetRecycledChangeFormsBuffer(
+    std::vector<MpChangeForm>& changeForms) override;
   const std::string& GetName() const override;
 
 private:

--- a/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.h
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/AsyncSaveStorage.h
@@ -18,7 +18,7 @@ public:
   uint32_t GetNumFinishedUpserts() const override;
   void Tick() override;
   bool GetRecycledChangeFormsBuffer(
-    std::vector<MpChangeForm>& changeForms) override;
+    std::vector<std::optional<MpChangeForm>>& changeForms) override;
   const std::string& GetName() const override;
 
 private:

--- a/skymp5-server/cpp/server_guest_lib/save_storages/ISaveStorage.h
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/ISaveStorage.h
@@ -18,7 +18,8 @@ public:
                       const UpsertCallback& cb) = 0;
   virtual uint32_t GetNumFinishedUpserts() const = 0;
   virtual void Tick() = 0;
-  virtual bool GetRecycledChangeFormsBuffer(std::vector<MpChangeForm>& changeForms) = 0;
+  virtual bool GetRecycledChangeFormsBuffer(
+    std::vector<std::optional<MpChangeForm>>& changeForms) = 0;
 
   virtual const std::string& GetName() const = 0;
 };

--- a/skymp5-server/cpp/server_guest_lib/save_storages/ISaveStorage.h
+++ b/skymp5-server/cpp/server_guest_lib/save_storages/ISaveStorage.h
@@ -18,6 +18,7 @@ public:
                       const UpsertCallback& cb) = 0;
   virtual uint32_t GetNumFinishedUpserts() const = 0;
   virtual void Tick() = 0;
+  virtual bool GetRecycledChangeFormsBuffer(std::vector<MpChangeForm>& changeForms) = 0;
 
   virtual const std::string& GetName() const = 0;
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d8f74e35423d8e0c4a1fbcbfc9930ad3c1282e56  | 
|--------|--------|

### Summary:
Implemented changeform buffer recycling in `skymp5-server` to enhance performance by reusing buffers across `WorldState`, `IDatabase`, and various database drivers.

**Key points**:
- Implemented changeform buffer recycling in `skymp5-server`.
- Modified `WorldState::TickSaveStorage` to use recycled buffers.
- Added `GetRecycledChangeFormsBuffer` in `IDatabase` and `AsyncSaveStorage`.
- Refactored `Upsert` method in `IDatabase` to return recyclable buffers.
- Updated `FileDatabase`, `MongoDatabase`, `ZipDatabase`, and `MigrationDatabase` to implement `UpsertImpl`.
- Enhanced performance by reducing buffer reallocations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->