### PR TITLE
internal: update macOS runner to macos-14-large in GitHub Actions

### DIFF
--- a/.github/workflows/pr-macos.yml
+++ b/.github/workflows/pr-macos.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-14-large
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions runner to `macos-14-large` in `pr-macos.yml` for improved build resources.
> 
>   - **GitHub Actions Workflow**:
>     - Update runner in `.github/workflows/pr-macos.yml` from `macos-14` to `macos-14-large` for the `build` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 77440e6f5abd6236a6d7bf88f2d71e2272542260. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->