### PR TITLE
Bash damage 

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
@@ -9,7 +9,10 @@
 namespace internal {
 
 bool IsUnarmedAttack(const uint32_t sourceFormId)
-{
+{ 
+  if (sourceFormId.isBashDamage == true) {
+    return false;
+  }
   return sourceFormId == 0x1f4;
 }
 
@@ -147,6 +150,10 @@ float TES5DamageFormulaImpl::CalculateDamage() const
   // TODO(#463): add sneak modifier
   float damage = incomingDamage * CalcArmorDamagePenalty();
 
+// Bash Damage = Base Damage+(Skill Modifier*Perk Bonus)+(Stamina Modifier)
+  if (hitData.isBashAttack) {
+    damage *= 0.3f;
+  }
   if (hitData.isPowerAttack) {
     damage *= 2.f;
   }

--- a/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
@@ -8,9 +8,9 @@
 
 namespace internal {
 
-bool IsUnarmedAttack(const uint32_t sourceFormId)
+bool IsUnarmedAttack(const uint32_t sourceFormId, bool isBashAttack)
 { 
-  if (sourceFormId.isBashDamage == true) {
+  if (isBashDamage == true) {
     return false;
   }
   return sourceFormId == 0x1f4;
@@ -121,9 +121,9 @@ float TES5DamageFormulaImpl::CalcUnarmedDamage() const
   return espm::GetData<espm::RACE>(raceId, espmProvider).unarmedDamage;
 }
 
-float TES5DamageFormulaImpl::DetermineDamageFromSource(uint32_t source) const
+float TES5DamageFormulaImpl::DetermineDamageFromSource(uint32_t source, bool isBashAttack) const
 {
-  return IsUnarmedAttack(source) ? CalcUnarmedDamage() : CalcWeaponRating();
+  return IsUnarmedAttack(source, isBashAttack) ? CalcUnarmedDamage() : CalcWeaponRating();
 }
 
 float TES5DamageFormulaImpl::CalcArmorDamagePenalty() const
@@ -144,7 +144,7 @@ float TES5DamageFormulaImpl::CalcArmorDamagePenalty() const
 
 float TES5DamageFormulaImpl::CalculateDamage() const
 {
-  const float incomingDamage = DetermineDamageFromSource(hitData.source);
+  const float incomingDamage = DetermineDamageFromSource(hitData.source, hitData.isBashAttack);
 
   // TODO(#461): add difficulty multiplier
   // TODO(#463): add sneak modifier


### PR DESCRIPTION
I do not know why the bash attack was counted as an unarmed attack, so I implemented a condition: if it is a bash attack, then isUnarmedAttack is set to false so we calculate weaponAttack (CalcWeaponRating). This allows us to correctly calculate weapon damage, as we can have bash damage when wielding a weapon. In the weapon damage calculations, I multiplied the total damage by 0.3, which reflects the typical damage ratio of a bash attack compared to a regular attack.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix bash attack classification and adjust damage calculation in `TES5DamageFormula.cpp`.
> 
>   - **Behavior**:
>     - Modify `IsUnarmedAttack` in `TES5DamageFormula.cpp` to return `false` for bash attacks, ensuring they are not treated as unarmed.
>     - Adjust `CalculateDamage` in `TES5DamageFormulaImpl` to multiply damage by `0.3` for bash attacks, reflecting typical bash damage ratio.
>   - **Misc**:
>     - Add comment for bash damage formula in `CalculateDamage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 9016322337ef5d7ac75668cc7788f90731c42683. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->