### PR TITLE
fix(skymp5-client): fix error in magicSyncService.ts

### DIFF
--- a/skymp5-client/src/services/services/magicSyncService.ts
+++ b/skymp5-client/src/services/services/magicSyncService.ts
@@ -154,10 +154,9 @@ export class MagicSyncService extends ClientListener {
         const leftHandEquipmentType = ac.getEquippedItemType(SlotType.Left);
         const rightHandEquipmentType = ac.getEquippedItemType(SlotType.Right);
 
-        // @ts-expect-error (TODO: Remove in 2.10.0)
-        if (leftHandEquipmentType === EquippedItemType.SpellOrScroll || leftHandEquipmentType === EquippedItemType.Staff ||
-            // @ts-expect-error (TODO: Remove in 2.10.0)
-            rightHandEquipmentType === EquippedItemType.SpellOrScroll || rightHandEquipmentType === EquippedItemType.Staff) {
+        // TODO: Spell => SpellOrScroll, since Spell is now a deprecated name
+        if (leftHandEquipmentType === EquippedItemType.Spell || leftHandEquipmentType === EquippedItemType.Staff ||
+            rightHandEquipmentType === EquippedItemType.Spell || rightHandEquipmentType === EquippedItemType.Staff) {
             return true;
         }
 

--- a/skymp5-client/src/services/services/magicSyncService.ts
+++ b/skymp5-client/src/services/services/magicSyncService.ts
@@ -154,7 +154,7 @@ export class MagicSyncService extends ClientListener {
         const leftHandEquipmentType = ac.getEquippedItemType(SlotType.Left);
         const rightHandEquipmentType = ac.getEquippedItemType(SlotType.Right);
 
-        // TODO: Spell => SpellOrScroll, since Spell is now a deprecated name
+        // TODO: Spell => SpellOrScroll, since Spell is now a deprecated name (TODO: Remove in 2.10.0)
         if (leftHandEquipmentType === EquippedItemType.Spell || leftHandEquipmentType === EquippedItemType.Staff ||
             rightHandEquipmentType === EquippedItemType.Spell || rightHandEquipmentType === EquippedItemType.Staff) {
             return true;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes logic in `magicSyncService.ts` to use `EquippedItemType.Spell` instead of deprecated `EquippedItemType.SpellOrScroll`.
> 
>   - **Behavior**:
>     - Fixes logic in `isAnyMagicStuffEquiped()` in `magicSyncService.ts` to use `EquippedItemType.Spell` instead of `EquippedItemType.SpellOrScroll`.
>     - Updates comment to reflect that `Spell` is now the correct term, replacing the deprecated `SpellOrScroll`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 05f7512beaa35b4b7c920ca561b73a5f45edba1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->