### PR TITLE
refact(skymp5-server): add helper for checking if spell is equipped

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/Equipment.cpp
+++ b/skymp5-server/cpp/server_guest_lib/Equipment.cpp
@@ -1,6 +1,12 @@
 #include "Equipment.h"
 #include "JsonUtils.h"
 
+bool Equipment::IsSpellEquipped(const uint32_t spellFormId) const
+{
+  return spellFormId == leftSpell || spellFormId == rightSpell ||
+    spellFormId == voiceSpell || spellFormId == instantSpell;
+}
+
 nlohmann::json Equipment::ToJson() const
 {
   nlohmann::json res{

--- a/skymp5-server/cpp/server_guest_lib/Equipment.h
+++ b/skymp5-server/cpp/server_guest_lib/Equipment.h
@@ -11,6 +11,8 @@ struct Equipment
   uint32_t voiceSpell = 0;
   uint32_t instantSpell = 0;
 
+  [[nodiscard]] bool IsSpellEquipped(uint32_t spellFormId) const;
+
   nlohmann::json ToJson() const;
 
   static Equipment FromJson(const simdjson::dom::element& element);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `IsSpellEquipped` helper function to `Equipment` class to check if a spell is equipped.
> 
>   - **Functionality**:
>     - Adds `IsSpellEquipped(uint32_t spellFormId)` to `Equipment` class in `Equipment.cpp` and `Equipment.h`.
>     - Checks if `spellFormId` matches `leftSpell`, `rightSpell`, `voiceSpell`, or `instantSpell`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 7f7800a4a537e6d216079b0c5bc049edc4595984. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->