### PR TITLE
internal: update node-embedder-api build process and version

### DIFF
--- a/overlay_ports/node-embedder-api/portfile.cmake
+++ b/overlay_ports/node-embedder-api/portfile.cmake
@@ -1,20 +1,53 @@
+# TODO: fix Linux build, should copy .so, not .a
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO nodejs/node
   REF "v${VERSION}"
-  SHA512 cb88b3576ac810ceace7d5824d5a6e1c4181a9327f1420d6eb1546a03a22f5f80bdddcbef6bc478ce4cb62dcd724b7a04eda707845a4003b96a5d6aed5463b37
+  SHA512 349d9da5ba8322074897adb160fb434c83cb69b2bec988a52b50a41202f250e1da8058df5362b16741a8a1bec7ffd8e3585f9af881b4d67e1c81a57fc8545c15
   HEAD_REF main
 )
 
 # Fixes arm64-windows host building x64-windows target
 vcpkg_replace_string("${SOURCE_PATH}/configure.py" "'ARM64'  : 'arm64'" "'ARM64'  : 'x64'")
 
+# 0 for /MT, 1 for /MTd, 2 for /MD, 3 for /MDd
+
+set(files_to_replace
+  common.gypi
+  tools/v8_gypfiles/toolchain.gypi
+  tools/gyp/pylib/gyp/MSVSSettings_test.py
+  deps/uv/common.gypi
+  deps/llhttp/common.gypi
+)
+
+foreach(file_to_replace ${files_to_replace})
+  vcpkg_replace_string("${SOURCE_PATH}/${file_to_replace}" "'RuntimeLibrary': '<(MSVC_runtimeType)'" "'RuntimeLibrary': '0'")
+  vcpkg_replace_string("${SOURCE_PATH}/${file_to_replace}" "'RuntimeLibrary': '1'" "'RuntimeLibrary': '0'")
+  vcpkg_replace_string("${SOURCE_PATH}/${file_to_replace}" "'RuntimeLibrary': '2'" "'RuntimeLibrary': '0'")
+  vcpkg_replace_string("${SOURCE_PATH}/${file_to_replace}" "'RuntimeLibrary': '3'" "'RuntimeLibrary': '0'")
+endforeach()
+
+
+if(VCPKG_TARGET_IS_WINDOWS)
+  if("${VCPKG_CRT_LINKAGE}" STREQUAL "static")
+    message(STATUS "Forcing static CRT linkage for nodejs")
+    vcpkg_replace_string("${SOURCE_PATH}/configure.py" "o['variables']['force_dynamic_crt'] = 1 if options.shared else 0" "o['variables']['force_dynamic_crt'] = 0")
+  else()
+    message(STATUS "Forcing dynamic CRT linkage for nodejs")
+    vcpkg_replace_string("${SOURCE_PATH}/configure.py" "o['variables']['force_dynamic_crt'] = 1 if options.shared else 0" "o['variables']['force_dynamic_crt'] = 1")
+  endif()
+endif()
+
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
 vcpkg_add_to_path(PREPEND "${PYTHON3_EXE_PATH}")
 
 if(VCPKG_TARGET_IS_WINDOWS)
-  set(nodejs_options openssl-no-asm static ${VCPKG_TARGET_ARCHITECTURE})
+  # dll/static is an option. 
+  # dll is recommended for embedding by nodejs authors 
+  # https://github.com/nodejs/node/blob/70fcb87af4c41be4f480b213d8b3edfc49629c9f/configure.py#L865
+  set(nodejs_options openssl-no-asm dll ${VCPKG_TARGET_ARCHITECTURE})
 
   if(NOT "${VCPKG_BUILD_TYPE}" STREQUAL "release")
     message(STATUS "Building nodejs Debug")
@@ -32,6 +65,13 @@ if(VCPKG_TARGET_IS_WINDOWS)
     if(NOT NODE_BUILD_SH_RES EQUAL 0)
       message(FATAL_ERROR "Failed to build nodejs Debug (code ${NODE_BUILD_SH_RES})")
     endif()
+
+    set(dll_path_debug "${SOURCE_PATH}/Debug/libnode.dll")
+    set(lib_path_debug "${SOURCE_PATH}/Debug/libnode.lib")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin/node-embedder-api")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/node-embedder-api")
+    file(COPY "${dll_path_debug}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/node-embedder-api")
+    file(COPY "${lib_path_debug}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/node-embedder-api")
   endif()
 
   message(STATUS "Building nodejs Release")
@@ -51,19 +91,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
     message(FATAL_ERROR "Failed to build nodejs Release (code ${NODE_BUILD_SH_RES})")
   endif()
 
-  file(GLOB libs_debug "${SOURCE_PATH}/Debug/*.lib")
-  foreach(path ${libs_debug})
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/node-embedder-api")
-    file(COPY "${path}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/node-embedder-api")
-  endforeach()
-
-  file(GLOB libs "${SOURCE_PATH}/Release/*.lib")
-  foreach(path ${libs})
-    if(NOT "${path}" MATCHES ".*cctest\.lib|.*embedtest\.lib")
-      file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/node-embedder-api")
-      file(COPY "${path}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/node-embedder-api")
-    endif()
-  endforeach()
+  set(dll_path_release "${SOURCE_PATH}/Release/libnode.dll")
+  set(lib_path_release "${SOURCE_PATH}/Release/libnode.lib")
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin/node-embedder-api")
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/node-embedder-api")
+  file(COPY "${dll_path_release}" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/node-embedder-api")
+  file(COPY "${lib_path_release}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/node-embedder-api")
 else()
   find_program(MAKE make REQUIRED)
 
@@ -144,19 +177,74 @@ file(COPY "${SOURCE_PATH}/src/node.h" DESTINATION "${CURRENT_PACKAGES_DIR}/inclu
 file(COPY "${SOURCE_PATH}/src/node_api.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api")
 file(COPY "${SOURCE_PATH}/src/node_version.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api")
 
-file(GLOB v8_headers "${SOURCE_PATH}/src/deps/v8/include/*.h")
-foreach(v8_header ${v8_headers})
-  file(COPY "${v8_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api")
+file(GLOB found_headers "${SOURCE_PATH}/deps/v8/include/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api")
 endforeach()
 
-file(GLOB v8_headers "${SOURCE_PATH}/src/deps/v8/include/cppgc/*.h")
-foreach(v8_header ${v8_headers})
-  file(COPY "${v8_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/cppgc")
+file(GLOB found_headers "${SOURCE_PATH}/deps/v8/include/cppgc/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/cppgc")
 endforeach()
 
-file(GLOB v8_headers "${SOURCE_PATH}/src/deps/v8/include/libplatform/*.h")
-foreach(v8_header ${v8_headers})
-  file(COPY "${v8_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/libplatform")
+file(GLOB found_headers "${SOURCE_PATH}/deps/v8/include/cppgc/internal/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/cppgc/internal")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/deps/v8/include/libplatform/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/libplatform")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/deps/uv/include/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/deps/uv/include/uv/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/uv")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/crypto/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/crypto")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/dataqueue/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/dataqueue")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/inspector/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/inspector")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/large_pages/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/large_pages")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/permission/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/permission")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/quic/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/quic")
+endforeach()
+
+file(GLOB found_headers "${SOURCE_PATH}/src/tracing/*.h")
+foreach(found_header ${found_headers})
+  file(COPY "${found_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/node-embedder-api/tracing")
 endforeach()
 
 # node_api.h requirements

--- a/overlay_ports/node-embedder-api/vcpkg.json
+++ b/overlay_ports/node-embedder-api/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "node-embedder-api",
-    "version": "22.0.0",
+    "version": "23.2.0",
     "description": "NodeJS API for embedding NodeJS in your C++ applications",
     "homepage": "https://nodejs.org/api/embedding.html",
     "license": "MIT",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `node-embedder-api` build process for Windows and increment version to 23.2.0.
> 
>   - **Build Process**:
>     - Updated `portfile.cmake` to copy `libnode.dll` and `libnode.lib` for both Debug and Release builds on Windows.
>     - Replaced `RuntimeLibrary` settings in multiple files to enforce static linkage.
>     - Added logic to force static or dynamic CRT linkage based on `VCPKG_CRT_LINKAGE`.
>     - Expanded header file copying to include additional directories like `cppgc`, `libplatform`, `uv`, `crypto`, `dataqueue`, `inspector`, `large_pages`, `permission`, `quic`, and `tracing`.
>   - **Version Update**:
>     - Updated version in `vcpkg.json` from `22.0.0` to `23.2.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 9e7b5b132030d2c914339e77eb491b40f25c6a69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->