### PR TITLE
feat(skymp5-server): normalize class names for future SP3 support

### DIFF
--- a/misc/wip_sp3.js
+++ b/misc/wip_sp3.js
@@ -1,8 +1,8 @@
 // This is an incomplete test for an incomplete SP3 implementation
 
 // TODO(1): Implement typed return values for methods and static functions (e.g. `sp.Game.getFormEx` should return a `Form` object, not a plain object)
-// TODO(2): Normalize class names to match SkyrimPlatform's naming convention (e.g. objectreference -> ObjectReference)
 // TODO(3): Implement 2 versions of method names: one with the SP-style/normalized naming convention (e.g. `getFormEx`) and one with the Papyrus naming convention (e.g. `GetFormEx`)
+// We can use TSConverter for this, see its sources in skyrim-platform
 
 function sortClassesByInheritance(classes, api) {
     let classesSorted = new Array;

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.h
@@ -6,7 +6,7 @@
 class PapyrusActor final : public IPapyrusClass<PapyrusActor>
 {
 public:
-  const char* GetName() override { return "actor"; }
+  const char* GetName() override { return "Actor"; }
 
   DEFINE_METHOD_SPSNIPPET(DrawWeapon);
   DEFINE_METHOD_SPSNIPPET(UnequipAll);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusCell.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusCell.h
@@ -6,7 +6,7 @@
 class PapyrusCell final : public IPapyrusClass<PapyrusCell>
 {
 public:
-  const char* GetName() override { return "cell"; }
+  const char* GetName() override { return "Cell"; }
 
   VarValue IsAttached(VarValue self, const std::vector<VarValue>& arguments);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusDebug.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusDebug.h
@@ -5,7 +5,7 @@
 class PapyrusDebug final : public IPapyrusClass<PapyrusDebug>
 {
 public:
-  const char* GetName() override { return "debug"; }
+  const char* GetName() override { return "Debug"; }
 
   DEFINE_STATIC_SPSNIPPET(Notification);
   DEFINE_STATIC_SPSNIPPET(MessageBox);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusEffectShader.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusEffectShader.h
@@ -5,7 +5,7 @@
 class PapyrusEffectShader final : public IPapyrusClass<PapyrusEffectShader>
 {
 public:
-  const char* GetName() override { return "effectshader"; }
+  const char* GetName() override { return "EffectShader"; }
   VarValue Play(VarValue self, const std::vector<VarValue>& arguments);
   VarValue Stop(VarValue self, const std::vector<VarValue>& arguments);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusFaction.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusFaction.h
@@ -6,7 +6,7 @@
 class PapyrusFaction final : public IPapyrusClass<PapyrusFaction>
 {
 public:
-  const char* GetName() override { return "faction"; }
+  const char* GetName() override { return "Faction"; }
 
   VarValue GetReaction(VarValue self, const std::vector<VarValue>& arguments);
   // SetReaction ignored, because no way to edit factions forever?

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusForm.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusForm.h
@@ -5,7 +5,7 @@
 class PapyrusForm final : public IPapyrusClass<PapyrusForm>
 {
 public:
-  const char* GetName() override { return "form"; }
+  const char* GetName() override { return "Form"; }
 
   VarValue RegisterForSingleUpdate(VarValue self,
                                    const std::vector<VarValue>& arguments);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusFormList.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusFormList.h
@@ -4,7 +4,7 @@
 class PapyrusFormList final : public IPapyrusClass<PapyrusFormList>
 {
 public:
-  const char* GetName() override { return "formlist"; }
+  const char* GetName() override { return "FormList"; }
 
   VarValue GetSize(VarValue self, const std::vector<VarValue>& arguments);
   VarValue GetAt(VarValue self, const std::vector<VarValue>& arguments);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusGame.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusGame.h
@@ -5,7 +5,7 @@
 class PapyrusGame final : public IPapyrusClass<PapyrusGame>
 {
 public:
-  const char* GetName() override { return "game"; }
+  const char* GetName() override { return "Game"; }
 
   DEFINE_STATIC_SPSNIPPET(ForceThirdPerson);
   DEFINE_STATIC_SPSNIPPET(DisablePlayerControls);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusKeyword.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusKeyword.h
@@ -6,7 +6,7 @@
 class PapyrusKeyword final : public IPapyrusClass<PapyrusKeyword>
 {
 public:
-  const char* GetName() override { return "keyword"; }
+  const char* GetName() override { return "Keyword"; }
 
   VarValue GetKeyword(VarValue self, const std::vector<VarValue>& arguments);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusMessage.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusMessage.h
@@ -5,7 +5,7 @@
 class PapyrusMessage final : public IPapyrusClass<PapyrusMessage>
 {
 public:
-  const char* GetName() override { return "message"; }
+  const char* GetName() override { return "Message"; }
 
   DEFINE_METHOD_SPSNIPPET(Show);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusNetImmerse.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusNetImmerse.h
@@ -5,7 +5,7 @@
 class PapyrusNetImmerse final : public IPapyrusClass<PapyrusNetImmerse>
 {
 public:
-  const char* GetName() override { return "netimmerse"; }
+  const char* GetName() override { return "NetImmerse"; }
 
   VarValue SetNodeTextureSet(VarValue self,
                              const std::vector<VarValue>& arguments);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusObjectReference.h
@@ -7,7 +7,7 @@ class PapyrusObjectReference final
   : public IPapyrusClass<PapyrusObjectReference>
 {
 public:
-  const char* GetName() override { return "objectreference"; }
+  const char* GetName() override { return "ObjectReference"; }
 
   VarValue IsHarvested(VarValue self, const std::vector<VarValue>& arguments);
   VarValue IsDisabled(VarValue self, const std::vector<VarValue>& arguments);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusPotion.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusPotion.h
@@ -5,7 +5,7 @@
 class PapyrusPotion final : public IPapyrusClass<PapyrusPotion>
 {
 public:
-  const char* GetName() override { return "potion"; }
+  const char* GetName() override { return "Potion"; }
 
   VarValue IsFood(VarValue self, const std::vector<VarValue>& arguments);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusSkymp.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusSkymp.h
@@ -4,7 +4,7 @@
 class PapyrusSkymp final : public IPapyrusClass<PapyrusSkymp>
 {
 public:
-  const char* GetName() override { return "skymp"; }
+  const char* GetName() override { return "Skymp"; }
 
   VarValue SetDefaultActor(VarValue self,
                            const std::vector<VarValue>& arguments);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusSound.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusSound.h
@@ -4,7 +4,7 @@
 class PapyrusSound final : public IPapyrusClass<PapyrusSound>
 {
 public:
-  const char* GetName() override { return "sound"; }
+  const char* GetName() override { return "Sound"; }
 
   VarValue Play(VarValue slef, const std::vector<VarValue>& arguments);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.h
@@ -4,7 +4,7 @@
 class PapyrusUtility final : public IPapyrusClass<PapyrusUtility>
 {
 public:
-  const char* GetName() override { return "utility"; }
+  const char* GetName() override { return "Utility"; }
 
   VarValue Wait(VarValue self, const std::vector<VarValue>& arguments);
   VarValue RandomInt(VarValue slef, const std::vector<VarValue>& arguments);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusVisualEffect.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusVisualEffect.h
@@ -4,7 +4,7 @@
 class PapyrusVisualEffect final : public IPapyrusClass<PapyrusVisualEffect>
 {
 public:
-  const char* GetName() override { return "visualeffect"; }
+  const char* GetName() override { return "VisualEffect"; }
   VarValue Play(VarValue self, const std::vector<VarValue>& arguments);
   VarValue Stop(VarValue self, const std::vector<VarValue>& arguments);
 

--- a/unit/PapyrusDebugTest.cpp
+++ b/unit/PapyrusDebugTest.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Notification", "[Papyrus][Debug]")
           nlohmann::json{ { "type", "spSnippet" },
                           { "snippetIdx", 4294967295 },
                           { "selfId", 0 },
-                          { "class", "debug" },
+                          { "class", "Debug" },
                           { "function", "Notification" },
                           { "arguments", { "Hello, world!" } } });
   REQUIRE(p.Messages()[2].userId == 3);
@@ -48,7 +48,7 @@ TEST_CASE("Notification", "[Papyrus][Debug]")
           nlohmann::json{ { "type", "spSnippet" },
                           { "snippetIdx", 4294967295 },
                           { "selfId", 0 },
-                          { "class", "debug" },
+                          { "class", "Debug" },
                           { "function", "Notification" },
                           { "arguments", { "Hello, \"world!\"" } } });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Normalize class names in `skymp5-server` to match SkyrimPlatform's naming conventions by updating `GetName()` methods.
> 
>   - **Class Name Normalization**:
>     - Updated `GetName()` return values in `PapyrusActor.h`, `PapyrusCell.h`, and `PapyrusDebug.h` to use capitalized class names (e.g., "actor" to "Actor").
>     - Similar updates in `PapyrusEffectShader.h`, `PapyrusFaction.h`, and `PapyrusForm.h`.
>     - Continued updates in `PapyrusFormList.h`, `PapyrusGame.h`, and `PapyrusKeyword.h`.
>     - Further updates in `PapyrusMessage.h`, `PapyrusNetImmerse.h`, and `PapyrusObjectReference.h`.
>     - Final updates in `PapyrusPotion.h`, `PapyrusSkymp.h`, `PapyrusSound.h`, `PapyrusUtility.h`, and `PapyrusVisualEffect.h`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 0b36da2eed19760227c02a0bb2dae491f6d14ac1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->