### PR TITLE
internal: add clang-format to the dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN \
     pkg-config \
     cmake \
     clang-15 \
+    clang-format-15 \
     ninja-build \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `clang-format-15` to `Dockerfile` for code formatting support in the dev image.
> 
>   - **Dockerfile Update**:
>     - Add `clang-format-15` to the list of installed packages in `Dockerfile` to support code formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 78e36ecc7254fe9c08e403a32277f73f6cc964d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->