### PR TITLE
fix(skymp5-server): fix division by 0 in MongoDatabase

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
@@ -114,8 +114,6 @@ void MongoDatabase::Iterate(const IterateCallback& iterateCallback)
 
   int numParts = std::min(totalDocuments, 100);
 
-  int partSize = totalDocuments / numParts;
-
   std::atomic<int> totalDocumentsProcessed = 0;
 
   std::string hash;
@@ -157,6 +155,7 @@ void MongoDatabase::Iterate(const IterateCallback& iterateCallback)
       // space is to be replaced with ] in case of empty array
       threadsDocumentsJsonArray[i] = "[ ";
 
+      int partSize = totalDocuments / numParts;
       auto skip = i * partSize;
       auto limit = (i == numParts - 1) ? totalDocuments - skip : partSize;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix division by zero in `MongoDatabase::Iterate` by moving `partSize` calculation inside the loop.
> 
>   - **Bug Fix**:
>     - Fix division by zero in `MongoDatabase::Iterate` by moving `partSize` calculation inside the loop where it is used.
>     - Ensures `partSize` is calculated only when `numParts` is non-zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b9a34e9721c1de2f9dc68bdb96c8e811b8253c6c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->