### PR TITLE
fear(skymp5-server): ban disabled/deleted objects activation

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1303,9 +1303,23 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
 
   auto base = loader.GetBrowser().LookupById(GetBaseId());
   if (!base.rec || !GetBaseId()) {
-    std::stringstream ss;
-    ss << std::hex << GetFormId() << " doesn't have base form";
-    throw std::runtime_error(ss.str());
+    return spdlog::error("MpObjectReference::ProcessActivate {:x} - doesn't "
+                         "have base form, activationSource is {:x}",
+                         GetFormId(), activationSource.GetFormId());
+  }
+
+  // Not sure if this is needed
+  if (IsDeleted()) {
+    return spdlog::warn("MpObjectReference::ProcessActivate {:x} - deleted "
+                        "object, activationSource is {:x}",
+                        GetFormId(), activationSource.GetFormId());
+  }
+
+  // Not sure if this is needed
+  if (IsDisabled()) {
+    return spdlog::warn("MpObjectReference::ProcessActivate {:x} - disabled "
+                        "object, activationSource is {:x}",
+                        GetFormId(), activationSource.GetFormId());
   }
 
   auto t = base.rec->GetType();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 69df5b3cacef942660f3dabba076e879bc38bba1  | 
|--------|--------|

### Summary:
`MpObjectReference::ProcessActivate` now prevents activation of deleted or disabled objects, logging warnings if such an attempt is made.

**Key points**:
- Modified `skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp`.
- Updated `MpObjectReference::ProcessActivate` to prevent activation of deleted or disabled objects.
- Added checks for `IsDeleted()` and `IsDisabled()`.
- Logs warnings if an object is deleted or disabled during activation attempt.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->