### PR TITLE
refact(skyrim-platform): improve AddItemEx

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
@@ -664,13 +664,6 @@ void TESModPlatform::AddItemEx(
     return;
   }
 
-  auto tuple = std::make_tuple(
-    containerRefr->formID, item, health, enchantment, maxCharge,
-    removeEnchantmentOnUnequip, chargePercent,
-    (std::string)textDisplayData.data(), soul, poison, poisonCount);
-
-  using Tuple = decltype(tuple);
-
   RE::ExtraDataList* extraList = nullptr;
 
   const bool isShieldLike =

--- a/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
@@ -671,8 +671,6 @@ void TESModPlatform::AddItemEx(
 
   using Tuple = decltype(tuple);
 
-  thread_local std::map<Tuple, RE::ExtraDataList*> g_lastEquippedExtraList[2];
-
   RE::ExtraDataList* extraList = nullptr;
 
   const bool isShieldLike =
@@ -685,35 +683,12 @@ void TESModPlatform::AddItemEx(
     (item->formType == RE::FormType::Armor && !isShieldLike) ||
     item->formType == RE::FormType::Light;
 
-  // Our extra-less items support is disgusting! EquipItem crashes when we try
-  // an iron sword. This hack saves our slav lives
-  if (item->formType != RE::FormType::Ammo && health <= 1)
-    health = 1.01f;
-
   if (health > 1 || enchantment || chargePercent > 0 ||
       strlen(textDisplayData.data()) > 0 || (soul > 0 && soul <= 5) ||
-      poison || g_worn || g_wornLeft) {
+      poison) {
     extraList = CreateExtraDataList();
 
     auto extraList_ = reinterpret_cast<void*>(extraList);
-
-    if (g_worn) {
-      if (isClothes) {
-        auto extra = reinterpret_cast<RE::BSExtraData*>(
-          new MyExtra<RE::ExtraDataType::kWorn>);
-        addExtra(extraList_, static_cast<uint32_t>(RE::ExtraDataType::kWorn),
-                 extra);
-      }
-    }
-
-    if (g_wornLeft) {
-      if (isClothes) {
-        auto extra = reinterpret_cast<RE::BSExtraData*>(
-          new MyExtra<RE::ExtraDataType::kWornLeft>);
-        addExtra(extraList_,
-                 static_cast<uint32_t>(RE::ExtraDataType::kWornLeft), extra);
-      }
-    }
 
     if (health > 1) {
       addExtra(extraList_, static_cast<uint32_t>(RE::ExtraDataType::kHealth),
@@ -804,7 +779,6 @@ void TESModPlatform::AddItemEx(
         }
 
         if (countDelta > 0) {
-          g_lastEquippedExtraList[g_worn ? false : true][tuple] = extraList;
           g_nativeCallRequirements.gameThrQ->AddTask([=] {
             if (actor != (void*)RE::TESForm::LookupByID(refrId))
               return;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `AddItemEx` in `PapyrusTESModPlatform.cpp` to remove unused code and simplify logic for adding extra data to items.
> 
>   - **Refactoring in `PapyrusTESModPlatform.cpp`:**
>     - Removed unused `tuple` and `g_lastEquippedExtraList` in `AddItemEx()`.
>     - Removed redundant checks and code related to `g_worn` and `g_wornLeft` for clothing items.
>     - Simplified logic for creating `extraList` and adding extra data based on item properties.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 27be3745fc2913e67424cd69cb8450af5616aac6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->