### PR TITLE
fix(skymp5-client): prevent profiling file overwrites by adding random suffix

### DIFF
--- a/skymp5-client/src/services/services/profilingService.ts
+++ b/skymp5-client/src/services/services/profilingService.ts
@@ -62,7 +62,8 @@ export class ProfilingService extends ClientListener {
             });
         });
 
-        fs.writeFileSync('./profile.cpuprofile', JSON.stringify(profile));
+        const fileNameSuffix = Math.random().toString().replace(".0", "");
+        fs.writeFileSync(`./profile${fileNameSuffix}.cpuprofile`, JSON.stringify(profile));
     }
 
     private getInteger(value: unknown) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add random suffix to profiling output file names in `ProfilingService` to prevent overwrites.
> 
>   - **Behavior**:
>     - Modify file naming in `ProfilingService` to include a random suffix, preventing overwrites of `profile.cpuprofile` files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 0015e1a0121b662af4a24af1304435856f4451a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->