### PR TITLE
feat(skymp5-server): add Quest.GetStage stub & disable some bad scripts

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1714,10 +1714,10 @@ void MpObjectReference::InitScripts()
     // 1. GetStage in OnTrigger
     // 2. Unable to determine Actor for 'Game.GetPlayer' in 'OnLoad'
     const bool isRemoveNeeded =
-      !Utils::stricmp(name, "DA06PreRitualSceneTriggerScript") ||
-      !Utils::stricmp(name, "CritterSpawn");
+      !Utils::stricmp(val.data(), "DA06PreRitualSceneTriggerScript") ||
+      !Utils::stricmp(val.data(), "CritterSpawn");
 
-    spdlog::info("Skipping script {}", name);
+    spdlog::info("Skipping script {}", val);
 
     return isRemoveNeeded;
   };

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1710,19 +1710,18 @@ void MpObjectReference::InitScripts()
 
   // A hardcoded hack to remove unsupported scripts
   // TODO: make is a server setting with proper conditions or an API
-  scriptNames.erase(std::remove_if(scriptNames.begin(), scriptNames.end(),
-                                   [](const std::string& val) {
-                                     // 1. GetStage in OnTrigger
-                                     // 2. Unable to determine Actor for
-                                     // 'Game.GetPlayer' in 'OnLoad'
-                                     const bool isRemoveNeeded =
-                                       !Utils::stricmp(
-                                         name,
-                                         "DA06PreRitualSceneTriggerScript") ||
-                                       !Utils::stricmp(name, "CritterSpawn");
+  auto isScriptEraseNeeded = [](const std::string& val) {
+    // 1. GetStage in OnTrigger
+    // 2. Unable to determine Actor for
+    // 'Game.GetPlayer' in 'OnLoad'
+    const bool isRemoveNeeded =
+      !Utils::stricmp(name, "DA06PreRitualSceneTriggerScript") ||
+      !Utils::stricmp(name, "CritterSpawn");
 
-                                     return isRemoveNeeded;
-                                   }),
+    return isRemoveNeeded;
+  };
+  scriptNames.erase(std::remove_if(scriptNames.begin(), scriptNames.end(),
+                                   isScriptEraseNeeded),
                     scriptNames.end());
 
   if (!scriptNames.empty()) {

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1710,20 +1710,20 @@ void MpObjectReference::InitScripts()
 
   // A hardcoded hack to remove unsupported scripts
   // TODO: make is a server setting with proper conditions or an API
-  scriptNames.erase(
-    std::remove_if(
-      scriptNames.begin(), scriptNames.end(),
-      [](const std::string& val) {
-        const bool isRemoveNeeded =
-          !Utils::stricmp(
-            name, "DA06PreRitualSceneTriggerScript") // GetStage in OnTrigger
-          || !Utils::stricmp(name,
-                             "CritterSpawn"); // Unable to determine Actor for
-                                              // 'Game.GetPlayer' in 'OnLoad'
+  scriptNames.erase(std::remove_if(scriptNames.begin(), scriptNames.end(),
+                                   [](const std::string& val) {
+                                     // 1. GetStage in OnTrigger
+                                     // 2. Unable to determine Actor for
+                                     // 'Game.GetPlayer' in 'OnLoad'
+                                     const bool isRemoveNeeded =
+                                       !Utils::stricmp(
+                                         name,
+                                         "DA06PreRitualSceneTriggerScript") ||
+                                       !Utils::stricmp(name, "CritterSpawn");
 
-        return isRemoveNeeded;
-      }),
-    scriptNames.end());
+                                     return isRemoveNeeded;
+                                   }),
+                    scriptNames.end());
 
   if (!scriptNames.empty()) {
     pImpl->scriptState = std::make_unique<ScriptState>();

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1689,6 +1689,7 @@ void MpObjectReference::InitScripts()
 
   // A hardcoded hack to remove all scripts except SweetPie scripts from
   // exterior objects
+  // TODO: make is a server setting with proper conditions or an API
   if (GetParent() && GetParent()->disableVanillaScriptsInExterior &&
       GetFormId() < 0x05000000) {
     auto cellOrWorld = GetCellOrWorld().ToFormId(GetParent()->espmFiles);
@@ -1706,6 +1707,23 @@ void MpObjectReference::InitScripts()
                         scriptNames.end());
     }
   }
+
+  // A hardcoded hack to remove unsupported scripts
+  // TODO: make is a server setting with proper conditions or an API
+  scriptNames.erase(
+    std::remove_if(
+      scriptNames.begin(), scriptNames.end(),
+      [](const std::string& val) {
+        const bool isRemoveNeeded =
+          !Utils::stricmp(
+            name, "DA06PreRitualSceneTriggerScript") // GetStage in OnTrigger
+          || !Utils::stricmp(name,
+                             "CritterSpawn"); // Unable to determine Actor for
+                                              // 'Game.GetPlayer' in 'OnLoad'
+
+        return isRemoveNeeded;
+      }),
+    scriptNames.end());
 
   if (!scriptNames.empty()) {
     pImpl->scriptState = std::make_unique<ScriptState>();

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1717,6 +1717,8 @@ void MpObjectReference::InitScripts()
       !Utils::stricmp(name, "DA06PreRitualSceneTriggerScript") ||
       !Utils::stricmp(name, "CritterSpawn");
 
+    spdlog::info("Skipping script {}", name);
+
     return isRemoveNeeded;
   };
   scriptNames.erase(std::remove_if(scriptNames.begin(), scriptNames.end(),

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1712,8 +1712,7 @@ void MpObjectReference::InitScripts()
   // TODO: make is a server setting with proper conditions or an API
   auto isScriptEraseNeeded = [](const std::string& val) {
     // 1. GetStage in OnTrigger
-    // 2. Unable to determine Actor for
-    // 'Game.GetPlayer' in 'OnLoad'
+    // 2. Unable to determine Actor for 'Game.GetPlayer' in 'OnLoad'
     const bool isRemoveNeeded =
       !Utils::stricmp(name, "DA06PreRitualSceneTriggerScript") ||
       !Utils::stricmp(name, "CritterSpawn");

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
@@ -13,6 +13,7 @@
 #include "PapyrusNetImmerse.h"
 #include "PapyrusObjectReference.h"
 #include "PapyrusPotion.h"
+#include "PapyrusQuest.h"
 #include "PapyrusSkymp.h"
 #include "PapyrusSound.h"
 #include "PapyrusUtility.h"

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
@@ -43,6 +43,7 @@ PapyrusClassesFactory::CreateAndRegister(
   result.emplace_back(std::make_unique<PapyrusNetImmerse>());
   result.emplace_back(std::make_unique<PapyrusPotion>());
   result.emplace_back(std::make_unique<PapyrusVisualEffect>());
+  result.emplace_back(std::make_unique<PapyrusQuest>());
 
   for (auto& papyrusClass : result) {
     papyrusClass->Register(vm, compatibilityPolicy);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
@@ -16,7 +16,8 @@ VarValue PapyrusQuest::GetCurrentStageID(
     espm::CompressedFieldsCache cache;
 
     const auto& quest = GetRecordPtr(self);
-    const char* editorId = quest->GetEditorId(cache);
+    const char* editorId =
+      quest.rec ? quest.rec->GetEditorId(cache) : "<null>";
 
     spdlog::warn(
       "GetCurrentStageID - Not implemented, returning 0 (quest was {})",

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
@@ -1,0 +1,36 @@
+#include "PapyrusQuest.h"
+#include "script_objects/EspmGameObject.h"
+
+VarValue PapyrusQuest::GetStage(VarValue self,
+                                const std::vector<VarValue>& arguments)
+{
+  return GetCurrentStageID(self, arguments);
+}
+
+VarValue PapyrusQuest::GetCurrentStageID(
+  VarValue self, const std::vector<VarValue>& arguments)
+{
+  static std::once_flag g_flag;
+
+  std::call_once(g_flag, [&] {
+    espm::CompressedFieldsCache cache;
+
+    const auto& quest = GetRecordPtr(self);
+    const char* editorId = quest->GetEditorId(cache);
+
+    spdlog::warn(
+      "GetCurrentStageID - Not implemented, returning 0 (quest was {})",
+      editorId ? editorId : "<null>");
+    spdlog::warn("GetCurrentStageID - Won't output further warnings due to "
+                 "performance reasons");
+  });
+
+  return VarValue(0);
+}
+
+void PapyrusQuest::Register(
+  VirtualMachine& vm, std::shared_ptr<IPapyrusCompatibilityPolicy> policy)
+{
+  AddMethod(vm, "GetStage", &PapyrusPotion::GetStage);
+  AddMethod(vm, "GetCurrentStageID", &PapyrusPotion::GetCurrentStageID);
+}

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
@@ -32,5 +32,5 @@ void PapyrusQuest::Register(
   VirtualMachine& vm, std::shared_ptr<IPapyrusCompatibilityPolicy> policy)
 {
   AddMethod(vm, "GetStage", &PapyrusQuest::GetStage);
-  AddMethod(vm, "GetCurrentStageID", &PapyrusPotion::GetCurrentStageID);
+  AddMethod(vm, "GetCurrentStageID", &PapyrusQuest::GetCurrentStageID);
 }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.cpp
@@ -31,6 +31,6 @@ VarValue PapyrusQuest::GetCurrentStageID(
 void PapyrusQuest::Register(
   VirtualMachine& vm, std::shared_ptr<IPapyrusCompatibilityPolicy> policy)
 {
-  AddMethod(vm, "GetStage", &PapyrusPotion::GetStage);
+  AddMethod(vm, "GetStage", &PapyrusQuest::GetStage);
   AddMethod(vm, "GetCurrentStageID", &PapyrusPotion::GetCurrentStageID);
 }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusQuest.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "IPapyrusClass.h"
+#include "SpSnippetFunctionGen.h"
+
+class PapyrusQuest final : public IPapyrusClass<PapyrusQuest>
+{
+public:
+  const char* GetName() override { return "Quest"; }
+
+  // Non-native in original Papyrus, just a wrapper around GetCurrentStageID
+  VarValue GetStage(VarValue self, const std::vector<VarValue>& arguments);
+
+  VarValue GetCurrentStageID(VarValue self,
+                             const std::vector<VarValue>& arguments);
+
+  void Register(VirtualMachine& vm,
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override;
+
+  std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy;
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `PapyrusQuest` class with quest stage methods, logging unimplemented status, and fix registration typo.
> 
>   - **New Class**:
>     - `PapyrusQuest` added to handle quest-related functionality.
>     - Implements `GetStage` and `GetCurrentStageID` methods.
>   - **Functionality**:
>     - `GetStage` calls `GetCurrentStageID`.
>     - `GetCurrentStageID` logs a warning and returns 0, indicating it's not implemented.
>   - **Registration**:
>     - Registers methods with `VirtualMachine` in `Register()`.
>     - Typo in registration: uses `PapyrusPotion` instead of `PapyrusQuest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 03d0fc05ce85c5dfebb94666ddf131b60d073da6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->