### PR TITLE
fix(skymp5-server): fix args order in take/put events

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/PutItemEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/PutItemEvent.cpp
@@ -19,9 +19,9 @@ std::string PutItemEvent::GetArgumentsJsonArray() const
 {
   std::string result;
   result += "[";
-  result += std::to_string(actor->GetFormId());
-  result += ",";
   result += std::to_string(sourceRefr->GetFormId());
+  result += ",";
+  result += std::to_string(actor->GetFormId());
   result += ",";
   result += std::to_string(entry.baseId);
   result += ",";

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/TakeItemEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/TakeItemEvent.cpp
@@ -20,9 +20,9 @@ std::string TakeItemEvent::GetArgumentsJsonArray() const
 {
   std::string result;
   result += "[";
-  result += std::to_string(actor->GetFormId());
-  result += ",";
   result += std::to_string(sourceRefr->GetFormId());
+  result += ",";
+  result += std::to_string(actor->GetFormId());
   result += ",";
   result += std::to_string(entry.baseId);
   result += ",";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 809496cb7c8df40d9f83905dec48d15f1cdb3609  | 
|--------|--------|

### Summary:
Fixes argument order in `GetArgumentsJsonArray` for `PutItemEvent` and `TakeItemEvent` to have `sourceRefr` before `actor`.

**Key points**:
- Fixes argument order in `GetArgumentsJsonArray` in `PutItemEvent` and `TakeItemEvent`.
- Moves `sourceRefr->GetFormId()` before `actor->GetFormId()`.
- Affects `skymp5-server/cpp/server_guest_lib/gamemode_events/PutItemEvent.cpp`.
- Affects `skymp5-server/cpp/server_guest_lib/gamemode_events/TakeItemEvent.cpp`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->