### PR TITLE
internal: update node-embedder-api to version with headers mismatch fixed

### DIFF
--- a/overlay_ports/node-embedder-api-prebuilt/portfile.cmake
+++ b/overlay_ports/node-embedder-api-prebuilt/portfile.cmake
@@ -1,6 +1,6 @@
-set(NODE_EMBEDDER_API_URL "https://node-embedder-api-prebuilt-vcpkg-port-v2.b-cdn.net/archive.zip")
+set(NODE_EMBEDDER_API_URL "https://node-embedder-api-prebuilt-vcpkg-port-v2.b-cdn.net/archive2_1.zip")
 set(NODE_EMBEDDER_API_FILENAME "node-embedder-api-prebuilt.zip")
-set(NODE_EMBEDDER_API_SHA512 31aa1c29b0c2cf4da4f6b2fa98471d0c692928d2efbe5d547e1910124db783483e8a899333fb116030b0d93b1896cba13dcd6ddb11b96e8308b02b90a36612f0)
+set(NODE_EMBEDDER_API_SHA512 bea6dbf02783e3cafbe8a752f3ce245e85189d3946902aece5a5ff6373cec684a986aa65df279f1c79fc886be380edac0926fc3808930a29a013d7fefeec67da)
 
 vcpkg_download_distfile(ARCHIVE
     URLS ${NODE_EMBEDDER_API_URL}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update URL and SHA512 hash in `portfile.cmake` for new node-embedder-api prebuilt package version.
> 
>   - **CMake Configuration**:
>     - Update `NODE_EMBEDDER_API_URL` in `portfile.cmake` to new archive URL `archive2_1.zip`.
>     - Update `NODE_EMBEDDER_API_SHA512` in `portfile.cmake` to new hash `bea6dbf02783e3cafbe8a752f3ce245e85189d3946902aece5a5ff6373cec684a986aa65df279f1c79fc886be380edac0926fc3808930a29a013d7fefeec67da`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 5b3d8ab5e8b1a3023569f186feedbbddd6cb063f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->