### PR TITLE
internal: fix CMake syntax in run_test_unit.cmake

### DIFF
--- a/cmake/run_test_unit.cmake
+++ b/cmake/run_test_unit.cmake
@@ -14,7 +14,7 @@ if(temp_coverage)
 endif()
 
 # Emscripten support
-if("${EXE_PATH}" MATCHES ".*\.js")
+if("${EXE_PATH}" MATCHES ".*\\.js")
   execute_process(COMMAND node ${EXE_PATH}
     RESULT_VARIABLE res
     OUTPUT_VARIABLE out


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes regex syntax in `run_test_unit.cmake` to correctly match `.js` files.
> 
>   - **Syntax Fix**:
>     - Corrects regex in `run_test_unit.cmake` to properly escape the backslash for matching `.js` files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for bd2b2d4b39a0b40dca33e852ce2ba90edf1e6690. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->