### PR TITLE
internal: add --all option to clang-format-hook.js

### DIFF
--- a/misc/git-hooks/clang-format-hook.js
+++ b/misc/git-hooks/clang-format-hook.js
@@ -1,36 +1,64 @@
 const { execSync } = require("child_process");
 const simpleGit = require("simple-git");
+const fs = require("fs");
+const path = require("path");
 
 const extensions = [".cpp", ".h", ".hpp", ".cxx", ".cc"];
 
+const findFiles = (dir, fileList = []) => {
+  const files = fs.readdirSync(dir);
+  files.forEach((file) => {
+    const fullPath = path.join(dir, file);
+    if (fs.statSync(fullPath).isDirectory()) {
+      findFiles(fullPath, fileList);
+    } else {
+      fileList.push(fullPath);
+    }
+  });
+  return fileList;
+};
+
+const formatFiles = (files) => {
+  const filesToFormat = files.filter((file) =>
+    extensions.some((ext) => file.endsWith(ext))
+  );
+
+  if (filesToFormat.length === 0) {
+    console.log("No files to format.");
+    return;
+  }
+
+  console.log("Formatting files:");
+  filesToFormat.forEach((file) => {
+    console.log(`  - ${file}`);
+    execSync(`clang-format -i ${file}`, { stdio: "inherit" });
+  });
+};
+
 (async () => {
+  const args = process.argv.slice(2);
+
   try {
-    const git = simpleGit();
-    const changedFiles = await git.diff(["--name-only", "--cached"]);
+    if (args.includes("--all")) {
+      console.log("Formatting all files in the repository...");
+      const allFiles = findFiles(process.cwd());
+      formatFiles(allFiles);
+    } else {
+      console.log("Formatting staged files...");
+      const git = simpleGit();
+      const changedFiles = await git.diff(["--name-only", "--cached"]);
 
-    const filesToFormat = changedFiles
-      .split("\n")
-      .filter(
-        (file) =>
-          extensions.some((ext) => file.endsWith(ext)) && file.trim() !== ""
-      );
+      const filesToFormat = changedFiles
+        .split("\n")
+        .filter((file) => file.trim() !== "");
+      formatFiles(filesToFormat);
 
-    if (filesToFormat.length === 0) {
-      console.log("No files to format.");
-      process.exit(0);
+      filesToFormat.forEach((file) => execSync(`git add ${file}`));
     }
 
-    console.log("Formatting files:");
-    filesToFormat.forEach((file) => {
-      console.log(`  - ${file}`);
-      execSync(`clang-format -i ${file}`, { stdio: "inherit" });
-      execSync(`git add ${file}`);
-    });
-
-    console.log("Formatting completed and changes staged.");
+    console.log("Formatting completed.");
   } catch (err) {
     console.error("Error during formatting:", err.message);
-    console.error("Autofix failed. Commit aborted.");
     process.exit(1);
   }
 })();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `--all` option to `clang-format-hook.js` to format all files in the repository.
> 
>   - **Feature Addition**:
>     - Add `--all` option to `clang-format-hook.js` to format all files in the repository.
>     - Introduce `findFiles` function to recursively find all files in the current directory.
>   - **Behavior**:
>     - If `--all` is specified, formats all files with specified extensions.
>     - If `--all` is not specified, formats only staged files as before.
>   - **Misc**:
>     - Minor refactoring to separate file finding and formatting logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b5e822ffbe760e38b069613376b57668c733c4b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->