### PR TITLE
fix(skymp5-server): add missing variable to a log

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1695,7 +1695,7 @@ void MpObjectReference::InitScripts()
     auto lookupRes =
       GetParent()->GetEspm().GetBrowser().LookupById(cellOrWorld);
     if (lookupRes.rec && lookupRes.rec->GetType() == "WRLD") {
-      spdlog::info("Skipping non-Sweet scripts for exterior form {:x}");
+      spdlog::info("Skipping non-Sweet scripts for exterior form {:x}", cellOrWorld);
       scriptNames.erase(std::remove_if(scriptNames.begin(), scriptNames.end(),
                                        [](const std::string& val) {
                                          auto kPrefix = "Sweet";

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.cpp
@@ -1695,7 +1695,8 @@ void MpObjectReference::InitScripts()
     auto lookupRes =
       GetParent()->GetEspm().GetBrowser().LookupById(cellOrWorld);
     if (lookupRes.rec && lookupRes.rec->GetType() == "WRLD") {
-      spdlog::info("Skipping non-Sweet scripts for exterior form {:x}", cellOrWorld);
+      spdlog::info("Skipping non-Sweet scripts for exterior form {:x}",
+                   cellOrWorld);
       scriptNames.erase(std::remove_if(scriptNames.begin(), scriptNames.end(),
                                        [](const std::string& val) {
                                          auto kPrefix = "Sweet";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `cellOrWorld` variable to logging in `MpObjectReference::InitScripts()` to log exterior form ID.
> 
>   - **Logging**:
>     - Add `cellOrWorld` variable to `spdlog::info` in `MpObjectReference::InitScripts()` to log the exterior form ID being skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 090c244a19bf9c2514ac0b95af71c0750e88d64a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->