### PR TITLE
internal: enable nuget binary caching for windows jobs

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -24,6 +24,10 @@ inputs:
   SKYMP5_PATCHES_PAT:
     description: "PAT for skymp5-patches repository"
     required: true
+  NUGET_GITHUB_TOKEN:
+    description: "A GitHub token for GitHub Packages (Nuget)"
+    required: false
+    default: ""
   EMSCRIPTEN:
     description: "Set to true if building for Emscripten"
     required: false
@@ -101,6 +105,30 @@ runs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+    - name: 'Setup NuGet Credentials'
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        `C:/vcpkg/vcpkg.exe fetch nuget | tail -n 1`
+
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "Pull request detected."
+          nuget sources add \
+            -source "https://nuget.pkg.github.com/${{ github.actor }}/index.json" \
+            -storepasswordincleartext \
+            -name "GitHub" \
+            -username "${{ github.actor }}" \
+            -password "${{ inputs.NUGET_GITHUB_TOKEN }}"
+        else
+          echo "Push event detected."
+          nuget sources add \
+            -source "https://nuget.pkg.github.com/skyrim-multiplayer/index.json" \
+            -storepasswordincleartext \
+            -name "GitHub" \
+            -username "skyrim-multiplayer" \
+            -password "${{ inputs.NUGET_GITHUB_TOKEN }}"
+        fi
 
     # Download Skyrim SE data files
     - uses: suisei-cn/actions-download-file@v1

--- a/.github/workflows/pr-windows-skyrim-ae-indev.yml
+++ b/.github/workflows/pr-windows-skyrim-ae-indev.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
   VCPKG_FEATURE_FLAGS: 'manifests'
 
 jobs:
@@ -33,3 +33,4 @@ jobs:
           DIST_ARTIFACT_NAME: dist-indev
           SERVER_DIST_ARTIFACT_NAME: server-dist-indev
           SKYMP5_PATCHES_PAT: ${{ secrets.SKYMP5_PATCHES_PAT }}
+          NUGET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-windows-skyrim-ae-sweetpie.yml
+++ b/.github/workflows/pr-windows-skyrim-ae-sweetpie.yml
@@ -34,4 +34,3 @@ jobs:
           SERVER_DIST_ARTIFACT_NAME: server-dist-sweetpie
           SKYMP5_PATCHES_PAT: ${{ secrets.SKYMP5_PATCHES_PAT }}
           NUGET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/pr-windows-skyrim-ae-sweetpie.yml
+++ b/.github/workflows/pr-windows-skyrim-ae-sweetpie.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
   VCPKG_FEATURE_FLAGS: 'manifests'
 
 jobs:
@@ -33,3 +33,5 @@ jobs:
           DIST_ARTIFACT_NAME: dist-sweetpie
           SERVER_DIST_ARTIFACT_NAME: server-dist-sweetpie
           SKYMP5_PATCHES_PAT: ${{ secrets.SKYMP5_PATCHES_PAT }}
+          NUGET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/pr-windows-skyrim-ae.yml
+++ b/.github/workflows/pr-windows-skyrim-ae.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
   VCPKG_FEATURE_FLAGS: 'manifests'
 
 jobs:
@@ -35,3 +35,4 @@ jobs:
           DIST_ARTIFACT_NAME: dist
           SERVER_DIST_ARTIFACT_NAME: server-dist
           SKYMP5_PATCHES_PAT: ${{ secrets.SKYMP5_PATCHES_PAT }}
+          NUGET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-windows-skyrim-se.yml
+++ b/.github/workflows/pr-windows-skyrim-se.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
   VCPKG_FEATURE_FLAGS: 'manifests'
 
 jobs:
@@ -35,3 +35,4 @@ jobs:
           DIST_ARTIFACT_NAME: dist-1.5
           SERVER_DIST_ARTIFACT_NAME: server-dist-1.5
           SKYMP5_PATCHES_PAT: ${{ secrets.SKYMP5_PATCHES_PAT }}
+          NUGET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable NuGet binary caching for Windows jobs by adding NuGet credentials and updating binary sources in GitHub Actions workflows.
> 
>   - **GitHub Actions**:
>     - Add `NUGET_GITHUB_TOKEN` input in `action.yml` for NuGet credentials.
>     - Update `VCPKG_BINARY_SOURCES` to include `nuget` in `pr-windows-skyrim-ae-indev.yml`, `pr-windows-skyrim-ae-sweetpie.yml`, `pr-windows-skyrim-ae.yml`, and `pr-windows-skyrim-se.yml`.
>     - Setup NuGet credentials in `action.yml` for Windows runners, handling both pull request and push events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for aae33ce95c0821943b6e682802551324e150e3d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->