### PR TITLE
feat(skymp5-client): adjust default game hours offset

### DIFF
--- a/skymp5-client/src/services/services/timeService.ts
+++ b/skymp5-client/src/services/services/timeService.ts
@@ -8,7 +8,7 @@ export class TimeService extends ClientListener {
 
     public getTime() {
         const hoursOffsetSetting = this.sp.settings["skymp5-client"]["hoursOffset"];
-        const hoursOffset = typeof hoursOffsetSetting === "number" ? hoursOffsetSetting : -3;
+        const hoursOffset = typeof hoursOffsetSetting === "number" ? hoursOffsetSetting : 0;
         const hoursOffsetMs = hoursOffset * 60 * 60 * 1000;
 
         const d = new Date(Date.now() + hoursOffsetMs);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `hoursOffset` to `0` in `TimeService` to align game time closer to UTC.
> 
>   - **Behavior**:
>     - Change default `hoursOffset` from `-3` to `0` in `getTime()` of `TimeService` class.
>     - Affects game time calculation by aligning it closer to UTC.
>   - **Misc**:
>     - No other changes in logic or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for fb845d61c505c415edb7c833c080dccc771950d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->