### PR TITLE
internal: remove actions/cache@v4 usage

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -73,12 +73,6 @@ runs:
         git commit -m "Merge PRs ${{inputs.DEPLOY_BRANCH}}"
       shell: powershell
 
-    - name: Cache build dir
-      uses: actions/cache@v4
-      with:
-        path: ${{github.workspace}}/build
-        key: ${{ runner.os }}-skymp-${{ hashFiles('./build-metadata.json') }}-${{ env.sha }}
-
     - name: Early build skymp5-client
       run: |
         cd ${{github.workspace}}/skymp5-client


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `actions/cache@v4` usage from `.github/actions/pr_base/action.yml`, eliminating build directory caching.
> 
>   - **GitHub Actions**:
>     - Remove `actions/cache@v4` step from `.github/actions/pr_base/action.yml`.
>     - Eliminates caching of the `build` directory based on `build-metadata.json` hash.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for aa9366b0d711e916ed28c5c986dc8a3d0cea2397. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->