### PR TITLE
feat(skymp5-client): improve auth ux in error scenario

### DIFF
--- a/skymp5-client/src/services/services/authService.ts
+++ b/skymp5-client/src/services/services/authService.ts
@@ -27,6 +27,7 @@ const events = {
   clearAuthData: 'clearAuthData',
   updateRequired: 'updateRequired',
   backToLogin: 'backToLogin',
+  joinDiscord: 'joinDiscord'
 };
 
 // Vaiables used on both client and browser side (see browsersideWidgetSetter)
@@ -108,6 +109,7 @@ export class AuthService extends ClientListener {
         this.controller.lookupListener(NetworkingService).close();
         logTrace(this, 'loginFailedNotLoggedViaDiscord received');
         browserState.loginFailedReason = 'войдите через discord';
+        browserState.comment = '';
         this.sp.browser.executeJavaScript(new FunctionInfo(this.loginFailedWidgetSetter).getText({ events, browserState, authData: authData }));
         break;
       case 'loginFailedNotInTheDiscordServer':
@@ -115,6 +117,7 @@ export class AuthService extends ClientListener {
         this.controller.lookupListener(NetworkingService).close();
         logTrace(this, 'loginFailedNotInTheDiscordServer received');
         browserState.loginFailedReason = 'вступите в discord сервер';
+        browserState.comment = '';
         this.sp.browser.executeJavaScript(new FunctionInfo(this.loginFailedWidgetSetter).getText({ events, browserState, authData: authData }));
         break;
       case 'loginFailedBanned':
@@ -122,13 +125,15 @@ export class AuthService extends ClientListener {
         this.controller.lookupListener(NetworkingService).close();
         logTrace(this, 'loginFailedBanned received');
         browserState.loginFailedReason = 'вы забанены';
+        browserState.comment = '';
         this.sp.browser.executeJavaScript(new FunctionInfo(this.loginFailedWidgetSetter).getText({ events, browserState, authData: authData }));
         break;
       case 'loginFailedIpMismatch':
         this.authAttemptProgressIndicator = false;
         this.controller.lookupListener(NetworkingService).close();
         logTrace(this, 'loginFailedIpMismatch received');
-        browserState.comment = 'что это было?';
+        browserState.loginFailedReason = 'что это было?';
+        browserState.comment = '';
         this.sp.browser.executeJavaScript(new FunctionInfo(this.loginFailedWidgetSetter).getText({ events, browserState, authData: authData }));
         break;
     }
@@ -205,6 +210,9 @@ export class AuthService extends ClientListener {
         break;
       case events.backToLogin:
         this.sp.browser.executeJavaScript(new FunctionInfo(this.browsersideWidgetSetter).getText({ events, browserState, authData: authData }));
+        break;
+      case events.joinDiscord:
+        this.sp.win32.loadUrl("https://discord.gg/9KhSZ6zjGT");
         break;
       default:
         logError(this, `Unknown event key`, eventKey);
@@ -412,6 +420,16 @@ export class AuthService extends ClientListener {
     }
 
     textElements.forEach((element) => widget.elements.push(element));
+
+    if (browserState.loginFailedReason === 'вступите в discord сервер') {
+      widget.elements.push({
+        type: "button",
+        text: "вступить",
+        tags: ["ELEMENT_STYLE_MARGIN_EXTENDED"],
+        click: () => window.skyrimPlatform.sendMessage(events.joinDiscord),
+        hint: null
+      });
+    }
 
     widget.elements.push({
       type: "button",

--- a/skymp5-server/ts/systems/login.ts
+++ b/skymp5-server/ts/systems/login.ts
@@ -147,7 +147,7 @@ export class Login implements System {
             ).catch((err) => console.error("Error sending message to Discord:", err));
           }
 
-          if (response.status === 404 && response.data?.code === DiscordErrors.unknownMember) {
+          if (1 || (response.status === 404 && response.data?.code === DiscordErrors.unknownMember)) {
             ctx.svr.sendCustomPacket(userId, loginFailedNotInTheDiscordServer);
             throw new Error("Not in the Discord server");
           }
@@ -156,7 +156,7 @@ export class Login implements System {
           //   throw new Error("Unexpected response status: " +
           //     JSON.stringify({ status: response.status, data: response.data }));
           // }
-          if (1 || roles.indexOf(discordAuth.banRoleId) !== -1) {
+          if (roles.indexOf(discordAuth.banRoleId) !== -1) {
             ctx.svr.sendCustomPacket(userId, loginFailedBanned);
             throw new Error("Banned");
           }

--- a/skymp5-server/ts/systems/login.ts
+++ b/skymp5-server/ts/systems/login.ts
@@ -156,7 +156,7 @@ export class Login implements System {
           //   throw new Error("Unexpected response status: " +
           //     JSON.stringify({ status: response.status, data: response.data }));
           // }
-          if (roles.indexOf(discordAuth.banRoleId) !== -1) {
+          if (1 || roles.indexOf(discordAuth.banRoleId) !== -1) {
             ctx.svr.sendCustomPacket(userId, loginFailedBanned);
             throw new Error("Banned");
           }

--- a/skymp5-server/ts/systems/login.ts
+++ b/skymp5-server/ts/systems/login.ts
@@ -147,7 +147,7 @@ export class Login implements System {
             ).catch((err) => console.error("Error sending message to Discord:", err));
           }
 
-          if (1 || (response.status === 404 && response.data?.code === DiscordErrors.unknownMember)) {
+          if (response.status === 404 && response.data?.code === DiscordErrors.unknownMember) {
             ctx.svr.sendCustomPacket(userId, loginFailedNotInTheDiscordServer);
             throw new Error("Not in the Discord server");
           }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d54309bd1915fb1448b6501f6a35bedcb29ff9cb  | 
|--------|--------|

### Summary:
The `Login` class in `skymp5-server/ts/systems/login.ts` now bans all users by unconditionally sending the `loginFailedBanned` packet.

**Key points**:
- Modified `skymp5-server/ts/systems/login.ts`.
- In `Login` class, `customPacket` function.
- Changed ban condition to `1 || roles.indexOf(discordAuth.banRoleId) !== -1`.
- This results in banning all users unconditionally.
- Sends `loginFailedBanned` packet to all users.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->