### PR TITLE
fix(skymp5-server): force template chain recalculation in case of incompatible esp/esm change

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -9,8 +9,7 @@
 template <uint16_t TemplateFlag, class Callback>
 auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
                       const std::vector<FormDesc>& templateChain,
-                      const Callback& callback,
-                      std::string* outError = nullptr)
+                      const Callback& callback)
 {
   const std::vector<FormDesc> chainDefault = { FormDesc::FromFormId(
     baseId, worldState->espmFiles) };
@@ -64,10 +63,5 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
   ss << ", templateFlag=" << TemplateFlag;
   ss << ", detailedLog=" << detailedLog.str();
 
-  if (outError) {
-    *outError = ss.str();
-    return {};
-  } else {
-    throw std::runtime_error(ss.str());
-  }
+  throw std::runtime_error(ss.str());
 }

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -72,15 +72,19 @@ auto EvaluateTemplateNoThrow(WorldState* worldState, uint32_t baseId,
                              const Callback& callback,
                              std::string* outException)
 {
+  using ResultType = decltype(EvaluateTemplate<TemplateFlag, Callback>(
+    worldState, baseId, templateChain, callback));
+  std::optional<ResultType> result;
+
   try {
-    auto res = EvaluateTemplate<TemplateFlag, Callback>(
-      worldState, baseId, templateChain, callback);
-    std::optional<decltype(res)> resOptional(res);
-    return resOptional;
+    result = EvaluateTemplate<TemplateFlag, Callback>(worldState, baseId,
+                                                      templateChain, callback);
   } catch (std::exception& e) {
     if (outException) {
       *outException = e.what();
     }
-    return std::nullopt;
+    result.reset();
   }
+
+  return result;
 }

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -16,12 +16,30 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
   const std::vector<FormDesc>& chain =
     templateChain.size() > 0 ? templateChain : chainDefault;
 
+  std::stringstream detailedLog;
+
   for (auto it = chain.begin(); it != chain.end(); it++) {
     auto templateChainElement = it->ToFormId(worldState->espmFiles);
+
+    detailedLog << "Processing FormDesc: " << it->ToString() << "\n";
+
     auto npcLookupResult =
       worldState->GetEspm().GetBrowser().LookupById(templateChainElement);
+    detailedLog << "Variable npcLookupResult: " << npcLookupResult.rec << "\n";
+
     auto npc = espm::Convert<espm::NPC_>(npcLookupResult.rec);
+    detailedLog << "Variable npc: " << npc << "\n";
+
+    if (!npc) {
+      detailedLog << "Variable npc was nullptr, failing EvaluateTemplate\n";
+      break;
+    }
+
     auto npcData = npc->GetData(worldState->GetEspmCache());
+
+    detailedLog << "Variable npcData: baseTemplate=" << npcData.baseTemplate
+                << ", templateDataFlags=",
+      << npcData.templateDataFlags << "\n";
 
     if (npcData.baseTemplate == 0) {
       return callback(npcLookupResult, npcData);
@@ -44,6 +62,7 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
   }
 
   ss << ", templateFlag=" << TemplateFlag;
+  ss << ", detailedLog=" << detailedLog.str();
 
   throw std::runtime_error(ss.str());
 }

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -9,7 +9,8 @@
 template <uint16_t TemplateFlag, class Callback>
 auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
                       const std::vector<FormDesc>& templateChain,
-                      const Callback& callback)
+                      const Callback& callback,
+                      std::string* outError = nullptr)
 {
   const std::vector<FormDesc> chainDefault = { FormDesc::FromFormId(
     baseId, worldState->espmFiles) };
@@ -63,5 +64,9 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
   ss << ", templateFlag=" << TemplateFlag;
   ss << ", detailedLog=" << detailedLog.str();
 
-  throw std::runtime_error(ss.str());
+  if (outError) {
+    *outError = ss.str();
+  } else {
+    throw std::runtime_error(ss.str());
+  }
 }

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -38,8 +38,7 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
     auto npcData = npc->GetData(worldState->GetEspmCache());
 
     detailedLog << "Variable npcData: baseTemplate=" << npcData.baseTemplate
-                << ", templateDataFlags=",
-      << npcData.templateDataFlags << "\n";
+                << ", templateDataFlags=" << npcData.templateDataFlags << "\n";
 
     if (npcData.baseTemplate == 0) {
       return callback(npcLookupResult, npcData);

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -70,7 +70,7 @@ template <uint16_t TemplateFlag, class Callback>
 auto EvaluateTemplateNoThrow(WorldState* worldState, uint32_t baseId,
                              const std::vector<FormDesc>& templateChain,
                              const Callback& callback,
-                             std::string& outException)
+                             std::string* outException)
 {
   try {
     auto res = EvaluateTemplate<TemplateFlag, Callback>(
@@ -78,7 +78,9 @@ auto EvaluateTemplateNoThrow(WorldState* worldState, uint32_t baseId,
     std::optional<decltype(res)> resOptional(res);
     return resOptional;
   } catch (std::exception& e) {
-    outException = e.what();
+    if (outException) {
+      *outException = e.what();
+    }
     return std::nullopt;
   }
 }

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -65,3 +65,20 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
 
   throw std::runtime_error(ss.str());
 }
+
+template <uint16_t TemplateFlag, class Callback>
+auto EvaluateTemplateNoThrow(WorldState* worldState, uint32_t baseId,
+                             const std::vector<FormDesc>& templateChain,
+                             const Callback& callback,
+                             std::string& outException)
+{
+  try {
+    auto res = EvaluateTemplate<TemplateFlag, Callback>(
+      worldState, baseId, templateChain, callback);
+    std::optional<decltype(res)> resOptional(res);
+    return resOptional;
+  } catch (std::exception& e) {
+    outException = e.what();
+    return std::nullopt;
+  }
+}

--- a/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
+++ b/skymp5-server/cpp/server_guest_lib/EvaluateTemplate.h
@@ -66,6 +66,7 @@ auto EvaluateTemplate(WorldState* worldState, uint32_t baseId,
 
   if (outError) {
     *outError = ss.str();
+    return {};
   } else {
     throw std::runtime_error(ss.str());
   }

--- a/skymp5-server/cpp/server_guest_lib/LeveledListUtils.cpp
+++ b/skymp5-server/cpp/server_guest_lib/LeveledListUtils.cpp
@@ -1,4 +1,5 @@
 #include "LeveledListUtils.h"
+#include "EvaluateTemplate.h"
 #include <optional>
 #include <random>
 #include <spdlog/spdlog.h>

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -334,8 +334,8 @@ void MpActor::VisitProperties(const PropertiesVisitor& visitor,
   // this "if" is needed for unit testing: tests can call VisitProperties
   // without espm attached, which will cause tests to fail
   if (worldState && worldState->HasEspm()) {
-    baseActorValues =
-      GetBaseActorValues(worldState, baseId, raceId, templateChain);
+    baseActorValues = GetBaseActorValues(worldState, baseId, raceId,
+                                         ChangeForm().templateChain);
   }
 
   MpChangeForm changeForm = GetChangeForm();
@@ -780,7 +780,7 @@ espm::ObjectBounds MpActor::GetBounds() const
 
 const std::vector<FormDesc>& MpActor::GetTemplateChain() const
 {
-  return templateChain;
+  return ChangeForm().templateChain;
 }
 
 bool MpActor::IsCreatedAsPlayer() const
@@ -909,9 +909,10 @@ void MpActor::EnsureTemplateChainEvaluated(espm::Loader& loader,
     auto doNothing = [](const auto&, const auto&) { return; };
 
     auto evaluateTemplateChecked =
-      []<typename Flag>(WorldState* worldState, uint32_t baseId,
-                        const std::vector<uint32_t>& templateChain,
-                        const auto& callback, std::string* error) {
+      []<espm::NPC_::TemplateFlags Flag>(
+        WorldState* worldState, uint32_t baseId,
+        const std::vector<uint32_t>& templateChain, const auto& callback,
+        std::string* error) {
         try {
           EvaluateTemplate<Flag>(worldState, baseId, templateChain, callback);
         } catch (std::exception& e) {

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -906,55 +906,55 @@ void MpActor::EnsureTemplateChainEvaluated(espm::Loader& loader,
 
     EvaluateTemplate<espm::NPC_::UseTraits>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorTraits);
+      [](const auto&, const auto&) { return; }, &errorTraits);
 
     EvaluateTemplate<espm::NPC_::UseStats>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorStats);
+      [](const auto&, const auto&) { return; }, &errorStats);
 
     EvaluateTemplate<espm::NPC_::UseFactions>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorFactions);
+      [](const auto&, const auto&) { return; }, &errorFactions);
 
     EvaluateTemplate<espm::NPC_::UseSpelllist>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorSpelllist);
+      [](const auto&, const auto&) { return; }, &errorSpelllist);
 
     EvaluateTemplate<espm::NPC_::UseAIData>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorAIData);
+      [](const auto&, const auto&) { return; }, &errorAIData);
 
     EvaluateTemplate<espm::NPC_::UseAIPackages>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorAIPackages);
+      [](const auto&, const auto&) { return; }, &errorAIPackages);
 
     EvaluateTemplate<espm::NPC_::Unused>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorUnused);
+      [](const auto&, const auto&) { return; }, &errorUnused);
 
     EvaluateTemplate<espm::NPC_::UseBaseData>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorBaseData);
+      [](const auto&, const auto&) { return; }, &errorBaseData);
 
     EvaluateTemplate<espm::NPC_::UseInventory>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorInventory);
+      [](const auto&, const auto&) { return; }, &errorInventory);
 
     EvaluateTemplate<espm::NPC_::UseScript>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorScript);
+      [](const auto&, const auto&) { return; }, &errorScript);
 
     EvaluateTemplate<espm::NPC_::UseDefPackList>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorDefPackList);
+      [](const auto&, const auto&) { return; }, &errorDefPackList);
 
     EvaluateTemplate<espm::NPC_::UseAttackData>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorAttackData);
+      [](const auto&, const auto&) { return; }, &errorAttackData);
 
     EvaluateTemplate<espm::NPC_::UseKeywords>(
       worldState, baseId, ChangeForm().templateChain,
-      [](const auto&, const auto&) { return 0; }, &errorKeywords);
+      [](const auto&, const auto&) { return; }, &errorKeywords);
 
     if (errorTraits.empty() && errorStats.empty() && errorFactions.empty() &&
         errorSpelllist.empty() && errorAIData.empty() &&

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1034,7 +1034,7 @@ std::map<uint32_t, uint32_t> MpActor::EvaluateDeathItem()
   }
 
   uint32_t baseId = base.ToGlobalId(base.rec->GetId());
-  auto& templateChain = templateChain;
+  auto& templateChain = ChangeForm().templateChain;
 
   uint32_t deathItemId = EvaluateTemplate<espm::NPC_::UseTraits>(
     worldState, baseId, templateChain,

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -967,7 +967,8 @@ void MpActor::EnsureTemplateChainEvaluated(espm::Loader& loader,
 
     spdlog::info(
       "MpActor::EnsureTemplateChainEvaluate {:x} - One of EvaluateTemplate "
-      "errored, forgetting previous template chain",
+      "errored, forgetting previous template chain. Likely, an update on "
+      "esp/esm side.",
       GetFormId());
   }
 

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -889,7 +889,86 @@ void MpActor::EnsureTemplateChainEvaluated(espm::Loader& loader,
   }
 
   if (!ChangeForm().templateChain.empty()) {
-    return;
+
+    std::string errorTraits;
+    std::string errorStats;
+    std::string errorFactions;
+    std::string errorSpelllist;
+    std::string errorAIData;
+    std::string errorAIPackages;
+    std::string errorUnused;
+    std::string errorBaseData;
+    std::string errorInventory;
+    std::string errorScript;
+    std::string errorDefPackList;
+    std::string errorAttackData;
+    std::string errorKeywords;
+
+    EvaluateTemplate<espm::NPC_::UseTraits>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorTraits);
+
+    EvaluateTemplate<espm::NPC_::UseStats>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorStats);
+
+    EvaluateTemplate<espm::NPC_::UseFactions>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorFactions);
+
+    EvaluateTemplate<espm::NPC_::UseSpelllist>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorSpelllist);
+
+    EvaluateTemplate<espm::NPC_::UseAIData>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorAIData);
+
+    EvaluateTemplate<espm::NPC_::UseAIPackages>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorAIPackages);
+
+    EvaluateTemplate<espm::NPC_::Unused>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorUnused);
+
+    EvaluateTemplate<espm::NPC_::UseBaseData>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorBaseData);
+
+    EvaluateTemplate<espm::NPC_::UseInventory>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorInventory);
+
+    EvaluateTemplate<espm::NPC_::UseScript>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorScript);
+
+    EvaluateTemplate<espm::NPC_::UseDefPackList>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorDefPackList);
+
+    EvaluateTemplate<espm::NPC_::UseAttackData>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorAttackData);
+
+    EvaluateTemplate<espm::NPC_::UseKeywords>(
+      worldState, baseId, ChangeForm().templateChain,
+      [](const auto&, const auto&) { return 0; }, &errorKeywords);
+
+    if (errorTraits.empty() && errorStats.empty() && errorFactions.empty() &&
+        errorSpelllist.empty() && errorAIData.empty() &&
+        errorAIPackages.empty() && errorUnused.empty() &&
+        errorBaseData.empty() && errorInventory.empty() &&
+        errorScript.empty() && errorDefPackList.empty() &&
+        errorAttackData.empty() && errorKeywords.empty()) {
+      return;
+    }
+
+    spdlog::info(
+      "MpActor::EnsureTemplateChainEvaluate {:x} - One of EvaluateTemplate "
+      "errored, forgetting previous template chain",
+      GetFormId());
   }
 
   EditChangeForm(

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1352,7 +1352,7 @@ void MpActor::DamageActorValue(espm::ActorValue av, float value)
 BaseActorValues MpActor::GetBaseValues()
 {
   return GetBaseActorValues(GetParent(), GetBaseId(), GetRaceId(),
-                            templateChain);
+                            ChangeForm().templateChain);
 }
 
 BaseActorValues MpActor::GetMaximumValues()
@@ -1698,8 +1698,8 @@ void MpActor::ApplyMagicEffects(std::vector<espm::Effects::Effect>& effects,
 
 void MpActor::RemoveMagicEffect(const espm::ActorValue actorValue) noexcept
 {
-  const ActorValues baseActorValues =
-    GetBaseActorValues(GetParent(), GetBaseId(), GetRaceId(), templateChain);
+  const ActorValues baseActorValues = GetBaseActorValues(
+    GetParent(), GetBaseId(), GetRaceId(), ChangeForm().templateChain);
   const float baseActorValue = baseActorValues.GetValue(actorValue);
   SetActorValue(actorValue, baseActorValue);
   EditChangeForm([actorValue](MpChangeForm& changeForm) {
@@ -1709,8 +1709,8 @@ void MpActor::RemoveMagicEffect(const espm::ActorValue actorValue) noexcept
 
 void MpActor::RemoveAllMagicEffects() noexcept
 {
-  const ActorValues baseActorValues =
-    GetBaseActorValues(GetParent(), GetBaseId(), GetRaceId(), templateChain);
+  const ActorValues baseActorValues = GetBaseActorValues(
+    GetParent(), GetBaseId(), GetRaceId(), ChangeForm().templateChain);
   SetActorValues(baseActorValues);
   EditChangeForm(
     [](MpChangeForm& changeForm) { changeForm.activeMagicEffects.Clear(); });

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -906,57 +906,45 @@ void MpActor::EnsureTemplateChainEvaluated(espm::Loader& loader,
     std::string errorAttackData;
     std::string errorKeywords;
 
-    auto doNothing = [](const auto&, const auto&) { return; };
+    auto doNothing = [](const auto&, const auto&) { return 1; };
 
-    auto evaluateTemplateChecked =
-      []<espm::NPC_::TemplateFlags Flag>(
-        WorldState* worldState, uint32_t baseId,
-        const std::vector<uint32_t>& templateChain, const auto& callback,
-        std::string* error) {
-        try {
-          EvaluateTemplate<Flag>(worldState, baseId, templateChain, callback);
-        } catch (std::exception& e) {
-          *error = e.what();
-        }
-      };
-
-    evaluateTemplateChecked<espm::NPC_::UseTraits>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseTraits>(
       worldState, baseId, templateChain, doNothing, &errorTraits);
 
-    evaluateTemplateChecked<espm::NPC_::UseStats>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseStats>(
       worldState, baseId, templateChain, doNothing, &errorStats);
 
-    evaluateTemplateChecked<espm::NPC_::UseFactions>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseFactions>(
       worldState, baseId, templateChain, doNothing, &errorFactions);
 
-    evaluateTemplateChecked<espm::NPC_::UseSpelllist>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseSpelllist>(
       worldState, baseId, templateChain, doNothing, &errorSpelllist);
 
-    evaluateTemplateChecked<espm::NPC_::UseAIData>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseAIData>(
       worldState, baseId, templateChain, doNothing, &errorAIData);
 
-    evaluateTemplateChecked<espm::NPC_::UseAIPackages>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseAIPackages>(
       worldState, baseId, templateChain, doNothing, &errorAIPackages);
 
-    evaluateTemplateChecked<espm::NPC_::Unused>(
+    EvaluateTemplateNoThrow<espm::NPC_::Unused>(
       worldState, baseId, templateChain, doNothing, &errorUnused);
 
-    evaluateTemplateChecked<espm::NPC_::UseBaseData>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseBaseData>(
       worldState, baseId, templateChain, doNothing, &errorBaseData);
 
-    evaluateTemplateChecked<espm::NPC_::UseInventory>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseInventory>(
       worldState, baseId, templateChain, doNothing, &errorInventory);
 
-    evaluateTemplateChecked<espm::NPC_::UseScript>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseScript>(
       worldState, baseId, templateChain, doNothing, &errorScript);
 
-    evaluateTemplateChecked<espm::NPC_::UseDefPackList>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseDefPackList>(
       worldState, baseId, templateChain, doNothing, &errorDefPackList);
 
-    evaluateTemplateChecked<espm::NPC_::UseAttackData>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseAttackData>(
       worldState, baseId, templateChain, doNothing, &errorAttackData);
 
-    evaluateTemplateChecked<espm::NPC_::UseKeywords>(
+    EvaluateTemplateNoThrow<espm::NPC_::UseKeywords>(
       worldState, baseId, templateChain, doNothing, &errorKeywords);
 
     if (errorTraits.empty() && errorStats.empty() && errorFactions.empty() &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhanced `EvaluateTemplate` in `EvaluateTemplate.h` with detailed logging for better debugging.
> 
>   - **Logging**:
>     - Added `detailedLog` stringstream in `EvaluateTemplate` to log processing details of `FormDesc` objects.
>     - Logs include `FormDesc` processing, `npcLookupResult`, `npc`, and `npcData` states.
>     - Appends `detailedLog` to error message in case of failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for d540ab18017cbe29871c7c4ee6544ec10e20712e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->