### PR TITLE
feat(skymp5-server): implement EquipSpell Papyrus native

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
@@ -235,18 +235,18 @@ VarValue PapyrusActor::EquipSpell(VarValue self, const std::vector<VarValue>& ar
     return VarValue::None();
   }
 
-  if (lookupRes.rec->GetType() != espm::Type::SPEL) {
+  if (lookupRes.rec->GetType() != espm::SPEL::kType) {
     spdlog::error("EquipSpell - form is not a spell");
     return VarValue::None();
   }
 
-  // If no such spell in spell list, add one (this is standard behavior)
-  auto baseId = lookupRes.ToGlobalId(lookupRes.rec->GetId());
-  if (!actor->IsSpellLearned(baseId)) {
-    actor->AddSpell(baseId);
-  }
-
   if (auto actor = GetFormPtr<MpActor>(self)) {
+    // If no such spell in spell list, add one (this is standard behavior)
+    auto baseId = lookupRes.ToGlobalId(lookupRes.rec->GetId());
+    if (!actor->IsSpellLearned(baseId)) {
+      actor->AddSpell(baseId);
+    }
+
     SpSnippet(GetName(), "EquipSpell",
               SpSnippetFunctionGen::SerializeArguments(arguments).data(),
               actor->GetFormId())

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
@@ -222,7 +222,8 @@ VarValue PapyrusActor::EquipItem(VarValue self,
   return VarValue::None();
 }
 
-VarValue PapyrusActor::EquipSpell(VarValue self, const std::vector<VarValue>& arguments)
+VarValue PapyrusActor::EquipSpell(VarValue self,
+                                  const std::vector<VarValue>& arguments)
 {
   if (arguments.size() < 2) {
     spdlog::error("EquipSpell requires at least 2 arguments");

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.h
@@ -34,6 +34,8 @@ public:
 
   VarValue EquipItem(VarValue self, const std::vector<VarValue>& arguments);
 
+  VarValue EquipSpell(VarValue self, const std::vector<VarValue>& arguments);
+
   VarValue UnequipItem(VarValue self, const std::vector<VarValue>& arguments);
 
   VarValue SetDontMove(VarValue self, const std::vector<VarValue>& arguments);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `EquipSpell` method to `PapyrusActor` for equipping spells, with argument validation and registration.
> 
>   - **Behavior**:
>     - Adds `EquipSpell` method to `PapyrusActor` to equip spells, checking for valid arguments and spell type.
>     - If the spell is not in the actor's spell list, it adds the spell.
>   - **Logging**:
>     - Logs errors for invalid arguments and spell types in `EquipSpell`.
>   - **Registration**:
>     - Registers `EquipSpell` method in `PapyrusActor::Register`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 1fe4f4c5aac731cc7b0470c1eabea17604b9141a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->