### PR TITLE
internal: add caching to GitHub Actions

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -66,6 +66,19 @@ runs:
         git commit -m "Merge PRs ${{inputs.DEPLOY_BRANCH}}"
       shell: powershell
 
+    - name: Get Current Git SHA
+      id: repo_sha
+      shell: powershell
+      run: |
+        $sha = git rev-parse HEAD
+        echo "sha=$sha" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Cache build dir
+      uses: actions/cache@v4
+      with:
+        path: ${{github.workspace}}/build
+        key: ${{ runner.os }}-skymp-${{ hashFiles('./build-metadata.json') }}-${{ env.sha }}
+
     - name: Early build skymp5-client
       run: |
         cd ${{github.workspace}}/skymp5-client


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add steps to cache build directory and store current Git SHA in GitHub Actions workflow.
> 
>   - **GitHub Actions**:
>     - Add step to cache build directory using `actions/cache@v4` with key based on OS, hash of `build-metadata.json`, and current Git SHA.
>     - Add step to get current Git SHA and store it in GitHub environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 86aa61b4fb697e6503c4437d2d9bcb56417a84a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->