### PR TITLE
feat(skymp5-server): support NPC-specific settings in SweetPieDamageFormula

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/formulas/SweetPieDamageFormula.h
+++ b/skymp5-server/cpp/server_guest_lib/formulas/SweetPieDamageFormula.h
@@ -14,6 +14,7 @@
 struct SweetPieDamageFormulaSettings
 {
   std::vector<float> damageMultByLevel{};
+  std::optional<std::vector<float>> damageMultByLevelTargetNpc{};
   std::unordered_map<std::string, std::vector<uint32_t>> weaponKeywords{};
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for NPC-specific damage multipliers in `SweetPieDamageFormula`.
> 
>   - **Behavior**:
>     - Adds support for NPC-specific damage multipliers in `SweetPieDamageFormula`.
>     - Uses `damageMultByLevelTargetNpc` if target is not a player and the setting is provided.
>   - **Configuration**:
>     - Adds `damageMultByLevelTargetNpc` to `SweetPieDamageFormulaSettings`.
>     - Parses `damageMultByLevelTargetNpc` from JSON config in `ParseConfig()`.
>   - **Functions**:
>     - Adds `IsPlayerBaseId()` helper function to determine if an actor is a player.
>     - Modifies `CalculateDamage()` to use NPC-specific multipliers if applicable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 02d7bf85053f2437f0bb364e83ffec8a98ae1c60. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->