### PR TITLE
feat(skymp5-server): add getAllForms API

### DIFF
--- a/serialization/include/concepts/ContainerLike.h
+++ b/serialization/include/concepts/ContainerLike.h
@@ -7,9 +7,11 @@
 #include "StringLike.h"
 
 template <typename T>
-concept ContainerLike = requires(T a) {
-  typename T::value_type;
-  typename T::iterator; // added
-  requires std::same_as<decltype(std::begin(a)), typename T::iterator>;
-  requires std::same_as<decltype(std::end(a)), typename T::iterator>;
-} && !StringLike<T>;
+concept ContainerLike =
+  requires(T a) {
+    typename T::value_type;
+    typename T::iterator; // added
+    requires std::same_as<decltype(std::begin(a)), typename T::iterator>;
+    requires std::same_as<decltype(std::end(a)), typename T::iterator>;
+  } && !
+StringLike<T>;

--- a/serialization/include/concepts/NoneOfTheAbove.h
+++ b/serialization/include/concepts/NoneOfTheAbove.h
@@ -9,5 +9,6 @@
 #include "StringLike.h"
 
 template <typename T>
-concept NoneOfTheAbove = !IntegralConstant<T> && !StringLike<T> &&
-  !ContainerLike<T> && !Optional<T> && !Arithmetic<T>;
+concept NoneOfTheAbove = !
+IntegralConstant<T> && !StringLike<T> && !ContainerLike<T> && !Optional<T> &&
+  !Arithmetic<T>;

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1073,7 +1073,7 @@ Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
     });
 
     size_t elementCount = forms->size();
-    Napi::TypedArray typedArray = Napi::Uint32Array::New(env, elementCount, arrayBuffer, 0);
+    Napi::TypedArray typedArray = Napi::Uint32Array::New(info.Env(), elementCount, arrayBuffer, 0);
 
     return typedArray;
 

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1057,23 +1057,27 @@ Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
   try {
     uint32_t modIndex = NapiHelper::ExtractUInt32(info[0], "modIndex");
 
-    std::shared_ptr<std::vector<uint32_t>> forms = partOne->worldState.GetAllForms(modIndex);
+    std::shared_ptr<std::vector<uint32_t>> forms =
+      partOne->worldState.GetAllForms(modIndex);
 
     if (!forms) {
-      static const auto kEmptyVector = std::make_shared<std::vector<uint32_t>>();
+      static const auto kEmptyVector =
+        std::make_shared<std::vector<uint32_t>>();
       forms = kEmptyVector;
     }
 
     size_t bufferSizeBytes = forms->size() * sizeof(uint32_t);
     void* data = const_cast<uint32_t*>(forms->data());
 
-    Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(info.Env(), data, bufferSizeBytes,
+    Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(
+      info.Env(), data, bufferSizeBytes,
       [forms](Napi::Env /*env*/, void* /*externalData*/) mutable {
-      forms.reset();
-    });
+        forms.reset();
+      });
 
     size_t elementCount = forms->size();
-    Napi::TypedArray typedArray = Napi::Uint32Array::New(info.Env(), elementCount, arrayBuffer, 0);
+    Napi::TypedArray typedArray =
+      Napi::Uint32Array::New(info.Env(), elementCount, arrayBuffer, 0);
 
     return typedArray;
 

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1057,17 +1057,17 @@ Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
   try {
     uint32_t modIndex = NapiHelper::ExtractUInt32(info[0], "modIndex");
 
-    std::shared_ptr<const std::vector<uint32_t> forms = partOne->worldState.GetAllForms(modIndex);
+    std::shared_ptr<const std::vector<uint32_t>> forms = partOne->worldState.GetAllForms(modIndex);
 
     if (!forms) {
-      static const auto kEmptyVector = std::make_shared<const std::vector<uint32_t>();
+      static const auto kEmptyVector = std::make_shared<const std::vector<uint32_t>>();
       forms = kEmptyVector;
     }
 
     size_t bufferSizeBytes = forms->size() * sizeof(uint32_t);
     void* data = forms->data();
 
-    Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(info.Env(), data, bufferSize,
+    Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(info.Env(), data, bufferSizeBytes,
       [forms](Napi::Env /*env*/, void* /*externalData*/) mutable {
       forms.reset();
     });

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1057,10 +1057,10 @@ Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
   try {
     uint32_t modIndex = NapiHelper::ExtractUInt32(info[0], "modIndex");
 
-    std::shared_ptr<const std::vector<uint32_t>> forms = partOne->worldState.GetAllForms(modIndex);
+    std::shared_ptr<std::vector<uint32_t>> forms = partOne->worldState.GetAllForms(modIndex);
 
     if (!forms) {
-      static const auto kEmptyVector = std::make_shared<const std::vector<uint32_t>>();
+      static const auto kEmptyVector = std::make_shared<std::vector<uint32_t>>();
       forms = kEmptyVector;
     }
 

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1068,7 +1068,7 @@ Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
     void* data = forms->data();
 
     Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(info.Env(), data, bufferSize,
-      [mutable forms](Napi::Env /*env*/, void* /*externalData*/) {
+      [forms](Napi::Env /*env*/, void* /*externalData*/) mutable {
       forms.reset();
     });
 

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1065,7 +1065,7 @@ Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
     }
 
     size_t bufferSizeBytes = forms->size() * sizeof(uint32_t);
-    void* data = forms->data();
+    void* data = const_cast<uint32_t*>(forms->data());
 
     Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(info.Env(), data, bufferSizeBytes,
       [forms](Napi::Env /*env*/, void* /*externalData*/) mutable {

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -98,6 +98,7 @@ Napi::Object ScampServer::Init(Napi::Env env, Napi::Object exports)
       InstanceMethod("getEspmLoadOrder", &ScampServer::GetEspmLoadOrder),
       InstanceMethod("getNeighborsByPosition",
                      &ScampServer::GetNeighborsByPosition),
+      InstanceMethod("getAllForms", &ScampServer::GetAllForms),
       InstanceMethod("getDescFromId", &ScampServer::GetDescFromId),
       InstanceMethod("getIdFromDesc", &ScampServer::GetIdFromDesc),
       InstanceMethod("callPapyrusFunction", &ScampServer::CallPapyrusFunction),
@@ -1046,6 +1047,36 @@ Napi::Value ScampServer::GetNeighborsByPosition(const Napi::CallbackInfo& info)
       arr.Set(arr.Length(), Napi::Number::New(info.Env(), ref->GetFormId()));
     }
     return arr;
+  } catch (std::exception& e) {
+    throw Napi::Error::New(info.Env(), std::string(e.what()));
+  }
+}
+
+Napi::Value ScampServer::GetAllForms(const Napi::CallbackInfo& info)
+{
+  try {
+    uint32_t modIndex = NapiHelper::ExtractUInt32(info[0], "modIndex");
+
+    std::shared_ptr<const std::vector<uint32_t> forms = partOne->worldState.GetAllForms(modIndex);
+
+    if (!forms) {
+      static const auto kEmptyVector = std::make_shared<const std::vector<uint32_t>();
+      forms = kEmptyVector;
+    }
+
+    size_t bufferSizeBytes = forms->size() * sizeof(uint32_t);
+    void* data = forms->data();
+
+    Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(info.Env(), data, bufferSize,
+      [mutable forms](Napi::Env /*env*/, void* /*externalData*/) {
+      forms.reset();
+    });
+
+    size_t elementCount = forms->size();
+    Napi::TypedArray typedArray = Napi::Uint32Array::New(env, elementCount, arrayBuffer, 0);
+
+    return typedArray;
+
   } catch (std::exception& e) {
     throw Napi::Error::New(info.Env(), std::string(e.what()));
   }

--- a/skymp5-server/cpp/addon/ScampServer.h
+++ b/skymp5-server/cpp/addon/ScampServer.h
@@ -53,6 +53,7 @@ public:
   Napi::Value Place(const Napi::CallbackInfo& info);
   Napi::Value LookupEspmRecordById(const Napi::CallbackInfo& info);
   Napi::Value GetNeighborsByPosition(const Napi::CallbackInfo& info);
+  Napi::Value GetAllForms(const Napi::CallbackInfo& info);
   Napi::Value GetEspmLoadOrder(const Napi::CallbackInfo& info);
   Napi::Value GetDescFromId(const Napi::CallbackInfo& info);
   Napi::Value GetIdFromDesc(const Napi::CallbackInfo& info);

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -52,7 +52,7 @@ struct WorldState::Impl
   std::vector<RelootTimeForTypesEntry> relootTimeForTypes;
   std::set<std::string> forbiddenRelootTypes;
   std::vector<std::unique_ptr<IPapyrusClassBase>> classes;
-  std::array<std::shared_ptr<const std::vector<uint32_t>>, 0x100> allFormsByModIndexCache;
+  std::array<std::shared_ptr<std::vector<uint32_t>>, 0x100> allFormsByModIndexCache;
   std::vector<uint32_t> attachEspmRecordFailures;
 };
 

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -868,10 +868,14 @@ std::shared_ptr<const std::vector<uint32_t>> WorldState::GetAllForms(uint32_t mo
     // TODO: Consider cleaning changeFormsForDeferredLoad after adding a form so we don't need de-duplicate in runtime
     std::unordered_set<uint32_t> formIds;
     for (const auto& p : forms) {
-      formIds.insert(p.first);
+      if (p.first / 0x01000000 == modIndex) {
+        formIds.insert(p.first);
+      }
     }
     for (const auto& p : pImpl->changeFormsForDeferredLoad) {
-      formIds.insert(p.first);
+      if (p.first / 0x01000000 == modIndex) {
+        formIds.insert(p.first);
+      }
     }
 
     resCache = std::make_shared<const std::vector<uint32_t>>(formIds.begin(), formIds.end());

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -52,7 +52,8 @@ struct WorldState::Impl
   std::vector<RelootTimeForTypesEntry> relootTimeForTypes;
   std::set<std::string> forbiddenRelootTypes;
   std::vector<std::unique_ptr<IPapyrusClassBase>> classes;
-  std::array<std::shared_ptr<std::vector<uint32_t>>, 0x100> allFormsByModIndexCache;
+  std::array<std::shared_ptr<std::vector<uint32_t>>, 0x100>
+    allFormsByModIndexCache;
   std::vector<uint32_t> attachEspmRecordFailures;
 };
 
@@ -859,7 +860,8 @@ const std::set<MpObjectReference*>& WorldState::GetNeighborsByPosition(
   return neighbours;
 }
 
-std::shared_ptr<std::vector<uint32_t>> WorldState::GetAllForms(uint32_t modIndex)
+std::shared_ptr<std::vector<uint32_t>> WorldState::GetAllForms(
+  uint32_t modIndex)
 {
   if (modIndex >= std::size(pImpl->allFormsByModIndexCache)) {
     spdlog::error("WorldState::GetAllForms - Invalid mod index {}", modIndex);
@@ -870,7 +872,8 @@ std::shared_ptr<std::vector<uint32_t>> WorldState::GetAllForms(uint32_t modIndex
 
   if (!resCache) {
     // Deduplicate form IDs
-    // TODO: Consider cleaning changeFormsForDeferredLoad after adding a form so we don't need de-duplicate in runtime
+    // TODO: Consider cleaning changeFormsForDeferredLoad after adding a form
+    // so we don't need de-duplicate in runtime
     std::unordered_set<uint32_t> formIds;
     for (const auto& p : forms) {
       if ((p.first >> 24) == modIndex) {
@@ -887,7 +890,8 @@ std::shared_ptr<std::vector<uint32_t>> WorldState::GetAllForms(uint32_t modIndex
       formIds.erase(failedToAttachFormId);
     }
 
-    resCache = std::make_shared<std::vector<uint32_t>>(formIds.begin(), formIds.end());
+    resCache =
+      std::make_shared<std::vector<uint32_t>>(formIds.begin(), formIds.end());
   }
 
   return resCache;

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -868,12 +868,12 @@ std::shared_ptr<const std::vector<uint32_t>> WorldState::GetAllForms(uint32_t mo
     // TODO: Consider cleaning changeFormsForDeferredLoad after adding a form so we don't need de-duplicate in runtime
     std::unordered_set<uint32_t> formIds;
     for (const auto& p : forms) {
-      if (p.first / 0x01000000 == modIndex) {
+      if ((p.first >> 24) == modIndex) {
         formIds.insert(p.first);
       }
     }
     for (const auto& p : pImpl->changeFormsForDeferredLoad) {
-      if (p.first / 0x01000000 == modIndex) {
+      if ((p.first >> 24) == modIndex) {
         formIds.insert(p.first);
       }
     }

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -115,6 +115,8 @@ public:
   const std::set<MpObjectReference*>& GetNeighborsByPosition(
     uint32_t cellOrWorld, int16_t cellX, int16_t cellY);
 
+  std::shared_ptr<const std::vector<uint32_t> GetAllForms(uint32_t modIndex);
+
   // See LookupFormById comment
   template <class F>
   F& GetFormAt(uint32_t formId)

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -115,7 +115,7 @@ public:
   const std::set<MpObjectReference*>& GetNeighborsByPosition(
     uint32_t cellOrWorld, int16_t cellX, int16_t cellY);
 
-  std::shared_ptr<const std::vector<uint32_t>> GetAllForms(uint32_t modIndex);
+  std::shared_ptr<std::vector<uint32_t>> GetAllForms(uint32_t modIndex);
 
   // See LookupFormById comment
   template <class F>

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -115,7 +115,7 @@ public:
   const std::set<MpObjectReference*>& GetNeighborsByPosition(
     uint32_t cellOrWorld, int16_t cellX, int16_t cellY);
 
-  std::shared_ptr<const std::vector<uint32_t> GetAllForms(uint32_t modIndex);
+  std::shared_ptr<const std::vector<uint32_t>> GetAllForms(uint32_t modIndex);
 
   // See LookupFormById comment
   template <class F>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `getAllForms` API to `ScampServer` to retrieve all form IDs for a given mod index, with caching and deduplication in `WorldState`.
> 
>   - **API Addition**:
>     - Add `getAllForms` method to `ScampServer` in `ScampServer.cpp` and `ScampServer.h`.
>     - Retrieves all form IDs for a given mod index.
>   - **WorldState Changes**:
>     - Implement `GetAllForms` in `WorldState.cpp` and `WorldState.h`.
>     - Caches form IDs by mod index and deduplicates them.
>     - Handles invalid mod indices by logging an error and returning `nullptr`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 7b2b9ffecb58e8e7f9d22431131e36c370c91bd7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->