### PR TITLE
fix(skymp5-server): debug crash

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1172,6 +1172,8 @@ void MpObjectReference::ApplyChangeForm(const MpChangeForm& changeForm)
 
     spdlog::critical("setPropertyTrackingInfo: trace = {}", ss.str());
 
+    pImpl->setPropertyTrackingInfo.reset();
+
     // std::terminate();
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance debugging in `MpObjectReference.cpp` by tracking property changes and logging detailed information when `ApplyChangeForm` is called after `SetProperty`.
> 
>   - **Debugging Enhancements**:
>     - Add `SetPropertyTrackingInfo` struct to track property changes in `MpObjectReference.cpp`.
>     - Capture stack trace in `SetProperty()` when `GetFormId()` is `0xE2218`.
>     - Log detailed information in `ApplyChangeForm()` if called after `SetProperty()`.
>   - **Logging**:
>     - Replace `std::terminate()` with detailed logging in `ApplyChangeForm()` to provide more context on errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 638e4a0f6a85ee7935e9564f2f554edca20f124b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->