### PR TITLE
internal: add libxml2 overlay port with GitHub download instead of GitLab

### DIFF
--- a/.linelint.yml
+++ b/.linelint.yml
@@ -3,6 +3,7 @@ ignore:
   - '**/third_party'
   - 'skymp5-scripts/'
   - 'overlay_ports/rsm-bsa/*.patch'
+  - 'overlay_ports/libxml2/*'
 
 rules:
   end-of-file:

--- a/overlay_ports/libxml2/disable-docs.patch
+++ b/overlay_ports/libxml2/disable-docs.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f922d5ab..70466bc7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -599,15 +599,5 @@ if(LIBXML2_WITH_PYTHON)
+ endif()
+ 
+-install(FILES doc/xml2-config.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
+-install(FILES doc/xmlcatalog.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
+-install(FILES doc/xmllint.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
+-install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT documentation
+-	PATTERN "Makefile.*" EXCLUDE
+-	PATTERN "*.1" EXCLUDE
+-	PATTERN "*.py" EXCLUDE
+-	PATTERN "*.res" EXCLUDE
+-	PATTERN "*.xml" EXCLUDE
+-	PATTERN "*.xsl" EXCLUDE)
+ 
+ configure_package_config_file(
+ 	libxml2-config.cmake.cmake.in libxml2-config.cmake

--- a/overlay_ports/libxml2/disable-docs.patch
+++ b/overlay_ports/libxml2/disable-docs.patch
@@ -18,3 +18,4 @@ index f922d5ab..70466bc7 100644
  
  configure_package_config_file(
  	libxml2-config.cmake.cmake.in libxml2-config.cmake
+ 

--- a/overlay_ports/libxml2/fix_cmakelist.patch
+++ b/overlay_ports/libxml2/fix_cmakelist.patch
@@ -1,0 +1,90 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9701bdc..39e96ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -393,15 +393,15 @@ endif()
+ if(LIBXML2_WITH_ICU)
+ 	target_link_libraries(LibXml2 PRIVATE ICU::data ICU::i18n ICU::uc)
+ 	if(WIN32)
+-		set(ICU_LIBS "-licudt -licuin -licuuc")
++		set(ICU_LIBS "icu-i18n")
+ 	else()
+-		set(ICU_LIBS "-licudata -licui18n -licuuc")
++		set(ICU_LIBS "icu-i18n")
+ 	endif()
+ endif()
+ 
+ if(LIBXML2_WITH_LZMA)
+ 	target_link_libraries(LibXml2 PRIVATE LibLZMA::LibLZMA)
+-	set(LZMA_LIBS "-llzma")
++	set(LZMA_LIBS "liblzma")
+ endif()
+ 
+ if(LIBXML2_WITH_THREADS)
+@@ -411,7 +411,7 @@ endif()
+ 
+ if(LIBXML2_WITH_ZLIB)
+ 	target_link_libraries(LibXml2 PRIVATE ZLIB::ZLIB)
+-	set(Z_LIBS "-lz")
++	set(Z_LIBS "zlib")
+ endif()
+ 
+ set_target_properties(
+@@ -425,23 +425,9 @@ set_target_properties(
+         SOVERSION ${LIBXML_MAJOR_VERSION}
+ )
+ 
++set(XML_LIB_NAME xml2)
+ if(MSVC)
+-	if(BUILD_SHARED_LIBS)
+-		set_target_properties(
+-			LibXml2
+-			PROPERTIES
+-			DEBUG_POSTFIX d
+-		)
+-	else()
+-		set_target_properties(
+-			LibXml2
+-			PROPERTIES
+-			DEBUG_POSTFIX sd
+-			MINSIZEREL_POSTFIX s
+-			RELEASE_POSTFIX s
+-			RELWITHDEBINFO_POSTFIX s
+-		)
+-	endif()
++	set(XML_LIB_NAME libxml2)
+ endif()
+ 
+ install(FILES ${LIBXML2_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxml2/libxml COMPONENT development)
+@@ -586,7 +572,7 @@ endif()
+ write_basic_package_version_file(
+ 	${CMAKE_CURRENT_BINARY_DIR}/libxml2-config-version.cmake
+ 	VERSION ${PROJECT_VERSION}
+-	COMPATIBILITY ExactVersion
++	COMPATIBILITY SameMajorVersion
+ )
+ 
+ install(
+@@ -635,7 +621,7 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ configure_file(libxml-2.0.pc.in libxml-2.0.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml-2.0.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT development)
+ 
+-if(WIN32)
++if(1)
+ 	set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
+ endif()
+ configure_file(xml2-config.in xml2-config @ONLY)
+diff --git a/libxml-2.0.pc.in b/libxml-2.0.pc.in
+index 88e3963b..0d1706c9 100644
+--- a/libxml-2.0.pc.in
++++ b/libxml-2.0.pc.in
+@@ -8,6 +8,7 @@ Name: libXML
+ Version: @VERSION@
+ Description: libXML library version2.
+ Requires:
+-Libs: -L${libdir} @XML_LIBS@
+-Libs.private: @XML_PRIVATE_LIBS@ @LIBS@
++Requires.private: @ICU_LIBS@ @Z_LIBS@ @LZMA_LIBS@
++Libs: -L${libdir} -l@XML_LIB_NAME@
++Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WINSOCK_LIBS@ @LIBS@
+ Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@

--- a/overlay_ports/libxml2/fix_cmakelist.patch
+++ b/overlay_ports/libxml2/fix_cmakelist.patch
@@ -88,3 +88,4 @@ index 88e3963b..0d1706c9 100644
 +Libs: -L${libdir} -l@XML_LIB_NAME@
 +Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WINSOCK_LIBS@ @LIBS@
  Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@
+ 

--- a/overlay_ports/libxml2/portfile.cmake
+++ b/overlay_ports/libxml2/portfile.cmake
@@ -1,0 +1,88 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO GNOME/libxml2
+    REF "v${VERSION}"
+    SHA512 0
+    HEAD_REF master
+    PATCHES
+        disable-docs.patch
+        fix_cmakelist.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "ftp" LIBXML2_WITH_FTP
+        "http" LIBXML2_WITH_HTTP
+        "iconv" LIBXML2_WITH_ICONV
+        "legacy" LIBXML2_WITH_LEGACY
+        "lzma" LIBXML2_WITH_LZMA
+        "zlib" LIBXML2_WITH_ZLIB
+        "tools" LIBXML2_WITH_PROGRAMS
+        "icu"  LIBXML2_WITH_ICU
+)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DLIBXML2_WITH_TESTS=OFF
+        -DLIBXML2_WITH_HTML=ON
+        -DLIBXML2_WITH_C14N=ON
+        -DLIBXML2_WITH_CATALOG=ON
+        -DLIBXML2_WITH_DEBUG=ON
+        -DLIBXML2_WITH_ISO8859X=ON
+        -DLIBXML2_WITH_MEM_DEBUG=OFF
+        -DLIBXML2_WITH_MODULES=ON
+        -DLIBXML2_WITH_OUTPUT=ON
+        -DLIBXML2_WITH_PATTERN=ON
+        -DLIBXML2_WITH_PUSH=ON
+        -DLIBXML2_WITH_PYTHON=OFF
+        -DLIBXML2_WITH_READER=ON
+        -DLIBXML2_WITH_REGEXPS=ON
+        -DLIBXML2_WITH_SAX1=ON
+        -DLIBXML2_WITH_SCHEMAS=ON
+        -DLIBXML2_WITH_SCHEMATRON=ON
+        -DLIBXML2_WITH_THREADS=ON
+        -DLIBXML2_WITH_THREAD_ALLOC=OFF
+        -DLIBXML2_WITH_TREE=ON
+        -DLIBXML2_WITH_VALID=ON
+        -DLIBXML2_WITH_WRITER=ON
+        -DLIBXML2_WITH_XINCLUDE=ON
+        -DLIBXML2_WITH_XPATH=ON
+        -DLIBXML2_WITH_XPTR=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libxml2-${VERSION}")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES xmllint xmlcatalog AUTO_CLEAN)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(_file "${CURRENT_PACKAGES_DIR}/include/libxml2/libxml/xmlexports.h")
+    file(READ "${_file}" _contents)
+    string(REPLACE "#ifdef LIBXML_STATIC" "#undef LIBXML_STATIC\n#define LIBXML_STATIC\n#ifdef LIBXML_STATIC" _contents "${_contents}")
+    file(WRITE "${_file}" "${_contents}")
+endif()
+
+file(COPY "${CURRENT_PACKAGES_DIR}/include/libxml2/" DESTINATION "${CURRENT_PACKAGES_DIR}/include") # TODO: Fix usage in all dependent ports hardcoding the wrong include path.
+
+# Cleanup
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/xml2Conf.sh" "${CURRENT_PACKAGES_DIR}/debug/lib/xml2Conf.sh")
+
+file(COPY
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/Copyright")

--- a/overlay_ports/libxml2/usage
+++ b/overlay_ports/libxml2/usage
@@ -1,0 +1,4 @@
+The package libxml2 is compatible with built-in CMake targets:
+
+    find_package(LibXml2 REQUIRED)
+    target_link_libraries(main PRIVATE LibXml2::LibXml2)

--- a/overlay_ports/libxml2/vcpkg-cmake-wrapper.cmake
+++ b/overlay_ports/libxml2/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,3 @@
+list(REMOVE_ITEM ARGS "NO_MODULE" "CONFIG" "MODULE")
+_find_package(${ARGS} CONFIG)
+set(LIBXML2_FOUND "${LibXml2_FOUND}") # fphsa compatibility

--- a/overlay_ports/libxml2/vcpkg.json
+++ b/overlay_ports/libxml2/vcpkg.json
@@ -1,0 +1,63 @@
+{
+    "name": "libxml2",
+    "version": "2.11.9",
+    "port-version": 2,
+    "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
+    "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ],
+    "default-features": [
+        "iconv",
+        "lzma",
+        "zlib"
+    ],
+    "features": {
+        "ftp": {
+            "description": "Add the FTP support",
+            "supports": "!uwp"
+        },
+        "http": {
+            "description": "Add the HTTP support",
+            "supports": "!uwp"
+        },
+        "iconv": {
+            "description": "Add ICONV support",
+            "dependencies": [
+                "libiconv"
+            ]
+        },
+        "icu": {
+            "description": "Add ICU support",
+            "dependencies": [
+                "icu"
+            ]
+        },
+        "legacy": {
+            "description": "Add deprecated APIs for compatibility"
+        },
+        "lzma": {
+            "description": "Use LZMA",
+            "dependencies": [
+                "liblzma"
+            ]
+        },
+        "tools": {
+            "description": "Build tools"
+        },
+        "zlib": {
+            "description": "Use ZLib",
+            "dependencies": [
+                "zlib"
+            ]
+        }
+    }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `libxml2` port with CMake integration and configurable features in `overlay_ports`.
> 
>   - **New Port Addition**:
>     - Adds `libxml2` port in `overlay_ports` with version `2.11.9`.
>     - Configures build options in `portfile.cmake` for features like `ftp`, `http`, `iconv`, `lzma`, `zlib`, etc.
>   - **CMake Integration**:
>     - Provides `vcpkg-cmake-wrapper.cmake` for CMake compatibility.
>     - Adds `usage` file for CMake target linking instructions.
>   - **Dependencies and Features**:
>     - Lists dependencies in `vcpkg.json` including `vcpkg-cmake` and `vcpkg-cmake-config`.
>     - Defines default features and optional features with dependencies in `vcpkg.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for cc5d74b6356d64f4f1bb54ae9c4a5766e94d64ce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->