### PR TITLE
internal: improve Windows log file copying in GitHub Actions

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -219,7 +219,9 @@ runs:
       run: |
         $logDir = "${{ github.workspace }}\vcpkg_logs"
         New-Item -ItemType Directory -Path $logDir -Force | Out-Null
-        Copy-Item -Path "C:\vcpkg\buildtrees\*.log" -Destination $logDir -Recurse -Force
+        Get-ChildItem -Path "C:\vcpkg\buildtrees" -Filter "*.log" -Recurse | ForEach-Object {
+          Copy-Item -Path $_.FullName -Destination $logDir -Force
+        }
 
     - name: Upload vcpkg logs (Windows)
       if: ${{ always() && runner.os == 'Windows' }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify Windows log file copying in GitHub Actions to use `Get-ChildItem` for better handling of nested directories.
> 
>   - **Behavior**:
>     - Modify log file copying in `.github/actions/pr_base/action.yml` to use `Get-ChildItem` and `ForEach-Object` for copying logs from `C:\vcpkg\buildtrees` to `$logDir` on Windows.
>   - **Misc**:
>     - No changes to non-Windows log handling or other parts of the workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 401b28e071c6824b5adf93685703a77ca5541123. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->