### PR TITLE
feat(skymp5-server): add spell retrieval methods to MpActor and PapyrusActor

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -668,6 +668,8 @@ bool MpActor::IsSpellLearned(const uint32_t spellId) const
 
 bool MpActor::IsSpellLearnedFromBase(const uint32_t spellId) const
 {
+  // TODO: support npc templates here?
+
   const auto npcData = espm::GetData<espm::NPC_>(GetBaseId(), GetParent());
   const auto npc = GetParent()->GetEspm().GetBrowser().LookupById(GetBaseId());
 
@@ -691,6 +693,11 @@ bool MpActor::IsSpellLearnedFromBase(const uint32_t spellId) const
   }
 
   return false;
+}
+
+std::vector<uint32_t> MpActor::GetSpellList() const
+{
+  return ChangeForm().learnedSpells.GetLearnedSpells();
 }
 
 std::unique_ptr<const Appearance> MpActor::GetAppearance() const

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -33,6 +33,7 @@ public:
 
   bool IsSpellLearned(uint32_t spellId) const; // including from base
   bool IsSpellLearnedFromBase(uint32_t spellId) const;
+  std::vector<uint32_t> GetSpellList() const;
 
   std::unique_ptr<const Appearance> GetAppearance() const;
   const std::string& GetAppearanceAsJson();

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.h
@@ -61,6 +61,11 @@ public:
 
   VarValue GetRace(VarValue self, const std::vector<VarValue>& arguments);
 
+  VarValue GetSpellCount(VarValue self,
+                         const std::vector<VarValue>& arguments);
+
+  VarValue GetNthSpell(VarValue self, const std::vector<VarValue>& arguments);
+
   void Register(VirtualMachine& vm,
                 std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add methods to `MpActor` and `PapyrusActor` for handling spell retrieval and counting.
> 
>   - **Behavior**:
>     - Add `GetSpellList()` to `MpActor` to retrieve learned spells.
>     - Add `GetSpellCount()` and `GetNthSpell()` to `PapyrusActor` to count and retrieve spells learned during gameplay.
>   - **Methods**:
>     - Implement `GetSpellCount()` and `GetNthSpell()` in `PapyrusActor.cpp`.
>     - Register new methods in `PapyrusActor::Register()`.
>   - **Misc**:
>     - Add TODO comment in `MpActor::IsSpellLearnedFromBase()` regarding NPC templates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for e181685dccf9c912db52d5b764278afb155aa2b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->