### PR TITLE
feat: add (MGEF & SPEL) reverse and calculation for spell damage to server side

### DIFF
--- a/libespm/include/libespm/MGEF.h
+++ b/libespm/include/libespm/MGEF.h
@@ -61,11 +61,41 @@ public:
   };
   static_assert(static_cast<std::underlying_type_t<EffectType>>(
                   EffectType::VampireLord) == 46);
+
+  enum class Flags : uint32_t
+  {
+    Hostile = 0x00000001,
+    Recover = 0x00000002,
+    Detrimental = 0x00000004,
+    SnapToNavmesh = 0x00000008,
+    NoHitEvent = 0x00000010,
+    DispelEffects = 0x00000100,
+    NoDuration = 0x00000200,
+    NoMagnitude = 0x00000400,
+    NoArea = 0x00000800,
+    FXPersist = 0x00001000,
+    GoryVisual = 0x00004000,
+    HideInUI = 0x00008000,
+    NoRecast = 0x00020000,
+    PowerAffectsMagnitude = 0x00200000,
+    PowerAffectsDuration = 0x00400000,
+    Painless = 0x04000000,
+    NoHitEffect = 0x08000000,
+    NoDeathDispel = 0x10000000
+  };
+
   struct DATA
   {
     // primary actor value
+    Flags flags;
     ActorValue primaryAV = espm::ActorValue::None;
     EffectType effectType;
+
+    [[nodiscard]] inline bool IsFlagSet(Flags flag) const
+    {
+      return (static_cast<uint32_t>(flags) & static_cast<uint32_t>(flag)) ==
+        static_cast<uint32_t>(flag);
+    }
   };
 
   struct Data

--- a/libespm/include/libespm/SPEL.h
+++ b/libespm/include/libespm/SPEL.h
@@ -22,9 +22,79 @@ public:
     Voice = 0x0B
   };
 
+  enum class SpellFlags
+  {
+    None = 0,
+    NotAutoCalculate = 0x1,
+    Unknown1 = 0x10000,
+    PCStartSpell = 0x20000,
+    Unknown2 = 0x40000,
+    AreaEffectIgnoresLineofSight = 0x80000,
+    IgnoreResistance = 0x100000,
+    DisallowSpellAbsorbOrReflect = 0x200000,
+    Unknown3 = 0x400000,
+    NoDualCastModifications = 0x800000,
+  };
+
+  enum class CastType
+  {
+    ConstantEffect = 0x00,
+    FireAndForget = 0x01,
+    Concentration = 0x02,
+  };
+
+  enum class Delivery
+  {
+    Self = 0x00,
+    Contact = 0x01,
+    Aimed = 0x02,
+    TargetActor = 0x03,
+    TargetLocation = 0x04,
+  };
+
+  struct SPITData
+  {
+    // if auto-calc, game bases cost on the sum of the effect costs
+    uint32_t spellCost = 0;
+    SpellFlags flags = SpellFlags::None;
+    SpellType type = SpellType::Spell;
+
+    // if auto-calc, game uses the maximum of the casting times of the effects
+    // instead
+    float chargeTime = 0.f;
+    CastType castType = CastType::ConstantEffect;
+    Delivery delivery = Delivery::Self;
+
+    // determines minimum duration of a Concentrated spell
+    float castDuration = 0.f;
+
+    // valid for Delivery TargetActor or TargetLocation
+    float range = 0.f;
+
+    uint32_t perkFormId = 0;
+  };
+
+  static_assert(sizeof(SPITData) == 36);
+
+  struct EFIT
+  {
+    float magnitude = 0.f;
+    uint32_t areaOfEffect = 0;
+    uint32_t duration = 0;
+  };
+
+  static_assert(sizeof(EFIT) == 12);
+
+  struct Effect
+  {
+    uint32_t effectFormId = 0;
+    const EFIT* effectItem = nullptr;
+  };
+
   struct Data
   {
-    SpellType type = SpellType::Spell;
+    const SPITData* spellItem = nullptr;
+    std::vector<Effect> effects{};
   };
 
   Data GetData(CompressedFieldsCache& compressedFieldsCache) const noexcept;

--- a/libespm/src/MGEF.cpp
+++ b/libespm/src/MGEF.cpp
@@ -13,6 +13,7 @@ MGEF::Data MGEF::GetData(
     this,
     [&](const char* type, uint32_t size, const char* data) {
       if (!std::memcmp(type, "DATA", 4)) {
+        result.data.flags = *reinterpret_cast<const Flags*>(data);
         result.data.effectType = EffectType{
           *reinterpret_cast<const std::underlying_type_t<EffectType>*>(data +
                                                                        0x40)

--- a/libespm/src/SPEL.cpp
+++ b/libespm/src/SPEL.cpp
@@ -12,7 +12,11 @@ SPEL::Data SPEL::GetData(
     this,
     [&](const char* type, uint32_t dataSize, const char* data) {
       if (!std::memcmp(type, "SPIT", 4)) {
-        result.type = *reinterpret_cast<const SpellType*>(data + 8);
+        result.spellItem = reinterpret_cast<const SPITData*>(data);
+      } else if (!std::memcmp(type, "EFID", 4)) {
+        result.effects.emplace_back(*reinterpret_cast<const uint32_t*>(data));
+      } else if (!std::memcmp(type, "EFIT", 4)) {
+        result.effects.back().effectItem = reinterpret_cast<const EFIT*>(data);
       }
     },
     compressedFieldsCache);

--- a/libespm/src/SPEL.cpp
+++ b/libespm/src/SPEL.cpp
@@ -14,7 +14,8 @@ SPEL::Data SPEL::GetData(
       if (!std::memcmp(type, "SPIT", 4)) {
         result.spellItem = reinterpret_cast<const SPITData*>(data);
       } else if (!std::memcmp(type, "EFID", 4)) {
-        result.effects.emplace_back(*reinterpret_cast<const uint32_t*>(data));
+        result.effects.emplace_back(
+          Effect{ *reinterpret_cast<const uint32_t*>(data), nullptr });
       } else if (!std::memcmp(type, "EFIT", 4)) {
         result.effects.back().effectItem = reinterpret_cast<const EFIT*>(data);
       }

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1173,10 +1173,11 @@ void ActionListener::OnSpellCast(const RawMessageData& rawMsgData,
 
   targetActorPtr->NetSetPercentages(targetActorValues, caster);
 
-  spdlog::info("Target {0:x} is hitted by {1:x} spell. By caster: {2:x}, "
-               "from castingSource : {3})",
-               spellCastData.target, spellCastData.spell, spellCastData.caster,
-               static_cast<uint32_t>(spellCastData.castingSource));
+  spdlog::info(
+    "Target {0:x} is hitted by {1:x} spell on {2} damage. By caster: {3:x}, "
+    "from castingSource : {4})",
+    spellCastData.target, spellCastData.spell, damage, spellCastData.caster,
+    static_cast<uint32_t>(spellCastData.castingSource));
 }
 
 void ActionListener::OnUnknown(const RawMessageData& rawMsgData)

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1540,7 +1540,7 @@ void MpActor::ApplyMagicEffect(espm::Effects::Effect& effect, bool hasSweetpie,
     auto spells = ChangeForm().learnedSpells.GetLearnedSpells();
     for (auto spellId : spells) {
       auto spellData = espm::GetData<espm::SPEL>(spellId, worldState);
-      if (spellData.type == espm::SPEL::SpellType::Disease) {
+      if (spellData.spellItem->type == espm::SPEL::SpellType::Disease) {
         spdlog::trace("Curing disease {:x}", spellId);
         RemoveSpell(spellId);
       }

--- a/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
@@ -198,10 +198,24 @@ float TES5SpellDamageFormulaImpl::GetBaseSpellDamage() const
   const auto spellData =
     espm::GetData<espm::SPEL>(spellCastData.spell, espmProvider);
 
-  // TODO Write damage calculation
-  std::ignore = spellData;
+  float damage = 0.f;
 
-  return 0.f;
+  for (const auto& effect : spellData.effects) {
+
+    if (!effect.effectItem || effect.effectFormId == 0) {
+      continue;
+    }
+
+    auto magicEffect =
+      espm::GetData<espm::MGEF>(effect.effectFormId, espmProvider);
+
+    if (magicEffect.data.IsFlagSet(espm::MGEF::Flags::Hostile) &&
+        magicEffect.data.primaryAV == espm::ActorValue::Health) {
+
+      damage += effect.effectItem->magnitude;
+    }
+  }
+  return damage;
 }
 
 float TES5SpellDamageFormulaImpl::CalculateDamage() const

--- a/skyrim-platform/src/platform_se/skyrim_platform/MagicApi.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/MagicApi.cpp
@@ -57,15 +57,16 @@ JsValue MagicApi::CastSpellImmediate(const JsFunctionArguments& args)
   const auto spellFormId =
     static_cast<RE::FormID>(static_cast<double>(args[3]));
 
-  const auto magicTarget = RE::TESForm::LookupByID<RE::TESObjectREFR>(
-    static_cast<uint32_t>(static_cast<double>(args[4])));
+  const auto magicTargetFormId =
+    static_cast<uint32_t>(static_cast<double>(args[4]));
 
   const auto aimAngle = static_cast<float>(static_cast<double>(args[5]));
   const auto aimHeading = static_cast<float>(static_cast<double>(args[6]));
   const RE::Projectile::ProjectileRot projectileAngles{ aimAngle, aimHeading };
 
   g_nativeCallRequirements.gameThrQ->AddTask(
-    [spellFormId, actorFormId, castingSource, magicTarget, projectileAngles,
+    [spellFormId, actorFormId, castingSource, magicTargetFormId,
+     projectileAngles,
 
      animVars =
        skymp::magic::details::GetAnimationVariablesFromJSArg(args[7])]() {
@@ -101,6 +102,9 @@ JsValue MagicApi::CastSpellImmediate(const JsFunctionArguments& args)
         return;
       }
 
+      auto* magicTarget =
+        RE::TESForm::LookupByID<RE::TESObjectREFR>(magicTargetFormId);
+
       if (pSpell->GetCastingType() ==
           RE::MagicSystem::CastingType::kConcentration) {
 
@@ -126,22 +130,10 @@ JsValue MagicApi::CastSpellImmediate(const JsFunctionArguments& args)
       if (pSpell->data.delivery ==
           RE::MagicSystem::Delivery::kTargetLocation) {
         // TODO we need recalculate origin, cast ray from head to crosshair
-        // direction
-
-        // Maybe anything of this?
-        // pActor->GetLookingAtLocation();
-        // Or
-        // auto* crosshairPickData = RE::CrosshairPickData::GetSingleton();
-        // Or
-        /*const auto hud =
-          RE::UI::GetSingleton()->GetMenu<RE::HUDMenu>(RE::HUDMenu::MENU_NAME);
-
-        hud->UpdateCrosshairMagicTarget(true);*/
-        // Or
         auto viewDirection = pActor->Get3D2()->world.rotate.GetVectorY();
         viewDirection.Unitize();
         origin += viewDirection * 200.f;
-        origin.z = pActor->GetPositionZ();
+        origin.z = pActor->GetPositionZ() + 10.f;
       }
 
       RE::Projectile::LaunchData launchData(pActor, origin, projectileAngles,


### PR DESCRIPTION
Add (MGEF & SPEL) reverse and calculation for spell damage to server side
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add server-side spell damage calculation and update related data structures and logic for MGEF and SPEL records.
> 
>   - **Behavior**:
>     - Implement spell damage calculation in `TES5SpellDamageFormulaImpl::CalculateDamage()` in `TES5DamageFormula.cpp`.
>     - Update `ActionListener::OnSpellCast()` in `ActionListener.cpp` to log spell damage.
>   - **Data Structures**:
>     - Add `Flags` enum to `MGEF` and `SpellFlags`, `CastType`, `Delivery`, `SPITData`, `EFIT`, `Effect` structs to `SPEL` in `MGEF.h` and `SPEL.h`.
>     - Update `MGEF::GetData()` and `SPEL::GetData()` in `MGEF.cpp` and `SPEL.cpp` to handle new data structures.
>   - **Logic**:
>     - Modify `MpActor::ApplyMagicEffect()` in `MpActor.cpp` to handle new spell types and effects.
>     - Update `MpActor::ApplyMagicEffects()` in `MpActor.cpp` to apply multiple effects.
>   - **Misc**:
>     - Fix logging message in `ActionListener::OnSpellCast()` in `ActionListener.cpp` to include damage value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 506ea990e9ae51073269322be6d1de4f7999715a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->