### PR TITLE
feat(skymp5-server): add onReadBook event

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -20,6 +20,7 @@
 #include "gamemode_events/DeathEvent.h"
 #include "gamemode_events/DropItemEvent.h"
 #include "gamemode_events/EatItemEvent.h"
+#include "gamemode_events/ReadBookEvent.h"
 #include "gamemode_events/RespawnEvent.h"
 #include "libespm/espm.h"
 #include "papyrus-vm/Utils.h"
@@ -866,37 +867,9 @@ void MpActor::EatItem(uint32_t baseId, espm::Type t)
 
 bool MpActor::ReadBook(const uint32_t baseId)
 {
-  auto& loader = GetParent()->GetEspm();
-  auto bookLookupResult = loader.GetBrowser().LookupById(baseId);
-
-  if (!bookLookupResult.rec) {
-    spdlog::error("ReadBook {:x} - No book form {:x}", GetFormId(), baseId);
-    return false;
-  }
-
-  const auto bookData = espm::GetData<espm::BOOK>(baseId, GetParent());
-  const auto spellOrSkillFormId =
-    bookLookupResult.ToGlobalId(bookData.spellOrSkillFormId);
-
-  if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSpell)) {
-    if (ChangeForm().learnedSpells.IsSpellLearned(spellOrSkillFormId)) {
-      spdlog::info(
-        "ReadBook {:x} - Spell already learned {:x}, not spending the book",
-        GetFormId(), spellOrSkillFormId);
-      return false;
-    }
-
-    EditChangeForm([&](MpChangeForm& changeForm) {
-      changeForm.learnedSpells.LearnSpell(spellOrSkillFormId);
-    });
-    return true;
-  } else if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSkill)) {
-    spdlog::info("ReadBook {:x} - Skill book {:x} detected, not implemented",
-                 GetFormId(), baseId);
-    return false;
-  }
-
-  return false;
+  ReadBookEvent readBookEvent(this, baseId);
+  readBookEvent.Fire(GetParent());
+  return readBookEvent.SpellLearned();
 }
 
 void MpActor::EnsureTemplateChainEvaluated(espm::Loader& loader,

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -45,7 +45,7 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
     return;
   }
 
-  const auto bookData = espm::GetData<espm::BOOK>(baseId, GetParent());
+  const auto bookData = espm::GetData<espm::BOOK>(baseId, actor->GetParent());
   const auto spellOrSkillFormId =
     bookLookupResult.ToGlobalId(bookData.spellOrSkillFormId);
 

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -50,17 +50,14 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
     bookLookupResult.ToGlobalId(bookData.spellOrSkillFormId);
 
   if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSpell)) {
-    if (actor->ChangeForm().learnedSpells.IsSpellLearned(spellOrSkillFormId)) {
+    if (actor->IsSpellLearned(spellOrSkillFormId)) {
       spdlog::info("ReadBookEvent::OnFireSuccess - Actor {:x} reading book: "
                    "Spell already learned "
                    "{:x}, not spending the book",
                    actor->GetFormId(), spellOrSkillFormId);
       return;
     }
-
-    EditChangeForm([&](MpChangeForm& changeForm) {
-      changeForm.learnedSpells.LearnSpell(spellOrSkillFormId);
-    });
+    actor->AddSpell(spellOrSkillFormId);
     spellLearned = true;
     return;
   } else if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSkill)) {

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -39,7 +39,8 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
   auto bookLookupResult = loader.GetBrowser().LookupById(baseId);
 
   if (!bookLookupResult.rec) {
-    spdlog::error("ReadBookEvent::OnFireSuccess {:x} - No book form {:x}",
+    spdlog::error("ReadBookEvent::OnFireSuccess - Actor {:x} reading book: No "
+                  "book form {:x}",
                   actor->GetFormId(), baseId);
     return;
   }
@@ -50,9 +51,10 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
 
   if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSpell)) {
     if (actor->ChangeForm().learnedSpells.IsSpellLearned(spellOrSkillFormId)) {
-      spdlog::info("ReadBookEvent::OnFireSuccess {:x} - Spell already learned "
+      spdlog::info("ReadBookEvent::OnFireSuccess - Actor {:x} reading book: "
+                   "Spell already learned "
                    "{:x}, not spending the book",
-                   GetFormId(), spellOrSkillFormId);
+                   actor->GetFormId(), spellOrSkillFormId);
       return;
     }
 
@@ -62,9 +64,10 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
     spellLearned = true;
     return;
   } else if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSkill)) {
-    spdlog::info("ReadBookEvent::OnFireSuccess {:x} - Skill book {:x} "
-                 "detected, not implemented",
-                 GetFormId(), baseId);
+    spdlog::info(
+      "ReadBookEvent::OnFireSuccess - Actor {:x} reading skill book {:x} "
+      "detected, not implemented",
+      actor->GetFormId(), baseId);
     return;
   }
 }

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -49,7 +49,7 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
     bookLookupResult.ToGlobalId(bookData.spellOrSkillFormId);
 
   if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSpell)) {
-    if (ChangeForm().learnedSpells.IsSpellLearned(spellOrSkillFormId)) {
+    if (actor->ChangeForm().learnedSpells.IsSpellLearned(spellOrSkillFormId)) {
       spdlog::info("ReadBookEvent::OnFireSuccess {:x} - Spell already learned "
                    "{:x}, not spending the book",
                    GetFormId(), spellOrSkillFormId);

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -40,7 +40,7 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
 
   if (!bookLookupResult.rec) {
     spdlog::error("ReadBookEvent::OnFireSuccess {:x} - No book form {:x}",
-                  GetFormId(), baseId);
+                  actor->GetFormId(), baseId);
     return;
   }
 

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -1,0 +1,70 @@
+#include "ReadBookEvent.h"
+
+#include "MpActor.h"
+#include "WorldState.h"
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+ReadBookEvent::ReadBookEvent(MpActor* actor_, uint32_t baseId_)
+  : actor(actor_)
+  , baseId(baseId_)
+{
+}
+
+const char* ReadBookEvent::GetName() const
+{
+  return "onReadBook";
+}
+
+std::string ReadBookEvent::GetArgumentsJsonArray() const
+{
+  std::string result;
+  result += "[";
+  result += std::to_string(actor->GetFormId());
+  result += ",";
+  result += std::to_string(baseId);
+  result += "]";
+  return result;
+}
+
+bool ReadBookEvent::SpellLearned() const
+{
+  return spellLearned;
+}
+
+void ReadBookEvent::OnFireSuccess(WorldState* worldState)
+{
+  auto& loader = actor->GetParent()->GetEspm();
+  auto bookLookupResult = loader.GetBrowser().LookupById(baseId);
+
+  if (!bookLookupResult.rec) {
+    spdlog::error("ReadBookEvent::OnFireSuccess {:x} - No book form {:x}",
+                  GetFormId(), baseId);
+    return;
+  }
+
+  const auto bookData = espm::GetData<espm::BOOK>(baseId, GetParent());
+  const auto spellOrSkillFormId =
+    bookLookupResult.ToGlobalId(bookData.spellOrSkillFormId);
+
+  if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSpell)) {
+    if (ChangeForm().learnedSpells.IsSpellLearned(spellOrSkillFormId)) {
+      spdlog::info("ReadBookEvent::OnFireSuccess {:x} - Spell already learned "
+                   "{:x}, not spending the book",
+                   GetFormId(), spellOrSkillFormId);
+      return;
+    }
+
+    EditChangeForm([&](MpChangeForm& changeForm) {
+      changeForm.learnedSpells.LearnSpell(spellOrSkillFormId);
+    });
+    spellLearned = true;
+    return;
+  } else if (bookData.IsFlagSet(espm::BOOK::Flags::TeachesSkill)) {
+    spdlog::info("ReadBookEvent::OnFireSuccess {:x} - Skill book {:x} "
+                 "detected, not implemented",
+                 GetFormId(), baseId);
+    return;
+  }
+}

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.h
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "GameModeEvent.h"
+
+class MpActor;
+
+class ReadBookEvent : public GameModeEvent
+{
+public:
+  ReadBookEvent(MpActor* actor_, uint32_t baseId_);
+
+  const char* GetName() const override;
+
+  std::string GetArgumentsJsonArray() const override;
+
+  bool SpellLearned() const;
+
+private:
+  void OnFireSuccess(WorldState* worldState) override;
+
+  // event arguments
+  MpActor* actor = nullptr;
+  uint32_t baseId = 0;
+
+  // OnFireSuccess-specific arguments
+  // ...
+
+  // Results
+  bool spellLearned = false;
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `ReadBookEvent` to handle book reading in `MpActor`, updating learned spells and logging events.
> 
>   - **Behavior**:
>     - Introduces `ReadBookEvent` to handle book reading in `MpActor::ReadBook()`.
>     - Logs error if book form not found and logs unimplemented skill book handling.
>     - Updates actor's learned spells if the book teaches a spell.
>   - **Event Handling**:
>     - `ReadBookEvent` class added with methods `GetName()`, `GetArgumentsJsonArray()`, `SpellLearned()`, and `OnFireSuccess()`.
>     - `OnFireSuccess()` checks if the spell is already learned and updates the change form.
>   - **Misc**:
>     - Removes previous book reading logic from `MpActor::ReadBook()` and replaces it with `ReadBookEvent` firing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 8039acb61329fcb760b78a8c9fbea36e4c0c74b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->