### PR TITLE
fix(skymp5-server): fix RegisterForSingleUpdate behavior

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpForm.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpForm.cpp
@@ -97,3 +97,13 @@ float MpForm::GetWeight() const
 
   return GetWeightFromRecord(record, GetParent()->GetEspmCache());
 }
+
+std::optional<uint32_t> MpForm::GetSingleUpdateTimerId() const noexcept
+{
+  return singleUpdateTimerId;
+}
+
+void MpForm::SetSingleUpdateTimerId(std::optional<uint32_t> id) noexcept
+{
+  singleUpdateTimerId = id;
+}

--- a/skymp5-server/cpp/server_guest_lib/MpForm.h
+++ b/skymp5-server/cpp/server_guest_lib/MpForm.h
@@ -2,6 +2,7 @@
 #include "NiPoint3.h"
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string.h>
 #include <typeinfo>
 #include <vector>
@@ -62,13 +63,17 @@ public:
   auto GetFormId() const noexcept { return id; }
   float GetWeight() const;
 
+  std::optional<uint32_t> GetSingleUpdateTimerId() const noexcept;
+  void SetSingleUpdateTimerId(std::optional<uint32_t> id) noexcept;
+
+  virtual void Update();
+
   MpForm(const MpForm&) = delete;
   MpForm& operator=(const MpForm&) = delete;
 
 protected:
   virtual void Init(WorldState* parent_, uint32_t formId_,
                     bool hasChangeForm); // See WorldState::AddForm
-  virtual void Update();
   virtual void SendPapyrusEvent(const char* eventName,
                                 const VarValue* arguments = nullptr,
                                 size_t argumentsCount = 0);
@@ -80,6 +85,7 @@ private:
   WorldState* parent = nullptr;
   mutable GameObjectPtr gameObject;
   std::vector<std::shared_ptr<ActivePexInstance>> activePexInstances;
+  std::optional<uint32_t> singleUpdateTimerId;
 
 protected:
   virtual void BeforeDestroy() {}

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -89,16 +89,6 @@ public:
     return timerEffects.SetTimer(std::forward<T>(duration), outTimerId);
   }
 
-  template <typename T>
-  void RegisterForSingleUpdate(const VarValue& self, T&& duration)
-  {
-    SetTimer(std::forward<T>(duration)).Then([self](Viet::Void) {
-      if (auto form = GetFormPtr<MpForm>(self)) {
-        form->Update();
-      }
-    });
-  }
-
   bool RemoveTimer(uint32_t timerId);
   Viet::Promise<Viet::Void> SetTimer(
     std::reference_wrapper<const std::chrono::system_clock::time_point>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 995c1d5da43663e98aa7d4c2e2774c690d4ac1de  | 
|--------|--------|

### Summary:
Refactored `RegisterForSingleUpdate` to manage timers directly in `PapyrusForm`, ensuring only one active timer per form by removing existing timers before setting new ones.

**Key points**:
- Removed `RegisterForSingleUpdate` from `WorldState.h`.
- Added `GetSingleUpdateTimerId` and `SetSingleUpdateTimerId` to `MpForm` in `MpForm.h` and `MpForm.cpp`.
- Modified `PapyrusForm::RegisterForSingleUpdate` in `PapyrusForm.cpp` to handle timer logic directly.
- Ensures only one update timer is active per form by removing existing timers before setting a new one.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->