### PR TITLE
internal: fix ga-sdk-cpp port to install header

### DIFF
--- a/overlay_ports/ga-sdk-cpp/CMakelists.txt
+++ b/overlay_ports/ga-sdk-cpp/CMakelists.txt
@@ -59,10 +59,14 @@ find_package(RapidJSON CONFIG REQUIRED)
 set(RAPID_JSON_DIR ${RAPIDJSON_INCLUDE_DIRS})
 target_include_directories(ga-sdk-cpp PUBLIC ${RAPID_JSON_DIR})
 
+set_target_properties(ga-sdk-cpp PROPERTIES
+    PUBLIC_HEADER "source/gameanalytics/GameAnalytics.h"
+)
+
 # install
 install(TARGETS ga-sdk-cpp
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include
+    PUBLIC_HEADER DESTINATION include
 )

--- a/overlay_ports/ga-sdk-cpp/portfile.cmake
+++ b/overlay_ports/ga-sdk-cpp/portfile.cmake
@@ -18,3 +18,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4ccdc45e56c06854c004b8b9304961b17f778e45  | 
|--------|--------|

### Summary:
Fixes `ga-sdk-cpp` CMake configuration to install `GameAnalytics.h` header and clean up debug includes.

**Key points**:
- Updated `overlay_ports/ga-sdk-cpp/CMakelists.txt` to set `PUBLIC_HEADER` property for `ga-sdk-cpp` target.
- Changed `install` command in `overlay_ports/ga-sdk-cpp/CMakelists.txt` to use `PUBLIC_HEADER` for header installation.
- Modified `overlay_ports/ga-sdk-cpp/portfile.cmake` to remove debug include directory after installation.
- Ensured copyright file is installed in `overlay_ports/ga-sdk-cpp/portfile.cmake`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->