### PR TITLE
internal: support both server-side and client-side objects in wip_sp3.js

### DIFF
--- a/misc/wip_sp3.js
+++ b/misc/wip_sp3.js
@@ -63,6 +63,30 @@ function verifyTickIds(api, args, spPrivate, className, functionName) {
     }
 }
 
+let assign = (targetObject, sourceObject) => {
+    if (sourceObject.desc !== undefined) {
+        // Server-side/gamemode raw objects have desc and type properties
+        targetObject.desc = sourceObject.desc;
+        targetObject.type = sourceObject.type;
+
+        // Never check it in runtime again
+        assign = (targetObject, sourceObject) => {
+            targetObject.desc = sourceObject.desc;
+            targetObject.type = sourceObject.type;
+        };
+
+    } else if (sourceObject._skyrimPlatform_indexInPool !== undefined) {
+        // Client-side objects have _skyrimPlatform_indexInPool property starting with SP3 Update in 2024
+        // In previous version, they were completely native objects, without javascript properties
+        targetObject._skyrimPlatform_indexInPool = sourceObject._skyrimPlatform_indexInPool;
+
+        // Never check it in runtime again
+        assign = (targetObject, sourceObject) => {
+            targetObject._skyrimPlatform_indexInPool = sourceObject._skyrimPlatform_indexInPool;
+        };
+    }
+}
+
 function createSkyrimPlatform(api) {
     const sp = {};
     const spPrivate = {
@@ -120,8 +144,7 @@ function createSkyrimPlatform(api) {
                 spPrivate.isCtorEnabled = true;
                 const resWithClass = new ctor();
                 spPrivate.isCtorEnabled = false;
-                resWithClass.type = resWithoutClass.type;
-                resWithClass.desc = resWithoutClass.desc;
+                assign(resWithClass, resWithoutClass);
                 return resWithClass;
             };
         });
@@ -140,8 +163,7 @@ function createSkyrimPlatform(api) {
                 spPrivate.isCtorEnabled = true;
                 const resWithClass = new ctor();
                 spPrivate.isCtorEnabled = false;
-                resWithClass.type = resWithoutClass.type;
-                resWithClass.desc = resWithoutClass.desc;
+                assign(resWithClass, resWithoutClass);
                 return resWithClass;
             };
         });
@@ -152,8 +174,7 @@ function createSkyrimPlatform(api) {
                 spPrivate.isCtorEnabled = true;
                 const resWithClass = new f();
                 spPrivate.isCtorEnabled = false;
-                resWithClass.type = obj.type;
-                resWithClass.desc = obj.desc;
+                assign(resWithClass, obj);
                 return resWithClass;
             }
             return null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `assign` function in `wip_sp3.js` to support server-side and client-side object properties, updating constructors and methods to use it.
> 
>   - **Behavior**:
>     - Introduces `assign` function in `wip_sp3.js` to handle server-side and client-side object properties.
>     - `assign` function checks for `desc` and `type` for server-side objects, and `_skyrimPlatform_indexInPool` for client-side objects.
>     - Replaces direct property assignments with `assign` in `createSkyrimPlatform()` for constructors and methods.
>   - **Functions**:
>     - Modifies `createSkyrimPlatform()` to use `assign` for `resWithClass` in constructors and methods.
>     - Updates `from` method to use `assign` for object conversion.
>   - **Misc**:
>     - Removes redundant property assignments in favor of `assign` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for fe634c126a094e3c5f812d1d3e47a1aad697c2ee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->