### PR TITLE
internal: fix folder structure in vcpkg logs artifact

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -218,15 +218,19 @@ runs:
       shell: powershell
       run: |
         $logDir = "${{ github.workspace }}\vcpkg_logs"
+        
         New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        
+        $sourceDir = "C:\vcpkg\buildtrees"
 
-        Get-ChildItem -Path "C:\vcpkg\buildtrees" -Filter "*.log" -Recurse | ForEach-Object {
-          $relativePath = $_.FullName.Substring(3) # Убираем "C:\"
+        Get-ChildItem -Path $sourceDir -Filter "*.log" -Recurse | ForEach-Object {
+          $relativePath = $_.FullName.Substring($sourceDir.Length).TrimStart('\')
           $destinationPath = Join-Path -Path $logDir -ChildPath $relativePath
 
           New-Item -ItemType Directory -Path (Split-Path -Parent $destinationPath) -Force | Out-Null
           Copy-Item -Path $_.FullName -Destination $destinationPath -Force
         }
+
 
     - name: Upload vcpkg logs (Windows)
       if: ${{ always() && runner.os == 'Windows' }}

--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -219,8 +219,13 @@ runs:
       run: |
         $logDir = "${{ github.workspace }}\vcpkg_logs"
         New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+
         Get-ChildItem -Path "C:\vcpkg\buildtrees" -Filter "*.log" -Recurse | ForEach-Object {
-          Copy-Item -Path $_.FullName -Destination $logDir -Force
+          $relativePath = $_.FullName.Substring(3) # Убираем "C:\"
+          $destinationPath = Join-Path -Path $logDir -ChildPath $relativePath
+
+          New-Item -ItemType Directory -Path (Split-Path -Parent $destinationPath) -Force | Out-Null
+          Copy-Item -Path $_.FullName -Destination $destinationPath -Force
         }
 
     - name: Upload vcpkg logs (Windows)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts folder structure for vcpkg logs on Windows in `pr_base/action.yml` to maintain relative paths.
> 
>   - **Behavior**:
>     - Adjusts folder structure for vcpkg logs on Windows in `pr_base/action.yml`.
>     - Maintains relative path structure from `C:\vcpkg\buildtrees` to `vcpkg_logs`.
>   - **Implementation**:
>     - Uses `Join-Path` to construct destination paths.
>     - Creates necessary directories with `New-Item` before copying files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 1f10e922239438775d15ea2444cd64e7029b54c1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->