### PR TITLE
fix(libespm): disable search for 0 formId in CombineBrowser

### DIFF
--- a/libespm/src/CombineBrowser.cpp
+++ b/libespm/src/CombineBrowser.cpp
@@ -24,6 +24,12 @@ int32_t CombineBrowser::Impl::GetFileIndex(const char* fileName) const noexcept
 
 LookupResult CombineBrowser::LookupById(uint32_t combFormId) const noexcept
 {
+  // Otherwise, we'll find a TES4 record in Skyrim.esm which is not relevant
+  // for CombineBrowser use cases
+  if (combFormId == 0) {
+    return LookupResult();
+  }
+
   const RecordHeader* resRec = nullptr;
   uint8_t resFileIdx = 0;
   for (size_t i = 0; i < pImpl->numSources; ++i) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add check in `CombineBrowser::LookupById` to return empty result for `combFormId` 0, preventing irrelevant TES4 records.
> 
>   - **Behavior**:
>     - In `CombineBrowser::LookupById`, add check to return empty `LookupResult` if `combFormId` is 0, preventing irrelevant TES4 records from being found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 7b22b8989cd1e0950140617587c31639b045967f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->