### PR TITLE
fix(skymp5-server): fix equipment/inventory mismatch

### DIFF
--- a/skymp5-server/cpp/addon/property_bindings/EquipmentBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/EquipmentBinding.cpp
@@ -7,7 +7,7 @@ Napi::Value EquipmentBinding::Get(Napi::Env env, ScampServer& scampServer,
   auto& partOne = scampServer.GetPartOne();
 
   auto& actor = partOne->worldState.GetFormAt<MpActor>(formId);
-  auto& equipmentDump = actor.GetEquipmentAsJson();
+  auto& equipmentDump = actor.GetEquipment().ToJson();
   if (!equipmentDump.empty()) {
     return NapiHelper::ParseJson(env, equipmentDump);
   } else {

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -901,7 +901,9 @@ void ActionListener::OnHit(const RawMessageData& rawMsgData_,
     return;
   }
 
-  if (aggressor->GetEquipment().inv.HasItem(hitData.source) == false &&
+  auto equipment = aggressor->GetEquipment();
+
+  if (equipment && equipment->inv.HasItem(hitData.source) == false &&
       IsUnarmedAttack(hitData.source) == false) {
 
     if (aggressor->GetInventory().HasItem(hitData.source) == false) {
@@ -1007,8 +1009,9 @@ void ActionListener::OnHit(const RawMessageData& rawMsgData_,
 
       bool isBlockingByShield = false;
 
+      auto equipment = targetActor.GetEquipment();
       auto targetActorEquipmentEntries =
-        targetActor.GetEquipment().inv.entries;
+        equipment ? equipment->inv.entries : std::vector<Inventory::Entry>();
       for (auto& entry : targetActorEquipmentEntries) {
         if (entry.GetWorn() != Inventory::Worn::None) {
           auto res =
@@ -1110,22 +1113,24 @@ void ActionListener::OnSpellCast(const RawMessageData& rawMsgData,
 
   bool isEquippedSpellValid = false;
 
-  switch (spellCastData.castingSource) {
-    case SpellType::Left:
-      isEquippedSpellValid = spellCastData.spell == equipment.leftSpell;
-      break;
-    case SpellType::Right:
-      isEquippedSpellValid = spellCastData.spell == equipment.rightSpell;
-      break;
-    case SpellType::Voise:
-      isEquippedSpellValid = spellCastData.spell == equipment.voiceSpell;
-      break;
-    case SpellType::Instant:
-      isEquippedSpellValid = spellCastData.spell == equipment.instantSpell;
-      break;
+  if (equipment) {
+    switch (spellCastData.castingSource) {
+      case SpellType::Left:
+        isEquippedSpellValid = spellCastData.spell == equipment->leftSpell;
+        break;
+      case SpellType::Right:
+        isEquippedSpellValid = spellCastData.spell == equipment->rightSpell;
+        break;
+      case SpellType::Voise:
+        isEquippedSpellValid = spellCastData.spell == equipment->voiceSpell;
+        break;
+      case SpellType::Instant:
+        isEquippedSpellValid = spellCastData.spell == equipment->instantSpell;
+        break;
+    }
   }
 
-  if (isEquippedSpellValid == false) {
+  if (!isEquippedSpellValid) {
     spdlog::info("ActionListener::OnSpellCast - spell {0:x} not "
                  "found in equipment",
                  spellCastData.spell);

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -262,7 +262,7 @@ void ActionListener::OnUpdateEquipment(
   }
 
   SendToNeighbours(idx, rawMsgData, true);
-  actor->SetEquipment(data.ToJson().dump());
+  actor->SetEquipment(data);
 }
 
 void ActionListener::OnActivate(const RawMessageData& rawMsgData,

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "AnimationData.h"
 #include "Appearance.h"
+#include "Equipment.h"
 #include "GetBaseActorValues.h"
 #include "MpObjectReference.h"
 #include "libespm/espm.h"
@@ -27,18 +28,17 @@ public:
   MpActor(const LocationalData& locationalData_,
           const FormCallbacks& calbacks_, uint32_t optBaseId = 0);
 
-  const bool& IsRaceMenuOpen() const;
-  const bool& IsDead() const;
-  const bool& IsRespawning() const;
+  bool IsRaceMenuOpen() const;
+  bool IsDead() const;
+  bool IsRespawning() const;
 
   bool IsSpellLearned(uint32_t spellId) const; // including from base
   bool IsSpellLearnedFromBase(uint32_t spellId) const;
 
   std::unique_ptr<const Appearance> GetAppearance() const;
   const std::string& GetAppearanceAsJson();
-  const std::string& GetEquipmentAsJson() const;
   std::string GetLastAnimEventAsJson() const;
-  Equipment GetEquipment() const;
+  const std::optional<Equipment>& GetEquipment() const;
   std::array<std::optional<Inventory::Entry>, 2> GetEquippedWeapon() const;
   uint32_t GetRaceId() const;
   bool IsWeaponDrawn() const;
@@ -54,7 +54,7 @@ public:
 
   void SetRaceMenuOpen(bool isOpen);
   void SetAppearance(const Appearance* newAppearance);
-  void SetEquipment(const std::string& jsonString);
+  void SetEquipment(const Equipment& newEquipment);
 
   void AddToFaction(Faction faction, bool lazyLoad = true);
   bool IsInFaction(FormDesc factionForm, bool lazyLoad = true);

--- a/skymp5-server/cpp/server_guest_lib/MpChangeForms.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpChangeForms.cpp
@@ -48,11 +48,9 @@ nlohmann::json MpChangeForm::ToJson(const MpChangeForm& changeForm)
     res["appearanceDump"] = nlohmann::json::parse(changeForm.appearanceDump);
   }
 
-  if (changeForm.equipmentDump.empty()) {
-    res["equipmentDump"] = nullptr;
-  } else {
-    res["equipmentDump"] = nlohmann::json::parse(changeForm.equipmentDump);
-  }
+  res["equipmentDump"] = changeForm.equipmentDump
+    ? changeForm.equipmentDump->ToJson()
+    : nlohmann::json();
 
   res["learnedSpells"] = changeForm.learnedSpells.GetLearnedSpells();
 
@@ -189,9 +187,11 @@ MpChangeForm MpChangeForm::JsonToChangeForm(simdjson::dom::element& element)
   }
 
   ReadEx(element, equipmentDump, &jTmp);
-  res.equipmentDump = simdjson::minify(jTmp);
-  if (res.equipmentDump == "null") {
-    res.equipmentDump.clear();
+  auto equipmentDumpMinified = simdjson::minify(jTmp);
+  if (equipmentDumpMinified != "null") {
+    res.equipmentDump = Equipment::FromJson(jTmp);
+  } else {
+    res.equipmentDump = std::nullopt;
   }
 
   if (element.at_pointer(learnedSpells.GetData()).error() ==

--- a/skymp5-server/cpp/server_guest_lib/MpChangeForms.h
+++ b/skymp5-server/cpp/server_guest_lib/MpChangeForms.h
@@ -86,10 +86,14 @@ public:
   ActiveMagicEffectsMap activeMagicEffects;
   bool consoleCommandsAllowed = false;
 
-  // 'appearanceDump' and 'equipmentDump' can be empty. it means nullopt.
-  // "unexisting" equipment and equipment with zero entries are different
-  // values in skymp due to poor design
-  std::string appearanceDump, equipmentDump;
+  // 'appearanceDump' can be empty. it means nullopt.
+  // "unexisting" appearanceDump and appearanceDump with zero entries are
+  // different values in skymp due to poor design
+  std::string appearanceDump;
+
+  // Same as 'appearanceDump', but uses std::optional instead of a string
+  std::optional<Equipment> equipmentDump;
+
   ActorValues actorValues;
 
   // Used only for player characters. See GetSpawnPoint

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1875,7 +1875,7 @@ void MpObjectReference::EnsureBaseContainerAdded(espm::Loader& espm)
       e.SetWorn(Inventory::Worn::Right);
       eq.inv.AddItems({ e });
     }
-    actor->SetEquipment(eq.ToJson().dump());
+    actor->SetEquipment(eq);
   }
 
   std::vector<Inventory::Entry> entries;

--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -686,10 +686,9 @@ void PartOne::Init()
 
     const char *equipmentPrefix = "", *equipment = "";
     if (emitterAsActor) {
-      const std::optional<Equipment>& equipment =
-        emitterAsActor->GetEquipment();
+      auto optionalEquipment = emitterAsActor->GetEquipment();
       jEquipment =
-        equipment ? emitterAsActor->GetEquipment().ToJson().dump() : "";
+        optionalEquipment ? optionalEquipment->ToJson().dump() : std::string();
       if (!jEquipment.empty()) {
         equipmentPrefix = R"(, "equipment": )";
         equipment = jEquipment.data();

--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -686,7 +686,10 @@ void PartOne::Init()
 
     const char *equipmentPrefix = "", *equipment = "";
     if (emitterAsActor) {
-      jEquipment = emitterAsActor->GetEquipmentAsJson();
+      const std::optional<Equipment>& equipment =
+        emitterAsActor->GetEquipment();
+      jEquipment =
+        equipment ? emitterAsActor->GetEquipment().ToJson().dump() : "";
       if (!jEquipment.empty()) {
         equipmentPrefix = R"(, "equipment": )";
         equipment = jEquipment.data();

--- a/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
@@ -107,7 +107,12 @@ float TES5DamageFormulaImpl::CalcOpponentArmorRating() const
 {
   float combinedArmorRating = 0;
   auto eq = target.GetEquipment();
-  for (auto& entry : eq.inv.entries) {
+
+  if (!eq) {
+    return 0.f;
+  }
+
+  for (auto& entry : eq->inv.entries) {
     combinedArmorRating += CalcArmorRatingComponent(entry);
   }
   return combinedArmorRating;

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
@@ -110,9 +110,14 @@ VarValue PapyrusActor::IsEquipped(VarValue self,
     formIds.emplace_back(form.ToGlobalId(form.rec->GetId()));
   }
 
-  auto equipment = actor->GetEquipment().inv;
+  auto equipment = actor->GetEquipment();
+  if (!equipment) {
+    return VarValue(false);
+  }
+
+  auto inv = equipment->inv;
   // Enum entries of equipment
-  for (auto& entry : equipment.entries) {
+  for (auto& entry : inv.entries) {
     // Filter out non-worn (in current implementation it is possible)
     if (entry.GetWorn() == Inventory::Worn::Right ||
         entry.GetWorn() == Inventory::Worn::Left) {
@@ -313,8 +318,9 @@ VarValue PapyrusActor::WornHasKeyword(VarValue self,
       return VarValue(false);
     }
 
-    const std::vector<Inventory::Entry>& entries =
-      actor->GetEquipment().inv.entries;
+    auto equipment = actor->GetEquipment();
+    const std::vector<Inventory::Entry> entries =
+      equipment ? equipment->inv.entries : std::vector<Inventory::Entry>();
     WorldState* worldState = compatibilityPolicy->GetWorldState();
     for (const auto& entry : entries) {
       if (entry.GetWorn() != Inventory::Worn::None) {

--- a/unit/ActorTest.cpp
+++ b/unit/ActorTest.cpp
@@ -10,7 +10,7 @@ TEST_CASE(
   Appearance appearance;
   appearance.raceId = 0x123;
   actor.SetAppearance(&appearance);
-  actor.SetEquipment(R"({"numChanges": 0, "inv": {"entries":[]}})");
+  actor.SetEquipment(Equipment());
   actor.SetRaceMenuOpen(true);
 
   REQUIRE(actor.GetChangeForm().appearanceDump == appearance.ToJson());

--- a/unit/HitTest.cpp
+++ b/unit/HitTest.cpp
@@ -25,21 +25,18 @@ TEST_CASE("OnHit damages target actor based on damage formula", "[Hit]")
   hitData.target = 0x14;
   hitData.aggressor = 0x14;
   hitData.source = 0x0001397E; // iron dagger 4 damage, id = 80254
+
   ac.AddItem(hitData.source, 1);
-  ac.SetEquipment(R"(
-    {
-      "numChanges": 0,
-      "inv": {
-        "entries": [
-          {
-            "baseId": 80254,
-            "count": 1,
-            "worn": true
-          }
-        ]
-      }
-    }
-  )");
+
+  Inventory::Entry equipmentEntry;
+  equipmentEntry.baseId = hitData.source;
+  equipmentEntry.count = 1;
+  equipmentEntry.worn_ = true;
+
+  Equipment equipment;
+  equipment.inv.AddItems({ equipmentEntry });
+
+  ac.SetEquipment(equipment);
 
   auto past = std::chrono::steady_clock::now() - 10s;
   ac.SetLastHitTime(past);
@@ -64,7 +61,7 @@ TEST_CASE("OnHit function sends ChangeValues message with coorect percentages",
   p.CreateActor(0xff000000, { 0, 0, 0 }, 0, 0x3c);
   p.SetUserActor(0, 0xff000000);
   auto& ac = p.worldState.GetFormAt<MpActor>(0xff000000);
-  ac.SetEquipment(R"({"inv": {"entries": []}})");
+  ac.SetEquipment(Equipment());
 
   ActionListener::RawMessageData rawMsgData;
   rawMsgData.userId = 0;
@@ -73,20 +70,15 @@ TEST_CASE("OnHit function sends ChangeValues message with coorect percentages",
   hitData.aggressor = 0x14;
   hitData.source = 0x0001397E; // iron dagger 4 damage
   ac.AddItem(hitData.source, 1);
-  ac.SetEquipment(R"(
-    {
-      "numChanges": 0,
-      "inv": {
-        "entries": [
-          {
-            "baseId": 80254,
-            "count": 1,
-            "worn": true
-          }
-        ]
-      }
-    }
-  )");
+
+  Inventory::Entry equipmentEntry;
+  equipmentEntry.baseId = hitData.source;
+  equipmentEntry.count = 1;
+  equipmentEntry.worn_ = true;
+
+  Equipment equipment;
+  equipment.inv.AddItems({ entry });
+  ac.SetEquipment(equipment);
 
   p.Messages().clear();
   auto past = std::chrono::steady_clock::now() - 4s;
@@ -218,20 +210,15 @@ TEST_CASE("checking weapon cooldown", "[Hit]")
   hitData.aggressor = 0x14;
   hitData.source = 0x0001397E;
   ac.AddItem(hitData.source, 1);
-  ac.SetEquipment(R"(
-    {
-      "numChanges": 0,
-      "inv": {
-        "entries": [
-          {
-            "baseId": 80254,
-            "count": 1,
-            "worn": true
-          }
-        ]
-      }
-    }
-  )");
+
+  Inventory::Entry equipmentEntry;
+  equipmentEntry.baseId = hitData.source;
+  equipmentEntry.count = 1;
+  equipmentEntry.worn_ = true;
+
+  Equipment equipment;
+  equipment.inv.AddItems({ entry });
+  ac.SetEquipment(equipment);
 
   auto past = std::chrono::steady_clock::now() - 300ms;
 

--- a/unit/TemplateInventoryTest.cpp
+++ b/unit/TemplateInventoryTest.cpp
@@ -16,10 +16,11 @@ TEST_CASE("MS13BanditCampfire01 in BleakFalls should have inventory/equipment "
   uint32_t actorId = 0x39fe4;
   auto& bandit = p.worldState.GetFormAt<MpActor>(actorId);
 
-  REQUIRE(bandit.GetEquipment().inv.ToJson().size() > 0);
+  REQUIRE(bandit.GetEquipment() != std::nullopt);
+  REQUIRE(bandit.GetEquipment()->inv.ToJson().size() > 0);
 
   int numWeaps = 0;
-  for (auto entry : bandit.GetEquipment().inv.entries) {
+  for (auto entry : bandit.GetEquipment()->inv.entries) {
     auto lookupRes =
       p.worldState.GetEspm().GetBrowser().LookupById(entry.baseId);
     if (lookupRes.rec && lookupRes.rec->GetType() == "WEAP") {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix equipment/inventory mismatch by transitioning from JSON strings to `Equipment` objects in `skymp5-server`.
> 
>   - **Behavior**:
>     - Change equipment handling from JSON strings to `Equipment` objects in `MpActor` and `ActionListener`.
>     - Ensure equipment consistency with inventory in `MpActor::GetEquipment()`.
>   - **Functions**:
>     - Modify `MpActor::SetEquipment()` to accept `Equipment` objects.
>     - Update `MpActor::GetEquipment()` to return `std::optional<Equipment>`.
>   - **Tests**:
>     - Update unit tests in `ActorTest.cpp` and `HitTest.cpp` to use `Equipment` objects.
>     - Adjust tests in `TES5DamageFormulaTest.cpp` to reflect new equipment handling.
>   - **Misc**:
>     - Remove `MpActor::GetEquipmentAsJson()` and related JSON handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b33b2cfb13252fa96896fa1a89f81d90f2b4b48e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->