### PR TITLE
internal: fix reference errors in wip_sp3.js

### DIFF
--- a/misc/wip_sp3.js
+++ b/misc/wip_sp3.js
@@ -130,7 +130,7 @@ function createSkyrimPlatform(api) {
 
             const impl = api._sp3GetFunctionImplementation(sp, className, staticFunction);
             f[staticFunction] = function () {
-                verifyTickIds(api, Array.from(arguments), spPrivate, className, method);
+                verifyTickIds(api, Array.from(arguments), spPrivate, className, staticFunction);
                 const resWithoutClass = impl(...arguments);
                 if (resWithoutClass === null || typeof resWithoutClass !== "object") {
                     return resWithoutClass;
@@ -154,7 +154,7 @@ function createSkyrimPlatform(api) {
                 spPrivate.isCtorEnabled = false;
                 resWithClass.type = obj.type;
                 resWithClass.desc = obj.desc;
-                return res;
+                return resWithClass;
             }
             return null;
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix reference errors in `createSkyrimPlatform()` in `wip_sp3.js` by correcting function parameters and return values.
> 
>   - **Behavior**:
>     - Fix reference error in `createSkyrimPlatform()` by changing `method` to `staticFunction` in `verifyTickIds()` call.
>     - Correct return value in `createSkyrimPlatform()` from `res` to `resWithClass` in `staticFunction` implementation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b8c673b6b9469786ef291fd11087f030f25c6453. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->