### PR TITLE
fix(skymp5-server): fix form list reversed order

### DIFF
--- a/libespm/src/FLST.cpp
+++ b/libespm/src/FLST.cpp
@@ -13,11 +13,12 @@ FLST::Data FLST::GetData(
     [&](const char* type, uint32_t dataSize, const char* data) {
       if (!std::memcmp(type, "LNAM", 4)) {
         const auto formId = *reinterpret_cast<const uint32_t*>(data);
-        result.formIds.push_back(formId);
+        // push front by intention: order reversed in game files
+        // we care about indexes in PapyrusFormList
+        result.formIds.insert(result.formIds.begin(), formId);
       }
     },
     compressedFieldsCache);
-  std::reverse(result.formIds.begin(), result.formIds.end());
   return result;
 }
 

--- a/libespm/src/FLST.cpp
+++ b/libespm/src/FLST.cpp
@@ -13,9 +13,7 @@ FLST::Data FLST::GetData(
     [&](const char* type, uint32_t dataSize, const char* data) {
       if (!std::memcmp(type, "LNAM", 4)) {
         const auto formId = *reinterpret_cast<const uint32_t*>(data);
-        // push front by intention: order reversed in game files
-        // we care about indexes in PapyrusFormList
-        result.formIds.insert(result.formIds.begin(), formId);
+        result.formIds.push_back(formId);
       }
     },
     compressedFieldsCache);

--- a/unit/EspmTest.cpp
+++ b/unit/EspmTest.cpp
@@ -246,7 +246,7 @@ TEST_CASE("Loads FormList", "[espm]")
   REQUIRE(form.rec->GetType() == "FLST");
 
   auto data = reinterpret_cast<const espm::FLST*>(form.rec)->GetData(cache);
-  REQUIRE(data.formIds == std::vector<uint32_t>({ 0x3eab9, 0x4e4bb }));
+  REQUIRE(data.formIds == std::vector<uint32_t>({ 0x4e4bb, 0x3eab9 }));
 }
 
 TEST_CASE("Loads refr with primitive", "[espm]")

--- a/unit/PapyrusFormListTest.cpp
+++ b/unit/PapyrusFormListTest.cpp
@@ -17,10 +17,10 @@ TEST_CASE("GetSize/GetAt", "[Papyrus][FormList][espm]")
   REQUIRE(PapyrusFormList().GetSize(formlist, {}) == VarValue(2));
 
   VarValue element0 = PapyrusFormList().GetAt(formlist, { VarValue(0) });
-  REQUIRE(GetRecordPtr(element0).rec->GetId() == 0x3eab9);
+  REQUIRE(GetRecordPtr(element0).rec->GetId() == 0x4e4bb);
 
   VarValue element1 = PapyrusFormList().GetAt(formlist, { VarValue(1) });
-  REQUIRE(GetRecordPtr(element1).rec->GetId() == 0x4e4bb);
+  REQUIRE(GetRecordPtr(element1).rec->GetId() == 0x3eab9);
 
   REQUIRE(PapyrusFormList().GetAt(formlist, { VarValue(-1) }) ==
           VarValue::None());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 31e4845e4d648d0b5c0e3954d404b54440c1e4b8  | 
|--------|--------|

### Summary:
Update `libespm/src/FLST.cpp` to insert `formIds` at the front in `FLST::GetData` for correct order.

**Key points**:
- Modify `libespm/src/FLST.cpp` in `FLST::GetData` function.
- Change `formIds` storage from `push_back` and `reverse` to `insert` at the front.
- Ensure correct order of `formIds` as per game files for `PapyrusFormList` indexing.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->