### PR TITLE
feat: add SweetPieSpellDamageFormula for spell damage modification

### DIFF
--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -11,6 +11,7 @@
 #include "database_drivers/DatabaseFactory.h"
 #include "formulas/DamageMultFormula.h"
 #include "formulas/SweetPieDamageFormula.h"
+#include "formulas/SweetPieSpellDamageFormula.h"
 #include "formulas/TES5DamageFormula.h"
 #include "libespm/IterateFields.h"
 #include "papyrus-vm/Utils.h"

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -328,6 +328,9 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
     auto sweetPieDamageFormulaSettings =
       serverSettings["sweetPieDamageFormulaSettings"];
 
+    auto sweetPieSpellDamageFormulaSettings =
+      serverSettings["sweetPieSpellDamageFormulaSettings"];
+
     auto damageMultFormulaSettings =
       serverSettings["damageMultFormulaSettings"];
 
@@ -337,6 +340,8 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
                                                   damageMultFormulaSettings);
     formula = std::make_unique<SweetPieDamageFormula>(
       std::move(formula), sweetPieDamageFormulaSettings);
+    formula = std::make_unique<SweetPieSpellDamageFormula>(
+      std::move(formula), sweetPieSpellDamageFormulaSettings);
     partOne->SetDamageFormula(std::move(formula));
 
     partOne->worldState.AttachScriptStorage(

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieDamageFormula.h
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieDamageFormula.h
@@ -9,7 +9,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 
-// Modifies vanilla damage
+// Modifies vanilla damage for weapons
 
 struct SweetPieDamageFormulaSettings
 {

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -2,6 +2,7 @@
 
 #include "archives/JsonInputArchive.h"
 #include <limits>
+#include <sstream>
 
 namespace SweetPieSpellDamageFormulaPrivate {
 template <class T>
@@ -57,11 +58,22 @@ float SweetPieSpellDamageFormula::CalculateDamage(
   float biggestMult = -1;
 
   for (auto& entry : settings->entries) {
-    const auto itemId = entry.itemId;
-    const auto mult = SweetPieSpellDamageFormulaPrivate::Clamp(
+    const std::string& itemId = entry.itemId;
+    const float mult = SweetPieSpellDamageFormulaPrivate::Clamp(
       entry.mult, 0.f, std::numeric_limits<float>::infinity());
 
-    if (aggressor.GetItemCount(itemId) > 0) {
+    uint32_t itemIdParsed = 0;
+
+    if (itemId.find("0x") == 0 || itemId.find("0X") == 0) {
+      std::stringstream ss;
+      ss << std::hex << itemId.substr(2); // Skip "0x"
+      ss >> itemIdParsed;
+    } else {
+      std::stringstream ss(itemId);
+      ss >> itemIdParsed;
+    }
+
+    if (aggressor.GetItemCount(itemIdParsed) > 0) {
       biggestMult = std::max(biggestMult, mult);
     }
   }

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -37,16 +37,16 @@ SweetPieSpellDamageFormula::SweetPieSpellDamageFormula(
   }
 }
 
-float SweetPieSpellDamageFormula::CalculateDamage(
-  const MpActor& aggressor, const MpActor& target,
-  const HitData& hitData) const override
+float SweetPieSpellDamageFormula::CalculateDamage(const MpActor& aggressor,
+                                                  const MpActor& target,
+                                                  const HitData& hitData) const
 {
   return baseFormula->CalculateDamage(aggressor, target, hitData);
 }
 
 float SweetPieSpellDamageFormula::CalculateDamage(
   const MpActor& aggressor, const MpActor& target,
-  const SpellCastData& spellCastData) const override
+  const SpellCastData& spellCastData) const
 {
   const float baseDamage =
     baseFormula->CalculateDamage(aggressor, target, spellCastData);
@@ -73,7 +73,7 @@ float SweetPieSpellDamageFormula::CalculateDamage(
       ss >> itemIdParsed;
     }
 
-    if (aggressor.GetItemCount(itemIdParsed) > 0) {
+    if (aggressor.GetInventory().GetItemCount(itemIdParsed) > 0) {
       biggestMult = std::max(biggestMult, mult);
     }
   }

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -1,6 +1,7 @@
 #include "SweetPieSpellDamageFormula.h"
 
 #include "archives/JsonInputArchive.h"
+#include <limits>
 
 namespace SweetPieSpellDamageFormulaPrivate {
 template <class T>
@@ -57,8 +58,8 @@ float SweetPieSpellDamageFormula::CalculateDamage(
 
   for (auto& entry : setings->entries) {
     const auto itemId = entry.itemId;
-    const auto mult =
-      SweetPieSpellDamageFormulaPrivate::Clamp(entry.mult, 0.f, 1.f);
+    const auto mult = SweetPieSpellDamageFormulaPrivate::Clamp(
+      entry.mult, 0.f, std::numeric_limits<float>::infinity());
 
     if (aggressor.GetItemCount(itemId) > 0) {
       biggestMult = std::max(biggestMult, mult);

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -1,0 +1,75 @@
+#include "SweetPieSpellDamageFormula.h"
+
+#include "archives/JsonInputArchive.h"
+
+namespace SweetPieSpellDamageFormulaPrivate {
+template <class T>
+T Clamp(T value, T minValue, T maxValue)
+{
+  if (value < minValue) {
+    return minValue;
+  } else if (value > maxValue) {
+    return maxValue;
+  } else {
+    return value;
+  }
+}
+}
+
+SweetPieSpellDamageFormulaSettings
+SweetPieSpellDamageFormulaSettings::FromJson(const nlohmann::json& j)
+{
+  JsonInputArchive ar(j);
+  SweetPieSpellDamageFormulaSettings res;
+  res.Serialize(ar);
+  return res;
+}
+
+SweetPieSpellDamageFormula::SweetPieSpellDamageFormula(
+  std::unique_ptr<IDamageFormula> baseFormula_, const nlohmann::json& config)
+  : baseFormula(std::move(baseFormula_))
+  , settings(std::nullopt)
+{
+  if (config.is_object()) {
+    settings = ParseConfig(config);
+  }
+}
+
+float SweetPieSpellDamageFormula::CalculateDamage(
+  const MpActor& aggressor, const MpActor& target,
+  const HitData& hitData) const override
+{
+  return baseFormula->CalculateDamage(aggressor, target, hitData);
+}
+
+float SweetPieSpellDamageFormula::CalculateDamage(
+  const MpActor& aggressor, const MpActor& target,
+  const SpellCastData& spellCastData) const override
+{
+  const float baseDamage =
+    baseFormula->CalculateDamage(aggressor, target, spellCastData);
+
+  if (!setings) {
+    return baseDamage;
+  }
+
+  float biggestMult = -1;
+
+  for (auto& entry : setings->entries) {
+    const auto itemId = entry.itemId;
+    const auto mult =
+      SweetPieSpellDamageFormulaPrivate::Clamp(entry.mult, 0.f, 1.f);
+
+    if (aggressor.GetItemCount(itemId) > 0) {
+      biggestMult = std::max(biggestMult, mult);
+    }
+  }
+
+  return biggestMult >= 0 ? biggestMult * baseDamage : baseDamage;
+}
+
+SweetPieSpellDamageFormulaSettings SweetPieSpellDamageFormula::ParseConfig(
+  const nlohmann::json& config) const
+{
+  return SweetPieSpellDamageFormulaSettings::FromJson(config);
+}

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -50,13 +50,13 @@ float SweetPieSpellDamageFormula::CalculateDamage(
   const float baseDamage =
     baseFormula->CalculateDamage(aggressor, target, spellCastData);
 
-  if (!setings) {
+  if (!settings) {
     return baseDamage;
   }
 
   float biggestMult = -1;
 
-  for (auto& entry : setings->entries) {
+  for (auto& entry : settings->entries) {
     const auto itemId = entry.itemId;
     const auto mult = SweetPieSpellDamageFormulaPrivate::Clamp(
       entry.mult, 0.f, std::numeric_limits<float>::infinity());

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -1,3 +1,4 @@
+
 #include "SweetPieSpellDamageFormula.h"
 
 #include "archives/JsonInputArchive.h"
@@ -82,6 +83,7 @@ float SweetPieSpellDamageFormula::CalculateDamage(
   }
 
   float biggestMult = -1;
+  float defaultMult = 1.f;
 
   for (auto& entry : settings->entries) {
     const std::string& itemId = entry.itemId;
@@ -101,13 +103,17 @@ float SweetPieSpellDamageFormula::CalculateDamage(
       ss >> itemIdParsed;
     }
 
-    if (itemIdParsed == 0 ||
-        aggressor.GetInventory().GetItemCount(itemIdParsed) > 0) {
+    if (itemIdParsed == 0) {
+      defaultMult = mult;
+    }
+
+    if (aggressor.GetInventory().GetItemCount(itemIdParsed) > 0) {
       biggestMult = std::max(biggestMult, mult);
     }
   }
 
-  return biggestMult >= 0 ? biggestMult * baseDamage : baseDamage;
+  return biggestMult >= 0 ? biggestMult * baseDamage
+                          : defaultMult * baseDamage;
 }
 
 SweetPieSpellDamageFormulaSettings SweetPieSpellDamageFormula::ParseConfig(

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.cpp
@@ -86,8 +86,9 @@ float SweetPieSpellDamageFormula::CalculateDamage(
   for (auto& entry : settings->entries) {
     const std::string& itemId = entry.itemId;
     const float mult = SweetPieSpellDamageFormulaPrivate::Clamp(
-      SelectRespectiveMult(aggressor, target, entry), 0.f,
-      std::numeric_limits<float>::infinity());
+      SweetPieSpellDamageFormulaPrivate::SelectRespectiveMult(aggressor,
+                                                              target, entry),
+      0.f, std::numeric_limits<float>::infinity());
 
     uint32_t itemIdParsed = 0;
 

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
@@ -19,7 +19,7 @@ struct SweetPieSpellDamageFormulaSettingsEntry
     archive.Serialize("itemId", itemId).Serialize("mult", mult);
   }
 
-  uint32_t itemId = 0;
+  std::string itemId; // supports hex and decimal ids: "0x000feef1", "0"
   float mult = 0.f;
 };
 

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "IDamageFormula.h"
+#include "MpActor.h"
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
+// Modifies vanilla damage for spells
+
+struct SweetPieSpellDamageFormulaSettingsEntry
+{
+  template <class Archive>
+  void Serialize(Archive& archive)
+  {
+    archive.Serialize("itemId", itemId).Serialize("mult", mult);
+  }
+
+  uint32_t itemId = 0;
+  float mult = 0.f;
+};
+
+struct SweetPieSpellDamageFormulaSettings
+{
+
+  template <class Archive>
+  void Serialize(Archive& archive)
+  {
+    archive.Serialize("entries", entries);
+  }
+
+  static SweetPieSpellDamageFormulaSettings FromJson(const nlohmann::json& j);
+
+  std::vector<SweetPieSpellDamageFormulaSettingsEntry> entries;
+};
+
+class SweetPieSpellDamageFormula : public IDamageFormula
+{
+public:
+  SweetPieSpellDamageFormula(std::unique_ptr<IDamageFormula> baseFormula_,
+                             const nlohmann::json& config);
+
+  [[nodiscard]] float CalculateDamage(const MpActor& aggressor,
+                                      const MpActor& target,
+                                      const HitData& hitData) const override;
+
+  [[nodiscard]] float CalculateDamage(
+    const MpActor& aggressor, const MpActor& target,
+    const SpellCastData& spellCastData) const override;
+
+private:
+  SweetPieSpellDamageFormulaSettings ParseConfig(
+    const nlohmann::json& config) const;
+
+private:
+  std::unique_ptr<IDamageFormula> baseFormula;
+  std::optional<SweetPieSpellDamageFormulaSettings> settings;
+};

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
@@ -16,7 +16,7 @@ struct SweetPieSpellDamageFormulaSettingsEntry
   template <class Archive>
   void Serialize(Archive& archive)
   {
-    archive.Serialize("itemId", itemId).Serialize("mult", mult);
+    archive.Serialize("itemId", itemId).Serialize("multPlayerHitsPlayer", mult);
   }
 
   std::string itemId; // supports hex and decimal ids: "0x000feef1", "0"

--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieSpellDamageFormula.h
@@ -16,11 +16,14 @@ struct SweetPieSpellDamageFormulaSettingsEntry
   template <class Archive>
   void Serialize(Archive& archive)
   {
-    archive.Serialize("itemId", itemId).Serialize("multPlayerHitsPlayer", mult);
+    archive.Serialize("itemId", itemId)
+      .Serialize("multPlayerHitsPlayer", multPlayerHitsPlayer)
+      .Serialize("multPlayerHitsNpc", multPlayerHitsNpc);
   }
 
   std::string itemId; // supports hex and decimal ids: "0x000feef1", "0"
-  float mult = 0.f;
+  std::optional<float> multPlayerHitsPlayer;
+  std::optional<float> multPlayerHitsNpc;
 };
 
 struct SweetPieSpellDamageFormulaSettings


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SweetPieSpellDamageFormula` to modify spell damage based on item multipliers, configurable via JSON, and integrate it into the server's damage calculation.
> 
>   - **Behavior**:
>     - Adds `SweetPieSpellDamageFormula` to modify spell damage based on item multipliers in `ScampServer.cpp`.
>     - Configurable via `sweetPieSpellDamageFormulaSettings` in JSON.
>   - **Implementation**:
>     - New class `SweetPieSpellDamageFormula` in `SweetPieSpellDamageFormula.cpp` and `SweetPieSpellDamageFormula.h`.
>     - Implements `CalculateDamage()` for `SpellCastData` and `HitData`.
>     - Parses configuration using `SweetPieSpellDamageFormulaSettings::FromJson()`.
>   - **Misc**:
>     - Updates comment in `SweetPieDamageFormula.h` to specify it modifies weapon damage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 262de4889626aea18ac04bbffc7834b3b5117b3c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->