### PR TITLE
internal: update node-embedder-api-prebuilt to version 2

### DIFF
--- a/overlay_ports/node-embedder-api-prebuilt/vcpkg.json
+++ b/overlay_ports/node-embedder-api-prebuilt/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "node-embedder-api-prebuilt",
-    "version": "1",
+    "version": "2",
     "description": "NodeJS API for embedding NodeJS in your C++ applications",
     "homepage": "https://nodejs.org/api/embedding.html",
     "license": "MIT",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `node-embedder-api-prebuilt` version from 1 to 2 in `vcpkg.json`.
> 
>   - **Version Update**:
>     - Update `version` from "1" to "2" in `vcpkg.json` for `node-embedder-api-prebuilt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 1476b3f773a240cebeee95272c52a620c0a91511. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->