### PR TITLE
perf(skymp5-server): optimize out json copying in DynamicFields

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/DynamicFields.cpp
+++ b/skymp5-server/cpp/server_guest_lib/DynamicFields.cpp
@@ -9,7 +9,7 @@ void DynamicFields::Set(const std::string& propName,
   props[propName] = value;
 }
 
-nlohmann::json DynamicFields::Get(const std::string& propName) const
+const nlohmann::json& DynamicFields::Get(const std::string& propName) const
 {
   auto it = props.find(propName);
   if (it == props.end()) {

--- a/skymp5-server/cpp/server_guest_lib/DynamicFields.cpp
+++ b/skymp5-server/cpp/server_guest_lib/DynamicFields.cpp
@@ -11,9 +11,11 @@ void DynamicFields::Set(const std::string& propName,
 
 const nlohmann::json& DynamicFields::Get(const std::string& propName) const
 {
+  static const auto kNull = nlohmann::json();
+
   auto it = props.find(propName);
   if (it == props.end()) {
-    return nlohmann::json();
+    return kNull;
   }
   return it->second;
 }

--- a/skymp5-server/cpp/server_guest_lib/DynamicFields.h
+++ b/skymp5-server/cpp/server_guest_lib/DynamicFields.h
@@ -9,7 +9,7 @@ class DynamicFields
 {
 public:
   void Set(const std::string& propName, const nlohmann::json& value);
-  nlohmann::json Get(const std::string& propName) const;
+  const nlohmann::json& Get(const std::string& propName) const;
 
   const nlohmann::json& GetAsJson() const;
   static DynamicFields FromJson(const nlohmann::json& j);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7426ef06b48eed4fdc46f1d8790c5709ca82e8b1  | 
|--------|--------|

### Summary:
Optimize `DynamicFields::Get` to return a reference, reducing JSON copying overhead.

**Key points**:
- Change `DynamicFields::Get` to return `const nlohmann::json&` instead of `nlohmann::json` in `skymp5-server/cpp/server_guest_lib/DynamicFields.cpp` and `DynamicFields.h`.
- Optimizes performance by avoiding unnecessary JSON copying.
- Affects retrieval of properties in `DynamicFields` class.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->