### PR TITLE
feat: add isSecondActivation handling for client and server

### DIFF
--- a/skymp5-client/src/services/messages/activateMessage.ts
+++ b/skymp5-client/src/services/messages/activateMessage.ts
@@ -8,4 +8,5 @@ export interface ActivateMessage {
 interface ActivateMessageData {
     caster: number;
     target: number;
+    isSecondActivation: boolean;
 }

--- a/skymp5-client/src/services/services/activationService.ts
+++ b/skymp5-client/src/services/services/activationService.ts
@@ -58,7 +58,7 @@ export class ActivationService extends ClientListener {
         this.controller.emitter.emit("sendMessage", {
             message: {
                 t: MsgType.Activate,
-                data: { caster, target }
+                data: { caster, target, isSecondActivation: false }
             },
             reliability: "reliable"
         });

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -265,7 +265,8 @@ void ActionListener::OnUpdateEquipment(
 }
 
 void ActionListener::OnActivate(const RawMessageData& rawMsgData,
-                                uint32_t caster, uint32_t target)
+                                uint32_t caster, uint32_t target,
+                                bool isSecondActivation)
 {
   if (!partOne.HasEspm())
     throw std::runtime_error("No loaded esm or esp files are found");
@@ -291,9 +292,11 @@ void ActionListener::OnActivate(const RawMessageData& rawMsgData,
   if (!targetPtr)
     return;
 
+  constexpr bool kDefaultProcessingOnlyFalse = false;
   targetPtr->Activate(
     caster == 0x14 ? *ac
-                   : partOne.worldState.GetFormAt<MpObjectReference>(caster));
+                   : partOne.worldState.GetFormAt<MpObjectReference>(caster),
+    kDefaultProcessingOnlyFalse, isSecondActivation);
   if (hosterId) {
     auto actor = std::dynamic_pointer_cast<MpActor>(
       partOne.worldState.LookupFormById(caster));

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.h
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.h
@@ -51,7 +51,7 @@ public:
                                  uint32_t voiceSpell, uint32_t instantSpell);
 
   virtual void OnActivate(const RawMessageData& rawMsgData, uint32_t caster,
-                          uint32_t target);
+                          uint32_t target, bool isSecondActivation);
 
   virtual void OnPutItem(const RawMessageData& rawMsgData, uint32_t target,
                          const Inventory::Entry& entry);

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1513,9 +1513,10 @@ bool MpObjectReference::ProcessActivateSecond(
 
   auto base = loader.GetBrowser().LookupById(GetBaseId());
   if (!base.rec || !GetBaseId()) {
-    return spdlog::error("MpObjectReference::ProcessActivate {:x} - doesn't "
-                         "have base form, activationSource is {:x}",
-                         GetFormId(), activationSource.GetFormId());
+    spdlog::error("MpObjectReference::ProcessActivate {:x} - doesn't "
+                  "have base form, activationSource is {:x}",
+                  GetFormId(), activationSource.GetFormId());
+    return false;
   }
 
   auto t = base.rec->GetType();

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1510,6 +1510,13 @@ void MpObjectReference::ProcessActivateSecond(
   auto& loader = GetParent()->GetEspm();
   auto& compressedFieldsCache = GetParent()->GetEspmCache();
 
+  auto base = loader.GetBrowser().LookupById(GetBaseId());
+  if (!base.rec || !GetBaseId()) {
+    return spdlog::error("MpObjectReference::ProcessActivate {:x} - doesn't "
+                         "have base form, activationSource is {:x}",
+                         GetFormId(), activationSource.GetFormId());
+  }
+
   auto t = base.rec->GetType();
 
   if (t == espm::CONT::kType && actorActivator) {

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -393,7 +393,8 @@ void MpObjectReference::VisitProperties(const PropertiesVisitor& visitor,
 }
 
 void MpObjectReference::Activate(MpObjectReference& activationSource,
-                                 bool defaultProcessingOnly)
+                                 bool defaultProcessingOnly,
+                                 bool isSecondActivation)
 {
   if (spdlog::should_log(spdlog::level::trace)) {
     for (auto& script : ListActivePexInstances()) {
@@ -428,25 +429,29 @@ void MpObjectReference::Activate(MpObjectReference& activationSource,
     }
   }
 
-  ActivateEvent activateEvent(GetFormId(), activationSource.GetFormId());
-
-  bool activationBlockedByMpApi = !activateEvent.Fire(GetParent());
-
-  if (!activationBlockedByMpApi &&
-      (!activationBlocked || defaultProcessingOnly)) {
-    ProcessActivate(activationSource);
-    ActivateChilds();
+  if (isSecondActivation) {
+    ProcessActivateSecond(activationSource);
   } else {
-    spdlog::trace(
-      "Activation of form {:#x} has been blocked. Reasons: "
-      "blocked by MpApi={}, form is blocked={}, defaultProcessingOnly={}",
-      GetFormId(), activationBlockedByMpApi, activationBlocked,
-      defaultProcessingOnly);
-  }
+    ActivateEvent activateEvent(GetFormId(), activationSource.GetFormId());
 
-  if (!defaultProcessingOnly) {
-    auto arg = activationSource.ToVarValue();
-    SendPapyrusEvent("OnActivate", &arg, 1);
+    bool activationBlockedByMpApi = !activateEvent.Fire(GetParent());
+
+    if (!activationBlockedByMpApi &&
+        (!activationBlocked || defaultProcessingOnly)) {
+      ProcessActivateNormal(activationSource);
+      ActivateChilds();
+    } else {
+      spdlog::trace(
+        "Activation of form {:#x} has been blocked. Reasons: "
+        "blocked by MpApi={}, form is blocked={}, defaultProcessingOnly={}",
+        GetFormId(), activationBlockedByMpApi, activationBlocked,
+        defaultProcessingOnly);
+    }
+
+    if (!defaultProcessingOnly) {
+      auto arg = activationSource.ToVarValue();
+      SendPapyrusEvent("OnActivate", &arg, 1);
+    }
   }
 }
 
@@ -1293,7 +1298,8 @@ bool MpObjectReference::IsLocationSavingNeeded() const
     std::chrono::system_clock::now() - *last > std::chrono::seconds(30);
 }
 
-void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
+void MpObjectReference::ProcessActivateNormal(
+  MpObjectReference& activationSource)
 {
   auto actorActivator = activationSource.AsActor();
 
@@ -1458,10 +1464,6 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
       this->occupantDestroySink.reset(
         new OccupantDestroyEventSink(*GetParent(), this));
       this->occupant->AddEventSink(occupantDestroySink);
-    } else if (this->occupant == &activationSource) {
-      SetOpen(false);
-      this->occupant->RemoveEventSink(this->occupantDestroySink);
-      this->occupant = nullptr;
     }
   } else if (t == espm::ACTI::kType && actorActivator) {
     // SendOpenContainer being used to activate the object
@@ -1476,9 +1478,12 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
     constexpr float kOccupationReach = 256.f;
     auto distanceToOccupant = (occupantPos - GetPos()).Length();
 
+    spdlog::info("try normal-activate furn 1");
+
     if (!this->occupant || this->occupant->IsDisabled() ||
         distanceToOccupant > kOccupationReach ||
         occupantCellOrWorld != GetCellOrWorld()) {
+      spdlog::info("try normal-activate furn 2");
       if (this->occupant) {
         this->occupant->RemoveEventSink(this->occupantDestroySink);
       }
@@ -1492,7 +1497,31 @@ void MpObjectReference::ProcessActivate(MpObjectReference& activationSource)
       this->occupantDestroySink.reset(
         new OccupantDestroyEventSink(*GetParent(), this));
       this->occupant->AddEventSink(occupantDestroySink);
-    } else if (this->occupant == &activationSource) {
+    }
+  }
+}
+
+void MpObjectReference::ProcessActivateSecond(
+  MpObjectReference& activationSource)
+{
+  auto actorActivator = activationSource.AsActor();
+
+  auto worldState = GetParent();
+  auto& loader = GetParent()->GetEspm();
+  auto& compressedFieldsCache = GetParent()->GetEspmCache();
+
+  auto t = base.rec->GetType();
+
+  if (t == espm::CONT::kType && actorActivator) {
+    if (this->occupant == &activationSource) {
+      SetOpen(false);
+      this->occupant->RemoveEventSink(this->occupantDestroySink);
+      this->occupant = nullptr;
+    }
+  } else if (t == "FURN" && actorActivator) {
+    spdlog::info("second-activate furn 1");
+    if (this->occupant == &activationSource) {
+      spdlog::info("second-activate furn 2");
       this->occupant->RemoveEventSink(this->occupantDestroySink);
       this->occupant = nullptr;
     }

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -230,7 +230,7 @@ private:
   void CheckInteractionAbility(MpObjectReference& ac);
   bool IsLocationSavingNeeded() const;
   void ProcessActivateNormal(MpObjectReference& activationSource);
-  void ProcessActivateSecond(MpObjectReference& activationSource);
+  bool ProcessActivateSecond(MpObjectReference& activationSource);
   void ActivateChilds();
 
   bool everSubscribedOrListened = false;

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -114,7 +114,8 @@ public:
   virtual void VisitProperties(const PropertiesVisitor& visitor,
                                VisitPropertiesMode mode);
   virtual void Activate(MpObjectReference& activationSource,
-                        bool defaultProcessingOnly = false);
+                        bool defaultProcessingOnly = false,
+                        bool isSecondActivation = false);
   virtual void Disable();
   virtual void Enable();
 
@@ -228,7 +229,8 @@ private:
   void SendOpenContainer(uint32_t refId);
   void CheckInteractionAbility(MpObjectReference& ac);
   bool IsLocationSavingNeeded() const;
-  void ProcessActivate(MpObjectReference& activationSource);
+  void ProcessActivateNormal(MpObjectReference& activationSource);
+  void ProcessActivateSecond(MpObjectReference& activationSource);
   void ActivateChilds();
 
   bool everSubscribedOrListened = false;

--- a/skymp5-server/cpp/server_guest_lib/PacketParser.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PacketParser.cpp
@@ -29,7 +29,8 @@ static const JsonPointer t("t"), idx("idx"), content("content"), data("data"),
   magicka("magicka"), stamina("stamina"), leftSpell("leftSpell"),
   rightSpell("rightSpell"), voiceSpell("voiceSpell"),
   instantSpell("instantSpell"), weaponId("weaponId"), ammoId("ammoId"),
-  power("power"), isSunGazing("isSunGazing");
+  power("power"), isSunGazing("isSunGazing"),
+  isSecondActivation("isSecondActivation");
 }
 
 struct PacketParser::Impl
@@ -165,8 +166,11 @@ void PacketParser::TransformPacketIntoAction(Networking::UserId userId,
       uint64_t caster, target;
       ReadEx(data_, JsonPointers::caster, &caster);
       ReadEx(data_, JsonPointers::target, &target);
+      bool isSecondActivation;
+      ReadEx(data_, JsonPointers::isSecondActivation, &isSecondActivation);
       actionListener.OnActivate(rawMsgData, FormIdCasts::LongToNormal(caster),
-                                FormIdCasts::LongToNormal(target));
+                                FormIdCasts::LongToNormal(target),
+                                isSecondActivation);
     } break;
     case MsgType::UpdateProperty:
       break;

--- a/unit/PartOne_ActivateTest.cpp
+++ b/unit/PartOne_ActivateTest.cpp
@@ -41,10 +41,12 @@ TEST_CASE("Activate without espm attached", "[PartOne][espm]")
   DoConnect(partOne, 0);
 
   REQUIRE_THROWS_WITH(
-    DoMessage(
-      partOne, 0,
-      nlohmann::json{ { "t", MsgType::Activate },
-                      { "data", { { "caster", 0x15 }, { "target", 0 } } } }),
+    DoMessage(partOne, 0,
+              nlohmann::json{ { "t", MsgType::Activate },
+                              { "data",
+                                { { "caster", 0x15 },
+                                  { "target", 0 },
+                                  { "isSecondActivation", false } } } }),
     ContainsSubstring("No loaded esm or esp files are found"));
 }
 
@@ -55,16 +57,18 @@ TEST_CASE("Activate without Actor attached", "[PartOne][espm]")
   DoConnect(partOne, 0);
 
   REQUIRE_THROWS_WITH(
-    DoMessage(
-      partOne, 0,
-      nlohmann::json{ { "t", MsgType::Activate },
-                      { "data", { { "caster", 0x15 }, { "target", 0 } } } }),
+    DoMessage(partOne, 0,
+              nlohmann::json{ { "t", MsgType::Activate },
+                              { "data",
+                                { { "caster", 0x15 },
+                                  { "target", 0 },
+                                  { "isSecondActivation", false } } } }),
     ContainsSubstring("Can't do this without Actor attached"));
 
   DoDisconnect(partOne, 0);
 }
 
-TEST_CASE("Activate with bad caster", "[PartOne][espm]")
+TEST_CASE("Activate with bad hoster", "[PartOne][espm]")
 {
   auto& partOne = GetPartOne();
 
@@ -73,10 +77,12 @@ TEST_CASE("Activate with bad caster", "[PartOne][espm]")
   partOne.SetUserActor(0, 0xff000000);
 
   REQUIRE_THROWS_WITH(
-    DoMessage(
-      partOne, 0,
-      nlohmann::json{ { "t", MsgType::Activate },
-                      { "data", { { "caster", 0x15 }, { "target", 0 } } } }),
+    DoMessage(partOne, 0,
+              nlohmann::json{ { "t", MsgType::Activate },
+                              { "data",
+                                { { "caster", 0x15 },
+                                  { "target", 0 },
+                                  { "isSecondActivation", false } } } }),
     ContainsSubstring(
       "Bad hoster is attached to caster 0x15, expected 0xff000000, but "
       "found 0x0"));
@@ -94,11 +100,12 @@ TEST_CASE("Activate with incorrect WorldSpace", "[PartOne][espm]")
   partOne.SetUserActor(0, 0xff000000);
 
   REQUIRE_THROWS_WITH(
-    DoMessage(
-      partOne, 0,
-      nlohmann::json{
-        { "t", MsgType::Activate },
-        { "data", { { "caster", 0x14 }, { "target", barrelInWhiterun } } } }),
+    DoMessage(partOne, 0,
+              nlohmann::json{ { "t", MsgType::Activate },
+                              { "data",
+                                { { "caster", 0x14 },
+                                  { "target", barrelInWhiterun },
+                                  { "isSecondActivation", false } } } }),
     ContainsSubstring(
       "WorldSpace doesn't match: caster is in Tamriel (0x3c), target "
       "is in WhiterunWorld (0x1a26f)"));
@@ -107,8 +114,7 @@ TEST_CASE("Activate with incorrect WorldSpace", "[PartOne][espm]")
   partOne.DestroyActor(0xff000000);
 }
 
-TEST_CASE("Activation of unexisting ref doesn't throw anything",
-          "[PartOne][espm]")
+TEST_CASE("Activation of an unexisting ref doesn't throw", "[PartOne][espm]")
 {
   auto& partOne = GetPartOne();
   DoConnect(partOne, 0);
@@ -116,9 +122,11 @@ TEST_CASE("Activation of unexisting ref doesn't throw anything",
   partOne.SetUserActor(0, 0xff000000);
 
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", 0xdeadbeef } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", 0xdeadbeef },
+                                { "isSecondActivation", false } } } });
 
   DoDisconnect(partOne, 0);
   partOne.DestroyActor(0xff000000);
@@ -205,14 +213,18 @@ TEST_CASE("Activate DisplayCaseSmFlat01 in Whiterun", "[PartOne][espm]")
 
   REQUIRE(!ref.IsOpen());
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
   REQUIRE(ref.IsOpen());
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
   REQUIRE(!ref.IsOpen());
 
   REQUIRE(partOne.Messages().size() == 2);
@@ -243,9 +255,11 @@ TEST_CASE("Activate WRDoorMainGate01 in Whiterun", "[PartOne][espm]")
   auto& ref = partOne.worldState.GetFormAt<MpObjectReference>(refrId);
   ref.SetRelootTime(std::chrono::milliseconds(30));
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
   REQUIRE(partOne.Messages().size() >= 1);
   REQUIRE(partOne.Messages()[0].j["data"] == true);
   REQUIRE(partOne.Messages()[0].j["idx"] == ref.GetIdx());
@@ -309,9 +323,11 @@ TEST_CASE("Activate PurpleMountainFlower in Whiterun", "[PartOne][espm]")
   REQUIRE(!ref.IsHarvested());
 
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
 
   partOne.Tick(); // send deferred inventory update messages
 
@@ -503,20 +519,26 @@ TEST_CASE("Activate BarrelFood01 in Whiterun (open/close)", "[PartOne][espm]")
 
   // Open/close container
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
   REQUIRE(ref.IsOpen());
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", true } } } });
   REQUIRE(!ref.IsOpen());
 
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
   REQUIRE(ref.IsOpen());
 
   DoDisconnect(partOne, 0);
@@ -555,9 +577,11 @@ TEST_CASE("Activate torch", "[espm][PartOne]")
   REQUIRE(!ref.IsHarvested());
 
   DoMessage(partOne, 0,
-            nlohmann::json{
-              { "t", MsgType::Activate },
-              { "data", { { "caster", 0x14 }, { "target", refrId } } } });
+            nlohmann::json{ { "t", MsgType::Activate },
+                            { "data",
+                              { { "caster", 0x14 },
+                                { "target", refrId },
+                                { "isSecondActivation", false } } } });
 
   partOne.Tick(); // send deferred inventory update messages
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5d8b3a3efb5160f706e4757c30e507ab0f374771  | 
|--------|--------|

### Summary:
Introduced `isSecondActivation` to handle second activation events for containers and furniture, updating both client and server logic to process this new field.

**Key points**:
- Added `isSecondActivation` boolean to `ActivateMessageData` in `skymp5-client/src/services/messages/activateMessage.ts`.
- Updated `ActivationService` in `skymp5-client/src/services/services/activationService.ts` to include `isSecondActivation: false` in activation messages.
- Modified `RemoteServer` in `skymp5-client/src/services/services/remoteServer.ts` to handle second activation for containers and furniture.
- Updated `ActionListener` in `skymp5-server/cpp/server_guest_lib/ActionListener.cpp` to process `isSecondActivation` in `OnActivate`.
- Modified `MpObjectReference` in `skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp` to handle normal and second activation separately.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->