### PR TITLE
fix(skymp5-server): fix missing 'numChanges' in equipmentDump JSON

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpChangeForms.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpChangeForms.cpp
@@ -1,5 +1,6 @@
 #include "MpChangeForms.h"
 #include "JsonUtils.h"
+#include <spdlog/spdlog.h>
 
 namespace {
 std::vector<std::string> ToStringArray(const std::vector<FormDesc>& formDescs)
@@ -192,6 +193,15 @@ MpChangeForm MpChangeForm::JsonToChangeForm(simdjson::dom::element& element)
   res.equipmentDump = simdjson::minify(jTmp);
   if (res.equipmentDump == "null") {
     res.equipmentDump.clear();
+  } else {
+    auto equipment = nlohmann::json::parse(res.equipmentDump);
+    if (!equipment.contains("numChanges")) {
+      equipment["numChanges"] = 0;
+      res.equipmentDump = equipment.dump();
+      spdlog::info("MpChangeForm::JsonToChangeForm {} - Missing 'numChanges' "
+                   "key, setting to 0",
+                   res.formDesc.ToString());
+    }
   }
 
   if (element.at_pointer(learnedSpells.GetData()).error() ==

--- a/unit/SaveStorageTest.cpp
+++ b/unit/SaveStorageTest.cpp
@@ -112,7 +112,7 @@ TEST_CASE("ChangeForm is saved correctly", "[save]")
       f1.position = { 1, 2, 3 };
       f1.appearanceDump = "{}";
       f1.inv.AddItem(0xf, 1000);
-      f1.equipmentDump = "[]";
+      f1.equipmentDump = Equipment().ToJson().dump();
       f1.actorValues.healthPercentage = 0.25f;
       f1.actorValues.magickaPercentage = 0.3f;
       f1.actorValues.staminaPercentage = 1.0f;
@@ -135,7 +135,7 @@ TEST_CASE("ChangeForm is saved correctly", "[save]")
       REQUIRE(res.size() == 2);
       REQUIRE(res[{ 1, "" }].position == NiPoint3(1, 2, 3));
       REQUIRE(res[{ 1, "" }].appearanceDump == "{}");
-      REQUIRE(res[{ 1, "" }].equipmentDump == "[]");
+      REQUIRE(res[{ 1, "" }].equipmentDump == Equipment().ToJson().dump());
       REQUIRE(res[{ 1, "" }].inv == Inventory().AddItem(0xf, 1000));
       REQUIRE(res[{ 1, "" }].isDisabled == false);
       REQUIRE(res[{ 1, "" }].profileId == -1);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logging for missing 'numChanges' key in `equipmentDump` JSON in `MpChangeForm::JsonToChangeForm`.
> 
>   - **Behavior**:
>     - In `MpChangeForm::JsonToChangeForm`, if `equipmentDump` JSON lacks `numChanges`, it is set to 0 and logged using `spdlog`.
>   - **Logging**:
>     - Added `spdlog` include to `MpChangeForms.cpp` for logging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 78290eb6b9733a5e0591bbf0fd5c13416c219f4a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->