### PR TITLE
internal: update node-embedder-api-prebuilt vcpkg port

### DIFF
--- a/overlay_ports/node-embedder-api-prebuilt/portfile.cmake
+++ b/overlay_ports/node-embedder-api-prebuilt/portfile.cmake
@@ -1,6 +1,6 @@
 set(NODE_EMBEDDER_API_URL "https://node-embedder-api-prebuilt-vcpkg-port-v2.b-cdn.net/archive.zip")
 set(NODE_EMBEDDER_API_FILENAME "node-embedder-api-prebuilt.zip")
-set(NODE_EMBEDDER_API_SHA512 0)
+set(NODE_EMBEDDER_API_SHA512 31aa1c29b0c2cf4da4f6b2fa98471d0c692928d2efbe5d547e1910124db783483e8a899333fb116030b0d93b1896cba13dcd6ddb11b96e8308b02b90a36612f0)
 
 vcpkg_download_distfile(ARCHIVE
     URLS ${NODE_EMBEDDER_API_URL}

--- a/overlay_ports/node-embedder-api-prebuilt/portfile.cmake
+++ b/overlay_ports/node-embedder-api-prebuilt/portfile.cmake
@@ -1,6 +1,6 @@
-set(NODE_EMBEDDER_API_URL "https://node-embedder-api-prebuilt-vcpkg-port.b-cdn.net/node-embedder-api-prebuilt.zip")
+set(NODE_EMBEDDER_API_URL "https://node-embedder-api-prebuilt-vcpkg-port-v2.b-cdn.net/archive.zip")
 set(NODE_EMBEDDER_API_FILENAME "node-embedder-api-prebuilt.zip")
-set(NODE_EMBEDDER_API_SHA512 0082a1537052d2343a867cac2eb9acb9ba2da1607c3766ef5ada6fd2498e0fc3df754cabf3a47825358e441a7f594addcf8fdf3be84b05f27fa6eb8aefa1e2ed)
+set(NODE_EMBEDDER_API_SHA512 0)
 
 vcpkg_download_distfile(ARCHIVE
     URLS ${NODE_EMBEDDER_API_URL}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `portfile.cmake` to change the download URL and reset the SHA512 hash for the node embedder API prebuilt archive.
> 
>   - **URL Update**:
>     - Change `NODE_EMBEDDER_API_URL` to `https://node-embedder-api-prebuilt-vcpkg-port-v2.b-cdn.net/archive.zip` in `portfile.cmake`.
>   - **SHA512 Update**:
>     - Set `NODE_EMBEDDER_API_SHA512` to `0` in `portfile.cmake`, indicating a placeholder or reset value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for c865fd38fd7fd8d2815297b849e8017b629febf5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->