### PR TITLE
internal: handle vcpkg logs path on Windows for artifact upload

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -212,6 +212,15 @@ runs:
           ${{github.workspace}}/build/vcpkg-bootstrap.log
           ${{github.workspace}}/vcpkg/buildtrees/**/*.log
 
+    # actions/upload-artifact will not work for C:/vcpkg because it's not under github.workspace
+    - name: Prepare vcpkg logs (Windows)
+      if: ${{ always() && runner.os == 'Windows' }}
+      shell: powershell
+      run: |
+        $logDir = "${{ github.workspace }}\vcpkg_logs"
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        Copy-Item -Path "C:\vcpkg\buildtrees\*.log" -Destination $logDir -Recurse -Force
+
     - name: Upload vcpkg logs (Windows)
       if: ${{ always() && runner.os == 'Windows' }}
       uses: actions/upload-artifact@v4
@@ -219,7 +228,7 @@ runs:
         name: vcpkg_logs
         path: |
           ${{github.workspace}}/build/vcpkg-bootstrap.log
-          C:/vcpkg/buildtrees/**/*.log
+          ${{github.workspace}}/vcpkg_logs
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves vcpkg log handling on Windows in GitHub Actions by copying logs to a workspace directory for proper artifact upload.
> 
>   - **Windows vcpkg Logs Handling**:
>     - Adds a step to `action.yml` to prepare vcpkg logs on Windows by copying them to `${{ github.workspace }}\vcpkg_logs`.
>     - Modifies the path for uploading vcpkg logs to use `${{ github.workspace }}\vcpkg_logs` instead of `C:/vcpkg/buildtrees/**/*.log`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 4161c3a6a053123170e8b1e2e845ffd09b265458. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->