### PR TITLE
internal: rearrange Git SHA capture in workflow

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -55,6 +55,13 @@ runs:
               "token": "${{inputs.SKYMP5_PATCHES_PAT}}"
             }
           ]
+    
+    - name: Get Git SHA Before Gather
+      id: repo_sha
+      shell: powershell
+      run: |
+        $sha = git rev-parse HEAD
+        echo "sha=$sha" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Commit gathered PRs
       if: ${{ inputs.DEPLOY_BRANCH != '' }}
@@ -65,13 +72,6 @@ runs:
         git add .
         git commit -m "Merge PRs ${{inputs.DEPLOY_BRANCH}}"
       shell: powershell
-
-    - name: Get Current Git SHA
-      id: repo_sha
-      shell: powershell
-      run: |
-        $sha = git rev-parse HEAD
-        echo "sha=$sha" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Cache build dir
       uses: actions/cache@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rearrange steps in `action.yml` to capture Git SHA before gathering PRs, removing duplicate step.
> 
>   - **Workflow Changes**:
>     - Move "Get Git SHA" step before "Gather PRs" step in `action.yml` to capture SHA before changes.
>     - Remove duplicate "Get Current Git SHA" step after "Gather PRs".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for c730cfc4af656bfbac355e94544b72a24a338742. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->