### PR TITLE
feat(skymp5-server): add FindClosestReferenceOfTypeFromRef Papyrus native

### DIFF
--- a/misc/tests/test_findclosestreferenceoftypefromref.js
+++ b/misc/tests/test_findclosestreferenceoftypefromref.js
@@ -1,0 +1,35 @@
+const assert = require("node:assert");
+
+const main = async () => {
+  const akFormToPlace = { type: 'espm', desc: mp.getDescFromId(0x7) };
+  const barrelInWhiterun = 0x4cc2d;
+  const barrelObject = { type: 'form', desc: mp.getDescFromId(barrelInWhiterun) };
+
+  const barrelBaseForm = { type: 'espm', desc: mp.get(barrelInWhiterun, 'baseDesc') };
+
+  let searchRes;
+
+  // expect no actor to be found around the barrel
+  searchRes = mp.callPapyrusFunction("global", "Game", "FindClosestReferenceOfTypeFromRef", null, [akFormToPlace, barrelObject, 100]);
+  assert.deepEqual(searchRes, null);
+
+  // placing
+  const placedActor = mp.callPapyrusFunction("method", "ObjectReference", "PlaceAtMe", barrelObject, [akFormToPlace, 1, true, false]);
+
+  // expect the actor to be found around the barrel
+  searchRes = mp.callPapyrusFunction("global", "Game", "FindClosestReferenceOfTypeFromRef", null, [akFormToPlace, barrelObject, 100]);
+  assert.deepEqual(searchRes, placedActor);
+
+  // vice-versa
+  searchRes = mp.callPapyrusFunction("global", "Game", "FindClosestReferenceOfTypeFromRef", null, [barrelBaseForm, placedActor, 100]);
+  assert.deepEqual(searchRes, barrelObject);
+};
+
+main().then(() => {
+  console.log("Test passed!");
+  process.exit(0);
+}).catch((err) => {
+  console.log("Test failed!")
+  console.error(err);
+  process.exit(1);
+});

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -932,10 +932,6 @@ void MpObjectReference::Subscribe(MpObjectReference* emitter,
     return;
   }
 
-  // I don't know how often Subscrbe is called but I suppose
-  // it is to be invoked quite frequently. In this case, each
-  // time if below is performed we are obtaining a copy of
-  // MpChangeForm which can be large. See what it consists of.
   if (!emitter->pImpl->onInitEventSent &&
       listener->GetChangeForm().profileId != -1) {
     emitter->pImpl->onInitEventSent = true;

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusGame.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusGame.h
@@ -13,8 +13,19 @@ public:
 
   VarValue IncrementStat(VarValue self,
                          const std::vector<VarValue>& arguments);
+
+  // In Skyrim it's not a native, just a wrapper around
+  // FindClosestReferenceOfAnyTypeInList
+  // TODO: implement FindClosestReferenceOfAnyTypeInList native instead
   VarValue FindClosestReferenceOfAnyTypeInListFromRef(
     VarValue self, const std::vector<VarValue>& arguments);
+
+  // In Skyrim it's not a native, just a wrapper around
+  // FindClosestReferenceOfType
+  // TODO: implement FindClosestReferenceOfType native instead
+  VarValue FindClosestReferenceOfTypeFromRef(
+    VarValue self, const std::vector<VarValue>& arguments);
+
   VarValue GetPlayer(VarValue self, const std::vector<VarValue>& arguments);
   VarValue ShowRaceMenu(VarValue self, const std::vector<VarValue>& arguments);
   VarValue ShowLimitedRaceMenu(VarValue self,

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -379,6 +379,8 @@ VarValue PapyrusObjectReference::PlaceAtMe(
 
   bool isExplosion = akFormToPlace.rec->GetType() == "EXPL";
   if (isExplosion) {
+    spdlog::warn(
+      "PapyrusObjectReference::PlaceAtMe - explosion is not supported yet");
     // Well sp snippet fails ATM. and I don't want to overpollute clients and
     // network with those placeatme s for now
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 56236d39be18c5f191e32809bf3f5127147df4d3  | 
|--------|--------|

feat(skymp5-server): add FindClosestReferenceOfTypeFromRef Papyrus native

### Summary:
Add `FindClosestReferenceOfTypeFromRef` Papyrus native function to `PapyrusGame` and test it with a new script.

**Key points**:
- **New Functionality**:
  - Add `FindClosestReferenceOfTypeFromRef` to `PapyrusGame` in `PapyrusGame.cpp` and `PapyrusGame.h`.
  - Uses `FindClosestReferenceHelper` to find the closest reference of a specific type.
- **Testing**:
  - Add `test_findclosestreferenceoftypefromref.js` to test the new function.
- **Code Cleanup**:
  - Remove unnecessary comments in `Subscribe` function in `MpObjectReference.cpp`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->