### PR TITLE
perf(skymp5-server): optimize OnlinePlayersBinding

### DIFF
--- a/skymp5-server/cpp/addon/property_bindings/OnlinePlayersBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/OnlinePlayersBinding.cpp
@@ -1,25 +1,27 @@
 #include "OnlinePlayersBinding.h"
 
+#include "Config.h"
+
 Napi::Value OnlinePlayersBinding::Get(Napi::Env env, ScampServer& scampServer,
                                       uint32_t)
 {
   auto& partOne = scampServer.GetPartOne();
 
-  auto n = partOne->serverState.userInfo.size();
-  std::vector<uint32_t> onlineActors;
-  onlineActors.reserve(n);
+  thread_local std::vector<uint32_t> g_onlineActors(kMaxPlayers);
+  size_t numOnlineActors = 0;
 
+  auto n = partOne->serverState.userInfo.size();
   for (size_t i = 0; i < n; ++i) {
     if (auto actor = partOne->serverState.ActorByUser(i)) {
-      onlineActors.push_back(actor->GetFormId());
+      g_onlineActors[numOnlineActors] = actor->GetFormId();
+      ++numOnlineActors;
     }
   }
 
-  auto arr = Napi::Array::New(env, onlineActors.size());
-  int i = 0;
-  for (auto id : onlineActors) {
-    arr.Set(i, Napi::Number::New(env, id));
-    ++i;
+  auto arr = Napi::Array::New(env, numOnlineActors);
+  for (size_t k = 0; k < numOnlineActors; ++k) {
+    auto id = g_onlineActors[k];
+    arr.Set(k, Napi::Number::New(env, id));
   }
   return arr;
 }

--- a/skymp5-server/cpp/addon/property_bindings/OnlinePlayersBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/OnlinePlayersBinding.cpp
@@ -10,8 +10,8 @@ Napi::Value OnlinePlayersBinding::Get(Napi::Env env, ScampServer& scampServer,
   thread_local std::vector<uint32_t> g_onlineActors(kMaxPlayers);
   size_t numOnlineActors = 0;
 
-  auto n = partOne->serverState.userInfo.size();
-  for (size_t i = 0; i < n; ++i) {
+  auto maxConnectedId = partOne->serverState.maxConnectedId;
+  for (size_t i = 0; i <= maxConnectedId; ++i) {
     if (auto actor = partOne->serverState.ActorByUser(i)) {
       g_onlineActors[numOnlineActors] = actor->GetFormId();
       ++numOnlineActors;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 59dd1400ba1470bde8e976f6cbcec07749532bb4  | 
|--------|--------|

### Summary:
Optimizes `OnlinePlayersBinding::Get` by using a `thread_local` vector to store online actors, reducing dynamic memory allocations.

**Key points**:
- Optimizes `OnlinePlayersBinding::Get` in `skymp5-server/cpp/addon/property_bindings/OnlinePlayersBinding.cpp`.
- Introduces `thread_local` vector `g_onlineActors` to store actor IDs, reducing dynamic allocations.
- Replaces `onlineActors` vector with `g_onlineActors`.
- Uses `numOnlineActors` to track the number of online actors.
- Constructs `Napi::Array` using `numOnlineActors` for size.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->