### PR TITLE
fix(skymp5-server): fix spontaneous transmigration of souls

### DIFF
--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -71,6 +71,7 @@ Napi::Object ScampServer::Init(Napi::Env env, Napi::Object exports)
       InstanceMethod("setUserActor", &ScampServer::SetUserActor),
       InstanceMethod("getUserActor", &ScampServer::GetUserActor),
       InstanceMethod("getUserGuid", &ScampServer::GetUserGuid),
+      InstanceMethod("isConnected", &ScampServer::IsConnected),
       InstanceMethod("getActorPos", &ScampServer::GetActorPos),
       InstanceMethod("getActorCellOrWorld", &ScampServer::GetActorCellOrWorld),
       InstanceMethod("getActorName", &ScampServer::GetActorName),
@@ -465,6 +466,17 @@ Napi::Value ScampServer::GetUserGuid(const Napi::CallbackInfo& info)
   auto userId = info[0].As<Napi::Number>().Uint32Value();
   try {
     return Napi::String::New(info.Env(), partOne->GetUserGuid(userId));
+  } catch (std::exception& e) {
+    throw Napi::Error::New(info.Env(), (std::string)e.what());
+  }
+  return info.Env().Undefined();
+}
+
+Napi::Value ScampServer::IsConnected(const Napi::CallbackInfo& info)
+{
+  auto userId = info[0].As<Napi::Number>().Uint32Value();
+  try {
+    return Napi::Boolean::New(info.Env(), partOne->IsConnected(userId));
   } catch (std::exception& e) {
     throw Napi::Error::New(info.Env(), (std::string)e.what());
   }

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -70,6 +70,7 @@ Napi::Object ScampServer::Init(Napi::Env env, Napi::Object exports)
       InstanceMethod("createActor", &ScampServer::CreateActor),
       InstanceMethod("setUserActor", &ScampServer::SetUserActor),
       InstanceMethod("getUserActor", &ScampServer::GetUserActor),
+      InstanceMethod("getUserGuid", &ScampServer::GetUserGuid),
       InstanceMethod("getActorPos", &ScampServer::GetActorPos),
       InstanceMethod("getActorCellOrWorld", &ScampServer::GetActorCellOrWorld),
       InstanceMethod("getActorName", &ScampServer::GetActorName),
@@ -453,6 +454,17 @@ Napi::Value ScampServer::GetUserActor(const Napi::CallbackInfo& info)
   auto userId = info[0].As<Napi::Number>().Uint32Value();
   try {
     return Napi::Number::New(info.Env(), partOne->GetUserActor(userId));
+  } catch (std::exception& e) {
+    throw Napi::Error::New(info.Env(), (std::string)e.what());
+  }
+  return info.Env().Undefined();
+}
+
+Napi::Value ScampServer::GetUserGuid(const Napi::CallbackInfo& info)
+{
+  auto userId = info[0].As<Napi::Number>().Uint32Value();
+  try {
+    return Napi::String::New(info.Env(), partOne->GetUserGuid(userId));
   } catch (std::exception& e) {
     throw Napi::Error::New(info.Env(), (std::string)e.what());
   }

--- a/skymp5-server/cpp/addon/ScampServer.h
+++ b/skymp5-server/cpp/addon/ScampServer.h
@@ -31,6 +31,7 @@ public:
   Napi::Value SetUserActor(const Napi::CallbackInfo& info);
   Napi::Value GetUserActor(const Napi::CallbackInfo& info);
   Napi::Value GetUserGuid(const Napi::CallbackInfo& info);
+  Napi::Value IsConnected(const Napi::CallbackInfo& info);
   Napi::Value GetActorPos(const Napi::CallbackInfo& info);
   Napi::Value GetActorCellOrWorld(const Napi::CallbackInfo& info);
   Napi::Value GetActorName(const Napi::CallbackInfo& info);

--- a/skymp5-server/cpp/addon/ScampServer.h
+++ b/skymp5-server/cpp/addon/ScampServer.h
@@ -30,6 +30,7 @@ public:
   Napi::Value CreateActor(const Napi::CallbackInfo& info);
   Napi::Value SetUserActor(const Napi::CallbackInfo& info);
   Napi::Value GetUserActor(const Napi::CallbackInfo& info);
+  Napi::Value GetUserGuid(const Napi::CallbackInfo& info);
   Napi::Value GetActorPos(const Napi::CallbackInfo& info);
   Napi::Value GetActorCellOrWorld(const Napi::CallbackInfo& info);
   Napi::Value GetActorName(const Napi::CallbackInfo& info);

--- a/skymp5-server/cpp/mp_common/Networking.cpp
+++ b/skymp5-server/cpp/mp_common/Networking.cpp
@@ -265,14 +265,21 @@ void Networking::HandlePacketServerside(Networking::IServer::OnPacket onPacket,
                nullptr, 0);
       idManager.freeId(userId);
       break;
-    case ID_NEW_INCOMING_CONNECTION:
+    case ID_NEW_INCOMING_CONNECTION: {
       userId = idManager.allocateId(packet->guid);
       if (userId == Networking::InvalidUserId) {
         throw std::runtime_error("idManager is full");
       }
+
+      std::array<char, 256> guidToStringDestination;
+      packet->guid.ToString(guidToStringDestination,
+                            std::size(guidToStringDestination));
+      std::string guid = guidToStringDestination.data();
+
       onPacket(state, userId, Networking::PacketType::ServerSideUserConnect,
-               nullptr, 0);
+               static_cast<PacketData>(guid.data()), guid.size());
       break;
+    }
     default:
       userId = idManager.find(packet->guid);
       if (packetId >= Networking::MinPacketId) {

--- a/skymp5-server/cpp/mp_common/Networking.cpp
+++ b/skymp5-server/cpp/mp_common/Networking.cpp
@@ -277,7 +277,8 @@ void Networking::HandlePacketServerside(Networking::IServer::OnPacket onPacket,
       std::string guid = guidToStringDestination.data();
 
       onPacket(state, userId, Networking::PacketType::ServerSideUserConnect,
-               static_cast<PacketData>(guid.data()), guid.size());
+               reinterpret_cast<PacketData>(guid.data()), guid.size());
+
       break;
     }
     default:

--- a/skymp5-server/cpp/mp_common/Networking.cpp
+++ b/skymp5-server/cpp/mp_common/Networking.cpp
@@ -2,6 +2,7 @@
 #include "Exceptions.h"
 #include "IdManager.h"
 #include "RakNet.h"
+#include <array>
 #include <fmt/format.h>
 #include <iostream>
 #include <memory>

--- a/skymp5-server/cpp/mp_common/Networking.cpp
+++ b/skymp5-server/cpp/mp_common/Networking.cpp
@@ -272,7 +272,7 @@ void Networking::HandlePacketServerside(Networking::IServer::OnPacket onPacket,
       }
 
       std::array<char, 256> guidToStringDestination;
-      packet->guid.ToString(guidToStringDestination,
+      packet->guid.ToString(guidToStringDestination.data(),
                             std::size(guidToStringDestination));
       std::string guid = guidToStringDestination.data();
 

--- a/skymp5-server/cpp/server_guest_lib/PartOne.h
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.h
@@ -54,6 +54,7 @@ public:
                        uint32_t cellOrWorld, ProfileId profileId = -1);
   void SetUserActor(Networking::UserId userId, uint32_t actorFormId);
   uint32_t GetUserActor(Networking::UserId userId);
+  std::string GetUserGuid(Networking::UserId userId);
   Networking::UserId GetUserByActor(uint32_t formId);
   void DestroyActor(uint32_t actorFormId);
   void SetRaceMenuOpen(uint32_t formId, bool open);
@@ -106,7 +107,8 @@ private:
     Bot
   };
 
-  void AddUser(Networking::UserId userId, UserType userType);
+  void AddUser(Networking::UserId userId, UserType userType,
+               const std::string& guid);
 
   void HandleMessagePacket(Networking::UserId userId,
                            Networking::PacketData data, size_t length);

--- a/skymp5-server/cpp/server_guest_lib/ServerState.h
+++ b/skymp5-server/cpp/server_guest_lib/ServerState.h
@@ -49,6 +49,8 @@ struct UserInfo
     packetHistoryStartTime;
 
   std::vector<std::vector<DeferredMessage>> deferredChannels;
+
+  std::string guid;
 };
 
 class ServerState
@@ -65,10 +67,11 @@ public:
     activePlaybacks; // do not modify directly, use requestedPlaybacks
   std::map<Networking::UserId, Playback> requestedPlaybacks;
 
-  void Connect(Networking::UserId userId);
+  void Connect(Networking::UserId userId, const std::string& guid);
   void Disconnect(Networking::UserId userId) noexcept;
   bool IsConnected(Networking::UserId userId) const;
   MpActor* ActorByUser(Networking::UserId userId);
+  const std::string& UserGuid(Networking::UserId userId);
   Networking::UserId UserByActor(MpActor* actor);
   void EnsureUserExists(Networking::UserId userId);
 };

--- a/skymp5-server/ts/scampNative.ts
+++ b/skymp5-server/ts/scampNative.ts
@@ -31,6 +31,7 @@ export interface ScampServer {
   destroyActor(formId: number): void;
   setUserActor(userId: number, actorFormId: number): void;
   getUserActor(userId: number): number;
+  getUserGuid(userId: number): string;
   getActorName(actorId: number): string;
   getActorPos(actorId: number): number[];
   getActorCellOrWorld(actorId: number): number;

--- a/skymp5-server/ts/scampNative.ts
+++ b/skymp5-server/ts/scampNative.ts
@@ -32,6 +32,7 @@ export interface ScampServer {
   setUserActor(userId: number, actorFormId: number): void;
   getUserActor(userId: number): number;
   getUserGuid(userId: number): string;
+  isConnected(userId: number): boolean;
   getActorName(actorId: number): string;
   getActorPos(actorId: number): number[];
   getActorCellOrWorld(actorId: number): number;

--- a/unit/Networking_HandlePacketServersideTest.cpp
+++ b/unit/Networking_HandlePacketServersideTest.cpp
@@ -76,8 +76,8 @@ TEST_CASE("HandlePacketServerside", "[Networking]")
         *reinterpret_cast<bool*>(called) = true;
         REQUIRE(idManager->find(0) == RakNetGUID(222));
         REQUIRE(userId == 0);
-        REQUIRE(length == 0);
-        REQUIRE(data == nullptr);
+        REQUIRE(length == 3);
+        REQUIRE(std::string(reinterpret_cast<const char*>(data), 3) == "222");
         REQUIRE(packetType ==
                 Networking::PacketType::ServerSideUserDisconnect);
       },

--- a/unit/Networking_HandlePacketServersideTest.cpp
+++ b/unit/Networking_HandlePacketServersideTest.cpp
@@ -76,8 +76,8 @@ TEST_CASE("HandlePacketServerside", "[Networking]")
         *reinterpret_cast<bool*>(called) = true;
         REQUIRE(idManager->find(0) == RakNetGUID(222));
         REQUIRE(userId == 0);
-        REQUIRE(length == 3);
-        REQUIRE(std::string(reinterpret_cast<const char*>(data), 3) == "222");
+        REQUIRE(length == 0);
+        REQUIRE(data == nullptr);
         REQUIRE(packetType ==
                 Networking::PacketType::ServerSideUserDisconnect);
       },
@@ -99,8 +99,8 @@ TEST_CASE("HandlePacketServerside", "[Networking]")
          size_t length) {
         *reinterpret_cast<bool*>(called) = true;
         REQUIRE(userId == 0);
-        REQUIRE(length == 0);
-        REQUIRE(data == nullptr);
+        REQUIRE(length == 3);
+        REQUIRE(std::string(reinterpret_cast<const char*>(data), 3) == "222");
         REQUIRE(packetType == Networking::PacketType::ServerSideUserConnect);
       },
       &called, &packet, idm);

--- a/unit/ServerStateTest.cpp
+++ b/unit/ServerStateTest.cpp
@@ -8,7 +8,7 @@ TEST_CASE("Connect/Disconnect", "[ServerState]")
   ServerState st;
 
   REQUIRE(!st.userInfo[1]);
-  st.Connect(1);
+  st.Connect(1, "A");
   REQUIRE(st.userInfo[1]);
   st.Disconnect(1);
   REQUIRE(!st.userInfo[1]);
@@ -19,13 +19,13 @@ TEST_CASE("maxConnectedId", "[ServerState]")
   ServerState st;
 
   REQUIRE(st.maxConnectedId == 0);
-  st.Connect(0);
+  st.Connect(0, "B");
   REQUIRE(st.maxConnectedId == 0);
-  st.Connect(1);
+  st.Connect(1, "C");
   REQUIRE(st.maxConnectedId == 1);
-  st.Connect(2);
+  st.Connect(2, "D");
   REQUIRE(st.maxConnectedId == 2);
-  st.Connect(3);
+  st.Connect(3, "E");
   REQUIRE(st.maxConnectedId == 3);
 
   st.Disconnect(2);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8f7384ffa2cb01a0fee097a3bc559a92abb5479b  | 
|--------|--------|

### Summary:
This pull request adds a `GetUserGuid` method to handle user GUIDs across the server, addressing potential issues with user identification and connection handling.

**Key points**:
- Added `GetUserGuid` method to `ScampServer` in `skymp5-server/cpp/addon/ScampServer.cpp` and `ScampServer.h`.
- Updated `Networking::HandlePacketServerside` in `skymp5-server/cpp/mp_common/Networking.cpp` to handle GUID extraction on new connections.
- Modified `PartOne::AddUser` and `PartOne::HandlePacket` in `skymp5-server/cpp/server_guest_lib/PartOne.cpp` to include GUID handling.
- Updated `ServerState::Connect` and added `ServerState::UserGuid` in `skymp5-server/cpp/server_guest_lib/ServerState.cpp` and `ServerState.h`.
- Updated TypeScript interface in `skymp5-server/ts/scampNative.ts` to include `getUserGuid`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->