### PR TITLE
feat(skymp5-server): set spawn point in PlaceAtMe

### DIFF
--- a/misc/tests/test_spawnpoint_of_placed_actors.js
+++ b/misc/tests/test_spawnpoint_of_placed_actors.js
@@ -1,0 +1,25 @@
+// This test was not checked
+const assert = require("node:assert");
+
+const main = async () => {
+  const barrelInWhiterunId = 0x0004cc2d;
+  const baseNpcId = 0x00023abe;
+
+  const barrelInWhiterun = mp.callPapyrusFunction("global", "Game", "getFormEx", null, [barrelInWhiterunId]);
+  const baseNpc = mp.callPapyrusFunction("global", "Game", "getFormEx", null, [baseNpcId]);
+  const placedNpc = mp.callPapyrusFunction("method", "ObjectReference", "placeAtMe", barrelInWhiterun, [baseNpc, 1, false, false]);
+
+  const placedNpcSpawnPoint = mp.get(mp.getIdFromDesc(placedNpc), "spawnPoint");
+  const barrelInWhiterunLocationalData = mp.get(mp.getIdFromDesc(barrelInWhiterun), "locationalData");
+
+  assert.deepEqual(placedNpcSpawnPoint, barrelInWhiterunLocationalData);
+};
+
+main().then(() => {
+  console.log("Test passed!");
+  process.exit(0);
+}).catch((err) => {
+  console.log("Test failed!")
+  console.error(err);
+  process.exit(1);
+});

--- a/misc/tests/test_spawnpoint_of_placed_actors.js
+++ b/misc/tests/test_spawnpoint_of_placed_actors.js
@@ -1,4 +1,3 @@
-// This test was not checked
 const assert = require("node:assert");
 
 const main = async () => {
@@ -9,8 +8,8 @@ const main = async () => {
   const baseNpc = mp.callPapyrusFunction("global", "Game", "getFormEx", null, [baseNpcId]);
   const placedNpc = mp.callPapyrusFunction("method", "ObjectReference", "placeAtMe", barrelInWhiterun, [baseNpc, 1, false, false]);
 
-  const placedNpcSpawnPoint = mp.get(mp.getIdFromDesc(placedNpc), "spawnPoint");
-  const barrelInWhiterunLocationalData = mp.get(mp.getIdFromDesc(barrelInWhiterun), "locationalData");
+  const placedNpcSpawnPoint = mp.get(mp.getIdFromDesc(placedNpc.desc), "spawnPoint");
+  const barrelInWhiterunLocationalData = mp.get(mp.getIdFromDesc(barrelInWhiterun.desc), "locationalData");
 
   assert.deepEqual(placedNpcSpawnPoint, barrelInWhiterunLocationalData);
 };

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -406,6 +406,7 @@ VarValue PapyrusObjectReference::PlaceAtMe(
   if (akFormToPlace.rec->GetType() == "NPC_") {
     auto actor = new MpActor(locationalData, callbacks, baseId);
     newRefr.reset(actor);
+    actor->SetSpawnPoint(locationalData);
   } else {
     newRefr.reset(
       new MpObjectReference(locationalData, callbacks, baseId, type));

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.cpp
@@ -406,7 +406,6 @@ VarValue PapyrusObjectReference::PlaceAtMe(
   if (akFormToPlace.rec->GetType() == "NPC_") {
     auto actor = new MpActor(locationalData, callbacks, baseId);
     newRefr.reset(actor);
-    actor->SetSpawnPoint(locationalData);
   } else {
     newRefr.reset(
       new MpObjectReference(locationalData, callbacks, baseId, type));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set spawn point for NPCs in `PlaceAtMe` function in `PapyrusObjectReference.cpp`.
> 
>   - **Behavior**:
>     - In `PapyrusObjectReference::PlaceAtMe`, set spawn point for NPCs using `SetSpawnPoint(locationalData)` when placing them.
>   - **Misc**:
>     - No changes to other object types or additional functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for edb33ca54c6b01ae3c4caa3f294cf0773269e3f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->