### PR TITLE
internal: skip deleted files in clang-format hook and remove empty PapyrusQuest files

### DIFF
--- a/misc/git-hooks/clang-format-hook.js
+++ b/misc/git-hooks/clang-format-hook.js
@@ -50,7 +50,8 @@ const formatFiles = (files) => {
 
       const filesToFormat = changedFiles
         .split("\n")
-        .filter((file) => file.trim() !== "");
+        .filter((file) => file.trim() !== "")
+        .filter((file) => fs.existsSync(file)); // Do not try validate deleted files
       formatFiles(filesToFormat);
 
       filesToFormat.forEach((file) => execSync(`git add ${file}`));

--- a/skymp5-server/cpp/PapyrusQuest.h
+++ b/skymp5-server/cpp/PapyrusQuest.h
@@ -1,1 +1,0 @@
-#pragma once


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `clang-format-hook.js` to skip deleted files and remove `PapyrusQuest` files from `skymp5-server/cpp`.
> 
>   - **Behavior**:
>     - Update `formatFiles` in `clang-format-hook.js` to skip deleted files by checking `fs.existsSync(file)`.
>   - **Removals**:
>     - Delete `PapyrusQuest.cpp` and `PapyrusQuest.h` from `skymp5-server/cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 7920d3eb363ab4b2fe5b4bedfc6ffeafabcbf7b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->