### PR TITLE
refact(skyrim-platform): remove incorrect comment

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/PapyrusTESModPlatform.cpp
@@ -159,7 +159,6 @@ void TESModPlatform::SetWeaponDrawnMode(IVM* vm, StackID stackId,
   if (g_nativeCallRequirements.gameThrQ) {
     auto formId = actor->formID;
     g_nativeCallRequirements.gameThrQ->AddTask([=] {
-      // kinda redundant since we get formid from actor
       if (RE::TESForm::LookupByID<RE::Actor>(formId) != actor) {
         return;
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove incorrect comment in `SetWeaponDrawnMode()` in `PapyrusTESModPlatform.cpp`.
> 
>   - **Misc**:
>     - Remove incorrect comment in `SetWeaponDrawnMode()` in `PapyrusTESModPlatform.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 181fb0b1bcb67cfad5e535910061e34f5a392be8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->