### PR TITLE
perf(skymp5-server): skip ACTI and FURN objects in AttachSaveStorage

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -311,6 +311,15 @@ void PartOne::AttachSaveStorage(std::shared_ptr<ISaveStorage> saveStorage)
                             lookupRes.rec->GetType().ToString());
         return;
       }
+      if (lookupRes.rec &&
+          (lookupRes.rec->GetType() == "ACTI" ||
+           lookupRes.rec->GetType() == "FURN")) {
+        pImpl->logger->info("Skipping FF object {} (type is {}), will likely "
+                            "overwrite at some point",
+                            changeForm.formDesc.ToString(),
+                            lookupRes.rec->GetType().ToString());
+        return;
+      }
     }
 
     n++;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add condition in `AttachSaveStorage` to skip `ACTI` and `FURN` objects in `PartOne.cpp`.
> 
>   - **Behavior**:
>     - In `AttachSaveStorage` in `PartOne.cpp`, added condition to skip objects of type `ACTI` and `FURN` when processing FF objects.
>     - Logs a message when skipping these objects, indicating potential future overwriting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for cce9b0ee8197f86bdfefce0316f2f16926ad22fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->