### PR TITLE
feat(skymp5-server): implement Utility.GetCurrentRealTime and LeveledItem.GetNthForm

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -58,6 +58,7 @@ struct WorldState::Impl
 };
 
 WorldState::WorldState()
+  : worldStartTime(std::chrono::steady_clock::now())
 {
   logger.reset(new spdlog::logger("empty logger"));
 
@@ -70,6 +71,11 @@ void WorldState::Clear()
   forms.clear();
   grids.clear();
   formIdxManager.reset();
+}
+
+const std::chrono::steady_clock::time_point& WorldState::startPoint() const
+{
+  return worldStartTime;
 }
 
 void WorldState::AttachEspm(espm::Loader* espm_,

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -73,7 +73,7 @@ void WorldState::Clear()
   formIdxManager.reset();
 }
 
-const std::chrono::steady_clock::time_point& WorldState::startPoint() const
+const std::chrono::steady_clock::time_point& WorldState::GetStartPoint() const
 {
   return worldStartTime;
 }

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -55,7 +55,7 @@ public:
 
   void Clear();
 
-  const std::chrono::steady_clock::time_point& startPoint() const;
+  const std::chrono::steady_clock::time_point& GetStartPoint() const;
 
   void AttachEspm(espm::Loader* espm,
                   const FormCallbacksFactory& formCallbacksFactory);

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -55,6 +55,8 @@ public:
 
   void Clear();
 
+  const std::chrono::steady_clock::time_point& startPoint() const;
+
   void AttachEspm(espm::Loader* espm,
                   const FormCallbacksFactory& formCallbacksFactory);
   void AttachSaveStorage(std::shared_ptr<ISaveStorage> saveStorage);
@@ -290,4 +292,5 @@ private:
   struct Impl;
   std::shared_ptr<Impl> pImpl;
   Viet::Timer timerEffects, timerRegular;
+  std::chrono::steady_clock::time_point worldStartTime;
 };

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
@@ -9,6 +9,7 @@
 #include "PapyrusFormList.h"
 #include "PapyrusGame.h"
 #include "PapyrusKeyword.h"
+#include "PapyrusLeveledItem.h"
 #include "PapyrusMessage.h"
 #include "PapyrusNetImmerse.h"
 #include "PapyrusObjectReference.h"
@@ -44,6 +45,7 @@ PapyrusClassesFactory::CreateAndRegister(
   result.emplace_back(std::make_unique<PapyrusPotion>());
   result.emplace_back(std::make_unique<PapyrusVisualEffect>());
   result.emplace_back(std::make_unique<PapyrusQuest>());
+  result.emplace_back(std::make_unique<PapyrusLeveledItem>());
 
   for (auto& papyrusClass : result) {
     papyrusClass->Register(vm, compatibilityPolicy);

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
@@ -1,0 +1,40 @@
+#include "PapyrusLeveledItem.h"
+
+#include "LeveledListUtils.h"
+#include "WorldState.h"
+#include "script_objects/EspmGameObject.h"
+
+VarValue PapyrusLeveledItem::GetNthForm(VarValue self,
+                                        const std::vector<VarValue>& arguments)
+{
+  if (arguments.size() < 1) {
+    throw std::runtime_error(
+      "LeveledItem.GetNthForm requires at least 1 argument");
+  }
+
+  auto itemRecord = GetRecordPtr(self);
+  if (!itemRecord.rec) {
+    throw std::runtime_error("Self not found");
+  }
+  auto& loader = compatibilityPolicy->GetWorldState()->GetEspm();
+  auto leveledItem = espm::Convert<espm::LVLI>(itemRecord.rec);
+  if (leveledItem) {
+    auto vec =
+      LeveledListUtils::EvaluateList(loader.GetBrowser(), itemRecord, 1);
+    int index = static_cast<int>(arguments[0]);
+    if (vec.size() > index) {
+      auto formId = itemRecord.ToGlobalId(vec[index].formId);
+      auto record = itemRecord.parent->LookupById(formId);
+      return VarValue(std::make_shared<EspmGameObject>(record));
+    }
+  }
+  return VarValue::None();
+}
+
+void PapyrusLeveledItem::Register(
+  VirtualMachine& vm, std::shared_ptr<IPapyrusCompatibilityPolicy> policy)
+{
+  compatibilityPolicy = policy;
+
+  AddMethod(vm, "GetNthForm", &PapyrusLeveledItem::GetNthForm);
+}

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "IPapyrusClass.h"
+
+class PapyrusLeveledItem final : public IPapyrusClass<PapyrusLeveledItem>
+{
+public:
+  const char* GetName() override { return "LeveledItem"; }
+
+  VarValue GetNthForm(VarValue slef, const std::vector<VarValue>& arguments);
+
+  void Register(VirtualMachine& vm,
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override;
+
+  std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy;
+};

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.cpp
@@ -51,9 +51,9 @@ VarValue PapyrusUtility::RandomFloat(VarValue self,
 VarValue PapyrusUtility::GetCurrentRealTime(
   VarValue self, const std::vector<VarValue>& arguments)
 {
-  return VarValue(std::chrono::duration<double, std::micro>(
+  return VarValue(std::chrono::duration<double>(
                     std::chrono::steady_clock::now() -
-                    compatibilityPolicy->GetWorldState()->startPoint())
+                    compatibilityPolicy->GetWorldState()->GetStartPoint())
                     .count());
 }
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.cpp
@@ -48,6 +48,15 @@ VarValue PapyrusUtility::RandomFloat(VarValue self,
   return VarValue(distribute(g_generator));
 }
 
+VarValue PapyrusUtility::GetCurrentRealTime(
+  VarValue self, const std::vector<VarValue>& arguments)
+{
+  return VarValue(std::chrono::duration<double, std::micro>(
+                    std::chrono::steady_clock::now() -
+                    compatibilityPolicy->GetWorldState()->startPoint())
+                    .count());
+}
+
 void PapyrusUtility::Register(
   VirtualMachine& vm, std::shared_ptr<IPapyrusCompatibilityPolicy> policy)
 
@@ -57,4 +66,5 @@ void PapyrusUtility::Register(
   AddStatic(vm, "Wait", &PapyrusUtility::Wait);
   AddStatic(vm, "RandomInt", &PapyrusUtility::RandomInt);
   AddStatic(vm, "RandomFloat", &PapyrusUtility::RandomFloat);
+  AddStatic(vm, "GetCurrentRealTime", &PapyrusUtility::GetCurrentRealTime);
 }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusUtility.h
@@ -9,6 +9,8 @@ public:
   VarValue Wait(VarValue self, const std::vector<VarValue>& arguments);
   VarValue RandomInt(VarValue slef, const std::vector<VarValue>& arguments);
   VarValue RandomFloat(VarValue slef, const std::vector<VarValue>& arguments);
+  VarValue GetCurrentRealTime(VarValue self,
+                              const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
                 std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override;


### PR DESCRIPTION
@Pospelove , check this please. I could miss something in LeveledList usage.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implement `Utility.GetCurrentRealTime` and `LeveledItem.GetNthForm` in `skymp5-server` to enhance time tracking and leveled item handling.
> 
>   - **Behavior**:
>     - Implement `Utility.GetCurrentRealTime` in `PapyrusUtility.cpp` to return elapsed real time since server start.
>     - Implement `LeveledItem.GetNthForm` in `PapyrusLeveledItem.cpp` to retrieve a form from a leveled item list.
>   - **WorldState**:
>     - Add `GetStartPoint()` in `WorldState.cpp` to return server start time.
>     - Initialize `worldStartTime` in `WorldState` constructor.
>   - **Papyrus Classes**:
>     - Add `PapyrusLeveledItem` class with `GetNthForm` method.
>     - Register `PapyrusLeveledItem` in `PapyrusClassesFactory.cpp`.
>   - **Misc**:
>     - Add `GetCurrentRealTime` method to `PapyrusUtility.h`.
>     - Add `GetNthForm` method to `PapyrusLeveledItem.h`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 5362a71d9f1b0fffe28bc554dac38be3bb000db5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->