### PR TITLE
perf(skymp5-server): fix minor perf issues

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -144,9 +144,12 @@ void ActionListener::OnUpdateMovement(const RawMessageData& rawMsgData,
 
     actor->SetPos(pos, SetPosMode::CalledByUpdateMovement);
     actor->SetAngle(rot, SetAngleMode::CalledByUpdateMovement);
-    actor->SetAnimationVariableBool("bInJumpState", isInJumpState);
-    actor->SetAnimationVariableBool("_skymp_isWeapDrawn", isWeapDrawn);
-    actor->SetAnimationVariableBool("IsBlocking", isBlocking);
+    actor->SetAnimationVariableBool(
+      AnimationVariableBool::kVariable_bInJumpState, isInJumpState);
+    actor->SetAnimationVariableBool(
+      AnimationVariableBool::kVariable__skymp_isWeapDrawn, isWeapDrawn);
+    actor->SetAnimationVariableBool(
+      AnimationVariableBool::kVariable_IsBlocking, isBlocking);
 
     if (actor->GetBlockCount() == 5) {
       actor->SetIsBlockActive(false);

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -535,17 +535,9 @@ void MpObjectReference::SetPos(const NiPoint3& newPos, SetPosMode setPosMode)
       auto me = ToVarValue();
 
       // May be modified inside loop, so copying
-      const auto map = *primitivesWeAreInside;
+      const auto set = *primitivesWeAreInside;
 
-      for (auto emitterId : map) {
-        auto& emitter = GetParent()->LookupFormById(emitterId);
-        auto emitterRefr = emitter->AsObjectReference();
-        if (!emitterRefr) {
-          GetParent()->logger->error(
-            "Emitter not found ({0:x}) when trying to send OnTrigger event",
-            emitterId);
-          continue;
-        }
+      for (MpObjectReference* emitterRefr : set) {
         emitterRefr->SendPapyrusEvent("OnTrigger", &me, 1);
       }
     }

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -111,6 +111,8 @@ std::pair<int16_t, int16_t> GetGridPos(const NiPoint3& pos) noexcept
 
 struct AnimGraphHolder
 {
+  AnimGraphHolder() { boolVariables.fill(false); }
+
   std::array<bool, static_cast<size_t>(AnimationVariableBool::kNumVariables)>
     boolVariables;
 };

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -280,8 +280,6 @@ bool MpObjectReference::GetAnimationVariableBool(const char* name) const
                  "variable name: {}",
                  name);
     return false;
-
-    constexpr int s = sizeof(::MpChangeFormREFR);
   }
 
   return pImpl->animGraphHolder.boolVariables[static_cast<size_t>(variable)];

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -58,6 +58,17 @@ enum class SetPosMode
   Other
 };
 
+// Corresponding string is a constant name without "kVariable_" prefix
+// Keep in sync with MpObjectReference::GetAnimationVariableBool
+enum class AnimationVariableBool
+{
+  kInvalidVariable,
+  kVariable_bInJumpState,
+  kVariable__skymp_isWeapDrawn,
+  kVariable_IsBlocking,
+  kNumVariables
+};
+
 using SetAngleMode = SetPosMode;
 
 class MpObjectReference
@@ -118,7 +129,8 @@ public:
   void SetRelootTime(std::chrono::system_clock::duration newRelootTime);
   void SetChanceNoneOverride(uint8_t chanceNone);
   void SetCellOrWorld(const FormDesc& worldOrCell);
-  void SetAnimationVariableBool(const char* name, bool value);
+  void SetAnimationVariableBool(AnimationVariableBool animationVariableBool,
+                                bool value);
   void SetActivationBlocked(bool blocked);
   void ForceSubscriptionsUpdate();
   void SetPrimitive(const NiPoint3& boundsDiv2);

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -237,8 +237,14 @@ private:
 
   // Should be empty for non-actor refs
   std::unique_ptr<std::set<MpObjectReference*>> emitters;
-  std::unique_ptr<std::map<uint32_t, bool>> emittersWithPrimitives;
-  std::unique_ptr<std::set<uint32_t>> primitivesWeAreInside;
+
+  // The following keys were originally formIds, but changed to pointers for
+  // the sake of performance. Luckily, the server never releases objects, so
+  // the pointers are always valid.
+  // TODO: ensure primitivesWeAreInside is freed correctly
+  std::unique_ptr<std::map<MpObjectReference*, bool /* wasInside */>>
+    emittersWithPrimitives;
+  std::unique_ptr<std::set<MpObjectReference*>> primitivesWeAreInside;
 
   std::string baseType;
   uint32_t baseId = 0;

--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -898,7 +898,7 @@ void PartOne::TickPacketHistoryPlaybacks()
 
 void PartOne::TickDeferredMessages()
 {
-  for (Networking::UserId userId = 0; userId < serverState.userInfo.size();
+  for (Networking::UserId userId = 0; userId <= serverState.maxConnectedId;
        ++userId) {
     auto& userInfo = serverState.userInfo[userId];
     if (!userInfo) {

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -290,7 +290,7 @@ private:
   std::unordered_map<std::string, size_t> loadOrderMap;
   std::unordered_map<uint32_t, GridInfo> grids;
   std::unique_ptr<MakeID> formIdxManager;
-  std::vector<MpForm*> formByIdxUnreliable;
+  std::vector<MpObjectReference*> refrByIdxUnreliable;
   espm::Loader* espm = nullptr;
   FormCallbacksFactory formCallbacksFactory;
   std::unique_ptr<espm::CompressedFieldsCache> espmCache;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c4b80dc8006a388f26789efea2950919e4f45b92  | 
|--------|--------|

### Summary:
Optimized animation variable handling and user ID iteration in `skymp5-server` to improve performance.

**Key points**:
- Replaced `std::set` with `std::array` for animation variables in `AnimGraphHolder` in `MpObjectReference.cpp`.
- Updated `MpObjectReference::SetAnimationVariableBool` to use `AnimationVariableBool` enum.
- Optimized `PartOne::TickDeferredMessages` to iterate up to `maxConnectedId`.
- Adjusted `WorldState::AddForm` to handle `MpObjectReference` more efficiently.
- Refactored `WorldState::LookupFormByIdx` to use `refrByIdxUnreliable` vector.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->