### PR TITLE
feat(skymp5-server): add onUpdateAppearanceAttempt gamemode event

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -16,6 +16,7 @@
 #include "gamemode_events/CraftEvent.h"
 #include "gamemode_events/CustomEvent.h"
 #include "gamemode_events/EatItemEvent.h"
+#include "gamemode_events/UpdateAppearanceAttemptEvent.h"
 #include "script_objects/EspmGameObject.h"
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
@@ -201,12 +202,21 @@ void ActionListener::OnUpdateAppearance(const RawMessageData& rawMsgData,
 { // TODO: validate
 
   MpActor* actor = partOne.serverState.ActorByUser(rawMsgData.userId);
-  if (!actor || !actor->IsRaceMenuOpen())
+  if (!actor) {
     return;
+  }
 
-  actor->SetRaceMenuOpen(false);
-  actor->SetAppearance(&appearance);
-  SendToNeighbours(idx, rawMsgData, true);
+  const bool isAllowed = actor->IsRaceMenuOpen();
+
+  if (isAllowed) {
+    actor->SetRaceMenuOpen(false);
+    actor->SetAppearance(&appearance);
+    SendToNeighbours(idx, rawMsgData, true);
+  }
+
+  UpdateAppearanceAttemptEvent updateAppearanceAttemptEvent(actor, appearance,
+                                                            isAllowed);
+  updateAppearanceAttemptEvent.Fire(actor->GetParent());
 }
 
 void ActionListener::OnUpdateEquipment(

--- a/skymp5-server/cpp/server_guest_lib/Appearance.h
+++ b/skymp5-server/cpp/server_guest_lib/Appearance.h
@@ -15,6 +15,7 @@ struct Tint
 
 struct Appearance
 {
+  // TODO: port to archives
   static Appearance FromJson(const nlohmann::json& j);
   static Appearance FromJson(simdjson::dom::element& j);
   std::string ToJson() const;

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateAppearanceAttemptEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateAppearanceAttemptEvent.cpp
@@ -22,7 +22,7 @@ std::string UpdateAppearanceAttemptEvent::GetArgumentsJsonArray() const
   result += "[";
   result += std::to_string(actor->GetFormId());
   result += ",";
-  result += appearance.ToJson().dump();
+  result += appearance.ToJson();
   result += ",";
   result += isAllowed ? "true" : "false";
   result += "]";

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateAppearanceAttemptEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateAppearanceAttemptEvent.cpp
@@ -1,0 +1,42 @@
+#include "UpdateAppearanceAttemptEvent.h"
+
+#include "MpActor.h"
+#include <spdlog/spdlog.h>
+
+UpdateAppearanceAttemptEvent::UpdateAppearanceAttemptEvent(
+  MpActor* actor_, const Appearance& appearance_, bool isAllowed_)
+  : actor(actor_)
+  , appearance(appearance_)
+  , isAllowed(isAllowed_)
+{
+}
+
+const char* UpdateAppearanceAttemptEvent::GetName() const
+{
+  return "onUpdateAppearanceAttempt";
+}
+
+std::string UpdateAppearanceAttemptEvent::GetArgumentsJsonArray() const
+{
+  std::string result;
+  result += "[";
+  result += std::to_string(actor->GetFormId());
+  result += ",";
+  result += appearance.ToJson().dump();
+  result += ",";
+  result += isAllowed ? "true" : "false";
+  result += "]";
+  return result;
+}
+
+void UpdateAppearanceAttemptEvent::OnFireSuccess(WorldState* worldState)
+{
+}
+
+void UpdateAppearanceAttemptEvent::OnFireBlocked(WorldState* worldState)
+{
+  spdlog::warn(
+    "UpdateAppearanceAttemptEvent::OnFireBlocked - Not implemented. Please "
+    "consider never blocking {} event in gamemode",
+    GetName());
+}

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateAppearanceAttemptEvent.h
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateAppearanceAttemptEvent.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "GameModeEvent.h"
+
+class MpActor;
+
+#include "Appearance.h"
+
+class UpdateAppearanceAttemptEvent : public GameModeEvent
+{
+public:
+  UpdateAppearanceAttemptEvent(MpActor* actor_, const Appearance& appearance_,
+                               bool isAllowed_);
+
+  const char* GetName() const override;
+
+  std::string GetArgumentsJsonArray() const override;
+
+private:
+  void OnFireSuccess(WorldState* worldState) override;
+  void OnFireBlocked(WorldState* worldState) override;
+
+  MpActor* actor = nullptr;
+  Appearance appearance;
+  bool isAllowed = false;
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `onUpdateAppearanceAttempt` event to handle appearance update attempts in `ActionListener` and implement event class.
> 
>   - **Behavior**:
>     - Adds `onUpdateAppearanceAttempt` event in `ActionListener::OnUpdateAppearance()` to handle appearance update attempts.
>     - Triggers event regardless of whether the appearance update is allowed.
>   - **Event Implementation**:
>     - New class `UpdateAppearanceAttemptEvent` in `UpdateAppearanceAttemptEvent.cpp` and `UpdateAppearanceAttemptEvent.h`.
>     - Implements `GetName()` and `GetArgumentsJsonArray()` to provide event details.
>     - Logs a warning in `OnFireBlocked()` if the event is blocked.
>   - **Misc**:
>     - Adds a TODO comment in `Appearance.h` to port to archives.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for a9f801f62ca7089aebf592654db41d7d0c65108c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->