### PR TITLE
fix(skymp5-server): fix containers becoming unusable randomly

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1442,12 +1442,10 @@ void MpObjectReference::ProcessActivateNormal(
   } else if (t == espm::CONT::kType && actorActivator) {
     EnsureBaseContainerAdded(loader);
 
-    auto occupantPos = this->occupant ? this->occupant->GetPos() : NiPoint3();
     auto occupantCellOrWorld =
       this->occupant ? this->occupant->GetCellOrWorld() : FormDesc();
 
     constexpr float kOccupationReach = 512.f;
-    auto distanceToOccupant = (occupantPos - GetPos()).Length();
 
     if (CheckIfObjectCanStartOccupyThis(activationSource, kOccupationReach)) {
       if (this->occupant) {
@@ -1469,12 +1467,10 @@ void MpObjectReference::ProcessActivateNormal(
     activationSource.SendOpenContainer(GetFormId());
   } else if (t == "FURN" && actorActivator) {
 
-    auto occupantPos = this->occupant ? this->occupant->GetPos() : NiPoint3();
     auto occupantCellOrWorld =
       this->occupant ? this->occupant->GetCellOrWorld() : FormDesc();
 
     constexpr float kOccupationReach = 256.f;
-    auto distanceToOccupant = (occupantPos - GetPos()).Length();
 
     if (CheckIfObjectCanStartOccupyThis(activationSource, kOccupationReach)) {
       if (this->occupant) {
@@ -1573,25 +1569,31 @@ bool MpObjectReference::CheckIfObjectCanStartOccupyThis(
                  GetFormId(), activationSource.GetFormId());
     return true;
   }
+
   if (this->occupant->IsDisabled()) {
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is "
                  "disabled (activationSource = {:x})",
                  GetFormId(), activationSource.GetFormId());
     return true;
   }
-  if (distanceToOccupant > occupationReach) {
+
+  auto& occupantPos = this->occupant->GetPos();
+  auto distanceToOccupantSqr = (occupantPos - GetPos()).SqrLength();
+  if (distanceToOccupantSqr > occupationReach * occupationReach) {
     isActivationSourceAllowedToActivateThis = true;
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is too "
                  "far away (activationSource = {:x})",
                  GetFormId(), activationSource.GetFormId());
     return true;
   }
+
   if (occupantCellOrWorld != GetCellOrWorld()) {
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is in "
                  "another cell/world (activationSource = {:x})",
                  GetFormId(), activationSource.GetFormId());
     return true;
   }
+
   if (this->occupant == &activationSource) {
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is "
                  "already this object (activationSource = {:x})",

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1442,9 +1442,6 @@ void MpObjectReference::ProcessActivateNormal(
   } else if (t == espm::CONT::kType && actorActivator) {
     EnsureBaseContainerAdded(loader);
 
-    auto occupantCellOrWorld =
-      this->occupant ? this->occupant->GetCellOrWorld() : FormDesc();
-
     constexpr float kOccupationReach = 512.f;
 
     if (CheckIfObjectCanStartOccupyThis(activationSource, kOccupationReach)) {
@@ -1466,9 +1463,6 @@ void MpObjectReference::ProcessActivateNormal(
     // TODO: rename SendOpenContainer to SendActivate
     activationSource.SendOpenContainer(GetFormId());
   } else if (t == "FURN" && actorActivator) {
-
-    auto occupantCellOrWorld =
-      this->occupant ? this->occupant->GetCellOrWorld() : FormDesc();
 
     constexpr float kOccupationReach = 256.f;
 
@@ -1580,13 +1574,13 @@ bool MpObjectReference::CheckIfObjectCanStartOccupyThis(
   auto& occupantPos = this->occupant->GetPos();
   auto distanceToOccupantSqr = (occupantPos - GetPos()).SqrLength();
   if (distanceToOccupantSqr > occupationReach * occupationReach) {
-    isActivationSourceAllowedToActivateThis = true;
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is too "
                  "far away (activationSource = {:x})",
                  GetFormId(), activationSource.GetFormId());
     return true;
   }
 
+  auto &occupantCellOrWorld = this->occupant->GetCellOrWorld();
   if (occupantCellOrWorld != GetCellOrWorld()) {
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is in "
                  "another cell/world (activationSource = {:x})",

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1580,7 +1580,7 @@ bool MpObjectReference::CheckIfObjectCanStartOccupyThis(
     return true;
   }
 
-  auto &occupantCellOrWorld = this->occupant->GetCellOrWorld();
+  auto& occupantCellOrWorld = this->occupant->GetCellOrWorld();
   if (occupantCellOrWorld != GetCellOrWorld()) {
     spdlog::info("MpObjectReference::ProcessActivate {:x} - occupant is in "
                  "another cell/world (activationSource = {:x})",

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -232,6 +232,8 @@ private:
   void ProcessActivateNormal(MpObjectReference& activationSource);
   bool ProcessActivateSecond(MpObjectReference& activationSource);
   void ActivateChilds();
+  bool CheckIfObjectCanStartOccupyThis(MpObjectReference& activationSource,
+                                       float occupationReach);
 
   bool everSubscribedOrListened = false;
   std::unique_ptr<std::set<MpObjectReference*>> listeners;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes container usability issue by centralizing occupant checks in `CheckIfObjectCanStartOccupyThis()` in `MpObjectReference`.
> 
>   - **Behavior**:
>     - Fixes issue with containers becoming unusable by centralizing occupant checks in `CheckIfObjectCanStartOccupyThis()`.
>     - Updates `ProcessActivateNormal()` and `ProcessActivateSecond()` in `MpObjectReference.cpp` to use `CheckIfObjectCanStartOccupyThis()`.
>   - **Functions**:
>     - Adds `CheckIfObjectCanStartOccupyThis()` to `MpObjectReference` in `MpObjectReference.cpp` and `MpObjectReference.h`.
>   - **Logging**:
>     - Adds detailed logging in `CheckIfObjectCanStartOccupyThis()` for various occupant states.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 71563085bfa39664f06f2bd2fb9c998884b43b81. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->