### PR TITLE
internal: include lastCommitSha and prNumber in metadata for skymp5-patches

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -237,7 +237,11 @@ runs:
                 return refInfo;
               }
               else {
-                return { refInfoHash: crypto.createHash('sha256').update(refInfo.ref).digest('hex') };
+                return { 
+                  refInfoHash: crypto.createHash('sha256').update(refInfo.ref).digest('hex'),
+                  lastCommitSha: refInfo.lastCommitSha,
+                  prNumber: refInfo.prNumber
+                };
               }
             });
           }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `lastCommitSha` and `prNumber` to the return object in the `Compile metadata into public format` step for `skymp5-patches` in `pr_base` action.
> 
>   - **Behavior**:
>     - In `.github/actions/pr_base/action.yml`, modifies the return object in the `Compile metadata into public format` step to include `lastCommitSha` and `prNumber` when `repoName` is `skymp5-patches`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 2bc3f389f92536a86d46d5dbfaa74b8be103e72b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->