### PR TITLE
internal: change Arch deps to use nodejs 22

### DIFF
--- a/misc/deps_linux/archlinux.sh
+++ b/misc/deps_linux/archlinux.sh
@@ -17,7 +17,7 @@ if [[ "$1" == "--ensure-deps-noninteractive" ]]; then
   fi
   set -x
   PACMAN_ARGS="--noconfirm"
-  pacman -Syu $PACMAN_ARGS sudo
+  pacman -Syu $PACMAN_ARGS sudo --needed
   useradd -m skymp -u $CREATE_UID
   chown -R skymp:skymp /src
 
@@ -50,9 +50,9 @@ addpackage ninja  # would likely build with the regular make, but I haven't trie
 # gdb is also recommended for debugging but isn't required
 
 # These are needed for some parts of the client and server, as well as some build scripts
-addpackage nodejs  # 23 as of 20241222
-# alternatively, nodejs-lts-iron for 20 or nodejs-lts-hydrogen for 18
-# I only found 20, not 22 - https://archlinux.org/packages/?sort=&q=nodejs&maintainer=&flagged=
+addpackage nodejs-lts-jod  # 22
+# alternatively, nodejs for 23 (as of 20250118), nodejs-lts-iron for 20 or nodejs-lts-hydrogen for 18
+# see https://archlinux.org/packages/?sort=&q=nodejs&maintainer=&flagged=
 addpackage yarn
 
 # Some packages that you likely already have, but we'll just make sure


### PR DESCRIPTION
There isn't really much sense in using specifically 22, but the LTS version seems more robust and it appeared just a week ago:
https://archlinux.org/packages/extra/x86_64/nodejs-lts-jod/

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change Node.js dependency to LTS version 22 in `archlinux.sh`.
> 
>   - **Dependencies**:
>     - Change Node.js dependency to `nodejs-lts-jod` (version 22) in `archlinux.sh`.
>     - Update comments to reflect the new Node.js version and alternatives.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for c81e0ca712cf04e43e2af027e376297039a945db. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->