### PR TITLE
feat(skymp5-server): add OnFireBlocked to ReadBookEvent for blocked book reading handling

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -1,6 +1,7 @@
 #include "ReadBookEvent.h"
 
 #include "MpActor.h"
+#include "SpSnippetFunctionGen.h"
 #include "WorldState.h"
 #include "script_objects/EspmGameObject.h"
 #include <string>

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -2,6 +2,7 @@
 
 #include "MpActor.h"
 #include "WorldState.h"
+#include "script_objects/EspmGameObject.h"
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -67,4 +68,28 @@ void ReadBookEvent::OnFireSuccess(WorldState* worldState)
       actor->GetFormId(), baseId);
     return;
   }
+}
+
+void ReadBookEvent::OnFireBlocked(WorldState* worldState) override
+{
+  auto& loader = actor->GetParent()->GetEspm();
+  auto bookLookupResult = loader.GetBrowser().LookupById(baseId);
+
+  const auto bookData = espm::GetData<espm::BOOK>(baseId, actor->GetParent());
+  const auto spellOrSkillFormId =
+    bookLookupResult.ToGlobalId(bookData.spellOrSkillFormId);
+
+  if (!bookData.IsFlagSet(espm::BOOK::Flags::TeachesSpell)) {
+    return;
+  }
+
+  auto aSpell = VarValue(
+    std::make_shared<EspmGameObject>(br.LookupById(spellOrSkillFormId)));
+
+  std::vector<VarValue> arguments = { aSpell };
+
+  SpSnippet("Actor", "RemoveSpell",
+            SpSnippetFunctionGen::SerializeArguments(arguments).data(),
+            actor->GetFormId())
+    .Execute(actor, SpSnippetMode::kNoReturnResult);
 }

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -83,8 +83,8 @@ void ReadBookEvent::OnFireBlocked(WorldState* worldState) override
     return;
   }
 
-  auto aSpell = VarValue(
-    std::make_shared<EspmGameObject>(br.LookupById(spellOrSkillFormId)));
+  auto aSpell = VarValue(std::make_shared<EspmGameObject>(
+    loader.GetBrowser().LookupById(spellOrSkillFormId)));
 
   std::vector<VarValue> arguments = { aSpell };
 

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.h
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.h
@@ -16,6 +16,7 @@ public:
 
 private:
   void OnFireSuccess(WorldState* worldState) override;
+  void OnFireBlocked(WorldState* worldState) override;
 
   // event arguments
   MpActor* actor = nullptr;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `OnFireBlocked` method to `ReadBookEvent` to handle blocked book reading events by removing spells.
> 
>   - **Behavior**:
>     - Adds `OnFireBlocked(WorldState* worldState)` to `ReadBookEvent` in `ReadBookEvent.cpp` and `ReadBookEvent.h`.
>     - `OnFireBlocked` checks if the book teaches a spell and removes the spell from the actor if true.
>   - **Misc**:
>     - Includes `script_objects/EspmGameObject.h` in `ReadBookEvent.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 2a338e0d995b5cc0818824e6b175c487fd2568bb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->