### PR TITLE
fix(skymp5-server): fix SP3 list functions API & upload an example

### DIFF
--- a/misc/wip_sp3.js
+++ b/misc/wip_sp3.js
@@ -1,0 +1,118 @@
+// This is an incomplete test for an incomplete SP3 implementation
+
+// TODO(1): Implement typed return values for methods and static functions (e.g. `sp.Game.getFormEx` should return a `Form` object, not a plain object)
+// TODO(2): Normalize class names to match SkyrimPlatform's naming convention (e.g. objectreference -> ObjectReference)
+// TODO(3): Implement 2 versions of method names: one with the SP-style/normalized naming convention (e.g. `getFormEx`) and one with the Papyrus naming convention (e.g. `GetFormEx`)
+
+function sortClassesByInheritance(classes, api) {
+    let classesSorted = new Array;
+  
+    while (classes.length > 0) {
+        let stack = [classes.shift()];
+        let baseClass = stack[0];
+        while (baseClass) {
+            baseClass = api._sp3GetBaseClass(baseClass);
+            if (baseClass) {
+                stack.push(baseClass);
+            }
+        }
+        stack.reverse();
+        for (let i = 0; i < stack.length; i++) {
+            if (!classesSorted.includes(stack[i])) {
+                classesSorted.push(stack[i]);
+            }
+        }
+        classes = classes.filter(c => !stack.includes(c));
+    }
+  
+    return classesSorted;
+  }
+  
+  function createSkyrimPlatform(api) {
+  
+    let sp = {};
+  
+    //console.log(api.get)
+  
+    let classes = sortClassesByInheritance(api._sp3ListClasses(), api);
+  
+    console.log({classes})
+  
+    classes.forEach(className => {
+        const baseClassName = api._sp3GetBaseClass(className);
+        const staticFunctions = api._sp3ListStaticFunctions(className);
+        const methods = api._sp3ListMethods(className);
+  
+        console.log({className, baseClassName, staticFunctions, methods: JSON.stringify(methods)})
+  
+        const f = eval(`(function ${className}() {})`);
+  
+        if (baseClassName !== "") {
+            f.prototype = Object.create(sp[baseClassName].prototype);
+        }
+  
+        f.prototype.constructor = f;
+  
+        methods.forEach(method => {
+            // TODO(1):
+            // const impl = api._sp3GetFunctionImplementation(sp, className, method);
+            // f.prototype[method] = function () {
+            //   const resWithoutClass = impl(this, ...arguments);
+            // };
+  
+            f.prototype[method] = api._sp3GetFunctionImplementation(sp, className, method);
+        });
+  
+        staticFunctions.forEach(staticFunction => {
+            // TODO(1):
+            f[staticFunction] = api._sp3GetFunctionImplementation(sp, className, staticFunction);
+        });
+  
+        f["from"] = function (obj) {
+            if (api._sp3DynamicCast(obj, className)) {
+                let res = new f();
+                Object.assign(res, obj);
+                return res;
+            }
+            return null;
+        }
+  
+        sp[className] = f;
+    });
+  
+    return sp;
+  }
+  
+  const sp = createSkyrimPlatform(mp);
+  
+  // console.log(1);
+  
+  // console.log(sp.Game.getFormEx(0xff000000));
+  // console.log(sp.Game.getFormEx(0x7));
+  
+  // console.log(sp.Utility.randomInt(1, 100));
+  
+  // console.log("===", sp.Utility.randomInt(1, 1));
+  
+  // sp.Skymp.setDefaultActor();
+  // console.log(sp.Game.getPlayer());
+  
+  //var createdId = mp.createActor(0, [0,0,0], 0, 0x3c);
+  //console.log("createdId!", createdId);
+  
+  var form = sp.game.GetFormEx(4278190082);
+  console.log("form!", form);
+  form = { desc: "0", type:"form"};
+  console.log("form!", form);
+  
+  var actor = sp.actor.from(form);
+  console.log("actor!", actor);
+  
+  sp.skymp.SetDefaultActor(actor);
+  console.log("player!", sp.game.GetPlayer());
+  
+  var pos = [sp.game.GetPlayer().GetPositionX()];
+  console.log({pos})
+  
+  process.exit(0);
+  

--- a/misc/wip_sp3.js
+++ b/misc/wip_sp3.js
@@ -6,7 +6,7 @@
 
 function sortClassesByInheritance(classes, api) {
     let classesSorted = new Array;
-  
+
     while (classes.length > 0) {
         let stack = [classes.shift()];
         let baseClass = stack[0];
@@ -24,50 +24,50 @@ function sortClassesByInheritance(classes, api) {
         }
         classes = classes.filter(c => !stack.includes(c));
     }
-  
+
     return classesSorted;
-  }
-  
-  function createSkyrimPlatform(api) {
-  
+}
+
+function createSkyrimPlatform(api) {
+
     let sp = {};
-  
+
     //console.log(api.get)
-  
+
     let classes = sortClassesByInheritance(api._sp3ListClasses(), api);
-  
-    console.log({classes})
-  
+
+    console.log({ classes })
+
     classes.forEach(className => {
         const baseClassName = api._sp3GetBaseClass(className);
         const staticFunctions = api._sp3ListStaticFunctions(className);
         const methods = api._sp3ListMethods(className);
-  
-        console.log({className, baseClassName, staticFunctions, methods: JSON.stringify(methods)})
-  
+
+        console.log({ className, baseClassName, staticFunctions, methods: JSON.stringify(methods) })
+
         const f = eval(`(function ${className}() {})`);
-  
+
         if (baseClassName !== "") {
             f.prototype = Object.create(sp[baseClassName].prototype);
         }
-  
+
         f.prototype.constructor = f;
-  
+
         methods.forEach(method => {
             // TODO(1):
             // const impl = api._sp3GetFunctionImplementation(sp, className, method);
             // f.prototype[method] = function () {
             //   const resWithoutClass = impl(this, ...arguments);
             // };
-  
+
             f.prototype[method] = api._sp3GetFunctionImplementation(sp, className, method);
         });
-  
+
         staticFunctions.forEach(staticFunction => {
             // TODO(1):
             f[staticFunction] = api._sp3GetFunctionImplementation(sp, className, staticFunction);
         });
-  
+
         f["from"] = function (obj) {
             if (api._sp3DynamicCast(obj, className)) {
                 let res = new f();
@@ -76,43 +76,42 @@ function sortClassesByInheritance(classes, api) {
             }
             return null;
         }
-  
+
         sp[className] = f;
     });
-  
+
     return sp;
-  }
-  
-  const sp = createSkyrimPlatform(mp);
-  
-  // console.log(1);
-  
-  // console.log(sp.Game.getFormEx(0xff000000));
-  // console.log(sp.Game.getFormEx(0x7));
-  
-  // console.log(sp.Utility.randomInt(1, 100));
-  
-  // console.log("===", sp.Utility.randomInt(1, 1));
-  
-  // sp.Skymp.setDefaultActor();
-  // console.log(sp.Game.getPlayer());
-  
-  //var createdId = mp.createActor(0, [0,0,0], 0, 0x3c);
-  //console.log("createdId!", createdId);
-  
-  var form = sp.game.GetFormEx(4278190082);
-  console.log("form!", form);
-  form = { desc: "0", type:"form"};
-  console.log("form!", form);
-  
-  var actor = sp.actor.from(form);
-  console.log("actor!", actor);
-  
-  sp.skymp.SetDefaultActor(actor);
-  console.log("player!", sp.game.GetPlayer());
-  
-  var pos = [sp.game.GetPlayer().GetPositionX()];
-  console.log({pos})
-  
-  process.exit(0);
-  
+}
+
+const sp = createSkyrimPlatform(mp);
+
+// console.log(1);
+
+// console.log(sp.Game.getFormEx(0xff000000));
+// console.log(sp.Game.getFormEx(0x7));
+
+// console.log(sp.Utility.randomInt(1, 100));
+
+// console.log("===", sp.Utility.randomInt(1, 1));
+
+// sp.Skymp.setDefaultActor();
+// console.log(sp.Game.getPlayer());
+
+//var createdId = mp.createActor(0, [0,0,0], 0, 0x3c);
+//console.log("createdId!", createdId);
+
+var form = sp.game.GetFormEx(4278190082);
+console.log("form!", form);
+form = { desc: "0", type: "form" };
+console.log("form!", form);
+
+var actor = sp.actor.from(form);
+console.log("actor!", actor);
+
+sp.skymp.SetDefaultActor(actor);
+console.log("player!", sp.game.GetPlayer());
+
+var pos = [sp.game.GetPlayer().GetPositionX()];
+console.log({ pos })
+
+process.exit(0);

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1346,9 +1346,10 @@ Napi::Value ScampServer::SP3ListStaticFunctions(const Napi::CallbackInfo& info)
     auto staticFunctions =
       partOne->worldState.GetPapyrusVm().ListStaticFunctions(className.data());
     auto result = Napi::Array::New(info.Env(), staticFunctions.size());
+    size_t i = 0;
     for (auto& staticFunction : staticFunctions) {
-      result.Set(result.Length(),
-                 Napi::String::New(info.Env(), staticFunction.data()));
+      result.Set(i, Napi::String::New(info.Env(), staticFunction.data()));
+      ++i;
     }
     return result;
   } catch (std::exception& e) {
@@ -1363,9 +1364,11 @@ Napi::Value ScampServer::SP3ListMethods(const Napi::CallbackInfo& info)
     auto methods =
       partOne->worldState.GetPapyrusVm().ListMethods(className.data());
     auto result = Napi::Array::New(info.Env(), methods.size());
+    size_t i = 0;
     for (auto& method : methods) {
-      result.Set(result.Length(),
+      result.Set(i,
                  Napi::String::New(info.Env(), method.data()));
+                 ++i;
     }
     return result;
   } catch (std::exception& e) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes off-by-one errors in `SP3ListStaticFunctions` and `SP3ListMethods` in `ScampServer.cpp` and adds `wip_sp3.js` as an SP3 implementation example.
> 
>   - **Bug Fixes**:
>     - Fix off-by-one error in `SP3ListStaticFunctions()` and `SP3ListMethods()` in `ScampServer.cpp` by using an index variable `i` instead of `result.Length()` to set array elements.
>   - **New Example**:
>     - Add `wip_sp3.js` as an incomplete test/example for SP3 implementation with TODOs for typed return values, class name normalization, and method naming conventions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for e9a446d884ea4fe27f6b14dedeb9564ee5933219. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->