### PR TITLE
internal: remove unnecessary step from Ubuntu CI

### DIFF
--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -76,7 +76,7 @@ jobs:
                     cd /src \
                     && ./build.sh --configure \
                        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                       -DUNIT_DATA_DIR="/src/skyrim_data_files" && false
+                       -DUNIT_DATA_DIR="/src/skyrim_data_files" && echo kek > vcpkg/buildtrees/rsm-bsa/install-x64-linux-dbg-out.log && false
 
           - name: Upload vcpkg failure logs
             if: failure()

--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -76,7 +76,7 @@ jobs:
                     cd /src \
                     && ./build.sh --configure \
                        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                       -DUNIT_DATA_DIR="/src/skyrim_data_files"
+                       -DUNIT_DATA_DIR="/src/skyrim_data_files" && false
 
           - name: Upload vcpkg failure logs
             if: failure()

--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -76,7 +76,7 @@ jobs:
                     cd /src \
                     && ./build.sh --configure \
                        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                       -DUNIT_DATA_DIR="/src/skyrim_data_files" && echo kek > vcpkg/buildtrees/rsm-bsa/install-x64-linux-dbg-out.log && false
+                       -DUNIT_DATA_DIR="/src/skyrim_data_files"
 
           - name: Upload vcpkg failure logs
             if: failure()

--- a/.github/workflows/pr-ubuntu-docker.yml
+++ b/.github/workflows/pr-ubuntu-docker.yml
@@ -72,24 +72,18 @@ jobs:
                 options: |
                     -v ${{github.workspace}}:/src
                     -u skymp
-                    --name configure_container
                 run: |
                     cd /src \
                     && ./build.sh --configure \
                        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                        -DUNIT_DATA_DIR="/src/skyrim_data_files"
 
-          - name: Copy log file from container to workspace
-            if: failure()
-            run: |
-              sudo docker cp configure_container:/src/vcpkg/buildtrees/rsm-bsa/install-x64-linux-dbg-out.log ${{github.workspace}}/install-x64-linux-dbg-out.log
-
           - name: Upload vcpkg failure logs
             if: failure()
             uses: actions/upload-artifact@v4
             with:
               name: install-x64-linux-dbg-out.log
-              path: ${{github.workspace}}/install-x64-linux-dbg-out.log
+              path: ${{github.workspace}}/vcpkg/buildtrees/rsm-bsa/install-x64-linux-dbg-out.log
 
           - name: Upload compile_commands.json
             uses: actions/upload-artifact@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes unnecessary log file copy step from Ubuntu CI workflow, directly uploading from original path.
> 
>   - **CI Workflow**:
>     - Removes step to copy log file from Docker container in `.github/workflows/pr-ubuntu-docker.yml`.
>     - Directly uploads `install-x64-linux-dbg-out.log` from `vcpkg/buildtrees/rsm-bsa/` path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for e75cfd11bdedbb150b6b2f2c0f4902d410960ce6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->