### PR TITLE
perf(skymp5-server): implement parallel movement processing

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1097,12 +1097,14 @@ void ActionListener::TickDeferredSendToNeighboursMultithreaded()
     auto entry = std::move(deferredSendToNeighbours.front());
     deferredSendToNeighbours.pop_front();
 
+    ActionListener* self = this;
     futures.push_back(
-      threadPool.submit_task([this, entry = std::move(entry)]() mutable {
+      threadPool.submit_task([self, entry = std::move(entry)]() mutable {
         try {
           constexpr auto kReliableFalse = false;
-          SendToNeighbours(entry.idx, entry.myActor, entry.rawMsgCopy.data(),
-                           entry.rawMsgCopy.size(), kReliableFalse);
+          self->SendToNeighbours(entry.idx, entry.myActor,
+                                 entry.rawMsgCopy.data(),
+                                 entry.rawMsgCopy.size(), kReliableFalse);
         } catch (const std::exception& e) {
           spdlog::error(
             "ActionListener::TickDeferredSendToNeighboursMultithreaded - "

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1103,7 +1103,8 @@ void ActionListener::TickDeferredSendToNeighboursMultithreaded()
     auto myActor = entry.myActor;
     auto rawMsgCopy = std::move(entry.rawMsgCopy);
 
-    std::function<void()> t = [self, idx, myActor, rawMsgCopy]() {
+    std::function<void()> t = [self, idx, myActor,
+                               rawMsgCopy = std::move(rawMsgCopy)]() {
       try {
         constexpr auto kReliableFalse = false;
         self->SendToNeighbours(idx, myActor, rawMsgCopy.data(),

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1099,9 +1099,16 @@ void ActionListener::TickDeferredSendToNeighboursMultithreaded()
 
     futures.push_back(
       threadPool.submit_task([this, entry = std::move(entry)]() mutable {
-        constexpr auto kReliableFalse = false;
-        SendToNeighbours(entry.idx, entry.myActor, entry.rawMsgCopy.data(),
-                         entry.rawMsgCopy.size(), kReliableFalse);
+        try {
+          constexpr auto kReliableFalse = false;
+          SendToNeighbours(entry.idx, entry.myActor, entry.rawMsgCopy.data(),
+                           entry.rawMsgCopy.size(), kReliableFalse);
+        } catch (const std::exception& e) {
+          spdlog::error(
+            "ActionListener::TickDeferredSendToNeighboursMultithreaded - "
+            "Exception in task: {}",
+            e.what());
+        }
       }));
   }
 

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1099,12 +1099,15 @@ void ActionListener::TickDeferredSendToNeighboursMultithreaded()
 
     ActionListener* self = this;
 
-    std::function<void()> t = [self, entry = std::move(entry)]() {
+    auto idx = entry.idx;
+    auto myActor = entry.myActor;
+    auto rawMsgCopy = std::move(entry.rawMsgCopy);
+
+    std::function<void()> t = [self, idx, myActor, rawMsgCopy]() {
       try {
         constexpr auto kReliableFalse = false;
-        self->SendToNeighbours(entry.idx, entry.myActor,
-                               entry.rawMsgCopy.data(),
-                               entry.rawMsgCopy.size(), kReliableFalse);
+        self->SendToNeighbours(idx, myActor, rawMsgCopy.data(),
+                               rawMsgCopy.size(), kReliableFalse);
       } catch (const std::exception& e) {
         spdlog::error(
           "ActionListener::TickDeferredSendToNeighboursMultithreaded - "

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -48,7 +48,11 @@ MpActor* ActionListener::SendToNeighbours(uint32_t idx, MpActor* myActor,
       spdlog::error("SendToNeighbours - No permission to update actor {:x} "
                     "(already owned by user {})",
                     actor->GetFormId(), actorsOwningUserId);
-      partOne.SendHostStop(userId, *actor);
+
+      Networking::UserId myUserId = partOne.serverState.UserByActor(myActor);
+      if (myUserId != Networking::InvalidUserId) {
+        partOne.SendHostStop(myUserId, *actor);
+      }
 
       // TODO: implement cleaner solution
       static std::mutex g_hostersEraseMutex;
@@ -68,7 +72,11 @@ MpActor* ActionListener::SendToNeighbours(uint32_t idx, MpActor* myActor,
       spdlog::error(
         "SendToNeighbours - No permission to update actor {:x} (not a hoster)",
         actor->GetFormId());
-      partOne.SendHostStop(userId, *actor);
+
+      Networking::UserId myUserId = partOne.serverState.UserByActor(myActor);
+      if (myUserId != Networking::InvalidUserId) {
+        partOne.SendHostStop(myUserId, *actor);
+      }
       return nullptr;
     }
   }

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1100,8 +1100,8 @@ void ActionListener::TickDeferredSendToNeighboursMultithreaded()
     futures.push_back(
       threadPool.submit_task([this, entry = std::move(entry)]() mutable {
         constexpr auto kReliableFalse = false;
-        SendToNeighbours(idx, myActor, rawMsgCopy.data(), rawMsgCopy.size(),
-                         kReliableFalse);
+        SendToNeighbours(entry.idx, entry.myActor, entry.rawMsgCopy.data(),
+                         entry.rawMsgCopy.size(), kReliableFalse);
       }));
   }
 

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -26,6 +26,8 @@
 
 constexpr int kNumThreadsForThreadPool = 10;
 
+// Supports multithreading. Nothing must mutate the state read by this method
+// while it's executing
 MpActor* ActionListener::SendToNeighbours(uint32_t idx, MpActor* myActor,
                                           Networking::PacketData data,
                                           size_t length, bool reliable)
@@ -47,6 +49,10 @@ MpActor* ActionListener::SendToNeighbours(uint32_t idx, MpActor* myActor,
                     "(already owned by user {})",
                     actor->GetFormId(), actorsOwningUserId);
       partOne.SendHostStop(userId, *actor);
+
+      // TODO: implement cleaner solution
+      static std::mutex g_hostersEraseMutex;
+      std::lock_guard l(g_hostersEraseMutex);
 
       partOne.worldState.hosters.erase(actor->GetFormId());
       return nullptr;

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.h
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.h
@@ -7,6 +7,7 @@
 #include "PartOne.h"
 #include "libespm/Loader.h"
 #include <BS_thread_pool.hpp>
+#include <list>
 
 class ServerState;
 class WorldState;
@@ -106,12 +107,17 @@ private:
 
   struct DeferredSendToNeighboursEntry
   {
+    DeferredSendToNeighboursEntry(DeferredSendToNeighboursEntry&& rhs) =
+      default;
+    DeferredSendToNeighboursEntry& operator=(
+      DeferredSendToNeighboursEntry&& rhs) = default;
+
     uint32_t idx = -1;
     MpActor* myActor = nullptr;
     std::vector<uint8_t> rawMsgCopy;
   };
 
-  std::vector<DeferredSendToNeighboursEntry> deferredSendToNeighbours;
+  std::list<DeferredSendToNeighboursEntry> deferredSendToNeighbours;
 
   BS::thread_pool threadPool;
 

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.h
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.h
@@ -107,6 +107,7 @@ private:
 
   struct DeferredSendToNeighboursEntry
   {
+    DeferredSendToNeighboursEntry() = default;
     DeferredSendToNeighboursEntry(DeferredSendToNeighboursEntry&& rhs) =
       default;
     DeferredSendToNeighboursEntry& operator=(

--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -106,6 +106,7 @@ void PartOne::Tick()
   TickPacketHistoryPlaybacks();
   TickDeferredMessages();
   worldState.Tick();
+  GetActionListener().TickDeferredSendToNeighboursMultithreaded();
 }
 
 uint32_t PartOne::CreateActor(uint32_t formId, const NiPoint3& pos,

--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <mutex>
 #include <type_traits>
 #include <vector>
 
@@ -19,6 +20,9 @@ public:
   void Send(Networking::UserId targetUserId, Networking::PacketData data,
             size_t length, bool reliable) override
   {
+    // The reason for this is that ActionListener is now multi-threaded
+    std::lock_guard<std::mutex> lock(m);
+
     static auto g_serializer =
       MessageSerializerFactory::CreateMessageSerializer();
     auto deserializeResult = g_serializer->Deserialize(data, length);
@@ -34,6 +38,7 @@ public:
   }
 
   std::vector<PartOne::Message> messages;
+  std::mutex m;
 };
 
 struct PartOne::Impl

--- a/unit/TestUtils.cpp
+++ b/unit/TestUtils.cpp
@@ -63,6 +63,8 @@ void DoUpdateMovement(PartOne& partOne, uint32_t actorFormId,
                          partOne.worldState.LookupFormById(actorFormId).get())
                          ->GetIdx();
   DoMessage(partOne, userId, jMyMovement);
+
+  partOne.Tick();
 }
 
 std::shared_ptr<FakeListener> FakeListener::New()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 24dcf216986cd76cfa50b6cbd51fd2ae410c29f7  | 
|--------|--------|

### Summary:
Implemented parallel movement processing in `skymp5-server` using a thread pool for improved performance.

**Key points**:
- Introduced parallel processing for movement updates in `skymp5-server`.
- Added `BS::thread_pool` to `ActionListener` for concurrent processing.
- Modified `ActionListener::SendToNeighbours` to handle deferred messages.
- Added `ActionListener::TickDeferredSendToNeighboursMultithreaded` for multithreaded processing.
- Updated `PartOne::Tick` to call `TickDeferredSendToNeighboursMultithreaded`.
- Changes in `skymp5-server/cpp/server_guest_lib/ActionListener.cpp`, `ActionListener.h`, and `PartOne.cpp`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->