### PR TITLE
internal: upload all vcpkg logs in CI

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -203,13 +203,23 @@ runs:
         Invoke-Expression $cmake_command_full
       shell: powershell
 
-    - name: Upload vcpkg failure logs
-      if: failure()
+    - name: Upload vcpkg logs (non-Windows)
+      if: ${{ always() && runner.os != 'Windows' }}
       uses: actions/upload-artifact@v4
       with:
-        name: install-x64-windows-sp-dbg-out.log
-        #path: C:\vcpkg\buildtrees\spdlog\install-x64-windows-sp-dbg-out.log
-        path: C:\vcpkg\buildtrees\mongo-cxx-driver\install-x64-windows-sp-dbg-out.log
+        name: vcpkg_logs
+        path: |
+          ${{github.workspace}}/build/vcpkg-bootstrap.log
+          ${{github.workspace}}/vcpkg/buildtrees/**/*.log
+
+    - name: Upload vcpkg logs (Windows)
+      if: ${{ always() && runner.os == 'Windows' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: vcpkg_logs
+        path: |
+          ${{github.workspace}}/build/vcpkg-bootstrap.log
+          C:/vcpkg/buildtrees/**/*.log
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Separate vcpkg log uploads for Windows and non-Windows systems in GitHub Actions, ensuring logs are always uploaded.
> 
>   - **Behavior**:
>     - Separate vcpkg log uploads for Windows and non-Windows systems in `.github/actions/pr_base/action.yml`.
>     - Ensure logs are uploaded always, regardless of build success or failure.
>   - **Misc**:
>     - Remove specific log file name `install-x64-windows-sp-dbg-out.log` and replace with a more general `vcpkg_logs` artifact name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for ca45869ff0a868eed53a9169113757b3a231f047. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->