### PR TITLE
fix: revert papyrus error handling refactoring for now

### DIFF
--- a/papyrus-vm/include/papyrus-vm/ActivePexInstance.h
+++ b/papyrus-vm/include/papyrus-vm/ActivePexInstance.h
@@ -72,10 +72,10 @@ private:
 
   VarValue ExecuteAll(
     ExecutionContext& ctx,
-    std::optional<VarValue> previousCallResult = std::nullopt) noexcept;
+    std::optional<VarValue> previousCallResult = std::nullopt);
 
   void ExecuteOpCode(ExecutionContext* ctx, uint8_t op,
-                     const std::vector<VarValue*>& arguments) noexcept;
+                     const std::vector<VarValue*>& arguments);
 
   bool EnsureCallResultIsSynchronous(const VarValue& callResult,
                                      ExecutionContext* ctx);

--- a/papyrus-vm/include/papyrus-vm/VirtualMachine.h
+++ b/papyrus-vm/include/papyrus-vm/VirtualMachine.h
@@ -59,6 +59,7 @@ class VirtualMachine
 
 public:
   using OnEnter = std::function<void(const StackData&)>;
+  using ExceptionHandler = std::function<void(VmExceptionInfo)>;
   using MissingScriptHandler =
     std::function<std::optional<PexScript::Lazy>(std::string)>;
 
@@ -72,6 +73,8 @@ public:
   VirtualMachine(const std::vector<std::shared_ptr<PexScript>>& loadedScripts);
 
   void SetMissingScriptHandler(const MissingScriptHandler& handler);
+
+  void SetExceptionHandler(const ExceptionHandler& handler);
 
   void AddObject(std::shared_ptr<IGameObject> self,
                  const std::vector<ScriptInfo>& scripts);
@@ -109,6 +112,8 @@ public:
 
   bool IsNativeFunctionByNameExisted(const std::string& name) const;
 
+  ExceptionHandler GetExceptionHandler() const;
+
   std::set<CIString> ListClasses() const;
   CIString GetBaseClass(const CIString& className) const;
   std::set<CIString> ListStaticFunctions(const CIString& className) const;
@@ -129,6 +134,7 @@ private:
   std::set<std::shared_ptr<IGameObject>> gameObjectsHolder;
 
   MissingScriptHandler missingScriptHandler;
+  ExceptionHandler handler;
 
   std::shared_ptr<MakeID> stackIdMaker;
 };

--- a/papyrus-vm/src/papyrus-vm-lib/VarValue.cpp
+++ b/papyrus-vm/src/papyrus-vm-lib/VarValue.cpp
@@ -2,7 +2,6 @@
 #include "papyrus-vm/VirtualMachine.h"
 
 #include <cmath>
-#include <spdlog/spdlog.h>
 #include <sstream>
 
 VarValue VarValue::CastToInt() const
@@ -17,8 +16,7 @@ VarValue VarValue::CastToInt() const
     case kType_Bool:
       return VarValue((int32_t)this->data.b);
     default:
-      spdlog::error("VarValue::CastToInt - Wrong type in CastToInt");
-      return VarValue((int32_t)0);
+      throw std::runtime_error("Wrong type in CastToInt");
   }
 }
 
@@ -39,8 +37,7 @@ VarValue VarValue::CastToFloat() const
     case kType_Bool:
       return VarValue(static_cast<double>(this->data.b));
     default:
-      spdlog::error("VarValue::CastToFloat - Wrong type in CastToFloat");
-      return VarValue(static_cast<double>(0));
+      throw std::runtime_error("Wrong type in CastToFloat");
   }
 }
 
@@ -54,8 +51,7 @@ VarValue VarValue::CastToBool() const
         return VarValue(true);
       }
     case kType_Identifier:
-      spdlog::error("VarValue::CastToBool - Wrong type in CastToBool");
-      return VarValue(false);
+      throw std::runtime_error("Wrong type in CastToBool");
     case kType_String: {
       std::string str;
       if (this->data.string == str) {
@@ -77,8 +73,7 @@ VarValue VarValue::CastToBool() const
     case kType_BoolArray:
       return VarValue(this->pArray && this->pArray->size() > 0);
     default:
-      spdlog::error("VarValue::CastToBool - Wrong type in CastToBool");
-      return VarValue(false);
+      throw std::runtime_error("Wrong type in CastToBool");
   }
 }
 
@@ -128,11 +123,7 @@ VarValue::VarValue(uint8_t type)
       break;
 
     default:
-      this->type = this->kType_Object;
-      this->data.id = nullptr;
-      spdlog::error("VarValue::VarValue - Unknown type passed {}",
-                    static_cast<int>(type));
-      break;
+      throw std::runtime_error("Wrong type in VarValue::Constructor");
   }
 }
 
@@ -226,9 +217,7 @@ inline double ToDouble(const VarValue& v)
     case VarValue::kType_Float:
       return static_cast<double>(static_cast<int32_t>(v));
   }
-  spdlog::error("::ToDouble - Wrong type passed {}",
-                static_cast<int>(v.GetType()));
-  return 0.0;
+  throw std::runtime_error("Wrong type in ToDouble");
 }
 
 inline VarValue ConstructArithmeticResult(const VarValue& op1,
@@ -265,8 +254,7 @@ VarValue VarValue::operator+(const VarValue& argument2)
                                      ToDouble(*this) + ToDouble(argument2));
   }
 
-  spdlog::error("VarValue::operator+ - Wrong type");
-  return VarValue(0.0);
+  throw std::runtime_error("Wrong type in operator+");
 }
 
 VarValue VarValue::operator-(const VarValue& argument2)
@@ -292,8 +280,7 @@ VarValue VarValue::operator-(const VarValue& argument2)
                                      ToDouble(*this) - ToDouble(argument2));
   }
 
-  spdlog::error("VarValue::operator- - Wrong type");
-  return VarValue(0.0);
+  throw std::runtime_error("Wrong type in operator-");
 }
 
 VarValue VarValue::operator*(const VarValue& argument2)
@@ -319,8 +306,7 @@ VarValue VarValue::operator*(const VarValue& argument2)
                                      ToDouble(*this) * ToDouble(argument2));
   }
 
-  spdlog::error("VarValue::operator* - Wrong type");
-  return VarValue(0.0);
+  throw std::runtime_error("Wrong type in operator*");
 }
 
 VarValue VarValue::operator/(const VarValue& argument2)
@@ -352,8 +338,7 @@ VarValue VarValue::operator/(const VarValue& argument2)
                                      ToDouble(*this) / ToDouble(argument2));
   }
 
-  spdlog::error("VarValue::operator/ - Wrong type");
-  return VarValue(0.0);
+  throw std::runtime_error("Wrong type in operator/");
 }
 
 VarValue VarValue::operator%(const VarValue& argument2)
@@ -372,8 +357,7 @@ VarValue VarValue::operator%(const VarValue& argument2)
         break;
     }
   }
-  spdlog::error("VarValue::operator% - Wrong type");
-  return VarValue(0);
+  throw std::runtime_error("Wrong type in operator%");
 }
 
 VarValue VarValue::operator!()
@@ -386,10 +370,7 @@ VarValue VarValue::operator!()
       var.data.b = (this->data.id == nullptr);
       return var;
     case kType_Identifier:
-      spdlog::error("VarValue::operator! - Wrong type");
-      var.type = this->kType_Bool;
-      var.data.b = false;
-      return var;
+      throw std::runtime_error("Wrong type in operator!");
     case kType_Integer:
       var.type = this->kType_Bool;
       var.data.b = (this->data.i == 0);
@@ -417,10 +398,7 @@ VarValue VarValue::operator!()
       var.data.b = (this->pArray->size() < 1);
       return var;
     default:
-      spdlog::error("VarValue::operator! - Wrong type");
-      var.type = this->kType_Bool;
-      var.data.b = false;
-      return var;
+      throw std::runtime_error("Wrong type in operator!");
   }
 }
 
@@ -461,8 +439,7 @@ bool VarValue::operator==(const VarValue& argument2) const
     default:
       break;
   }
-  spdlog::error("VarValue::operator== - Wrong type");
-  return false;
+  throw std::runtime_error("Wrong type in operator!");
 }
 
 bool VarValue::operator!=(const VarValue& argument2) const
@@ -482,8 +459,7 @@ bool VarValue::operator>(const VarValue& argument2) const
     default:
       break;
   }
-  spdlog::error("VarValue::operator> - Wrong type");
-  return false;
+  throw std::runtime_error("Wrong type in operator>");
 }
 
 bool VarValue::operator>=(const VarValue& argument2) const
@@ -498,8 +474,7 @@ bool VarValue::operator>=(const VarValue& argument2) const
     default:
       break;
   }
-  spdlog::error("VarValue::operator>= - Wrong type");
-  return false;
+  throw std::runtime_error("Wrong type in operator>=");
 }
 
 bool VarValue::operator<(const VarValue& argument2) const
@@ -514,8 +489,7 @@ bool VarValue::operator<(const VarValue& argument2) const
     default:
       break;
   }
-  spdlog::error("VarValue::operator< - Wrong type");
-  return false;
+  throw std::runtime_error("Wrong type in operator<");
 }
 
 bool VarValue::operator<=(const VarValue& argument2) const
@@ -530,8 +504,7 @@ bool VarValue::operator<=(const VarValue& argument2) const
     default:
       break;
   }
-  spdlog::error("VarValue::operator<= - Wrong type");
-  return false;
+  throw std::runtime_error("Wrong type in operator<=");
 }
 
 std::ostream& operator<<(std::ostream& os, const VarValue& varValue)
@@ -619,9 +592,8 @@ VarValue VarValue::CastToString(const VarValue& var)
       }
     }
     case VarValue::kType_Identifier:
-      spdlog::error(
-        "VarValue::CastToString - kType_Identifier can't be casted");
-      return VarValue(std::string{});
+      throw std::runtime_error(
+        "Papyrus VM: failed to get valid type indentifier, ::CastToString()");
     case VarValue::kType_String:
       return var;
     case VarValue::kType_Integer:
@@ -645,8 +617,8 @@ VarValue VarValue::CastToString(const VarValue& var)
     case VarValue::kType_BoolArray:
       return GetElementsArrayAtString(var, var.kType_BoolArray);
     default:
-      spdlog::error("VarValue::CastToString - Wrong type");
-      return VarValue(std::string{});
+      throw std::runtime_error(
+        "Papyrus VM: Received wrong type, ::CastToString()");
   }
 }
 
@@ -681,17 +653,15 @@ VarValue VarValue::GetElementsArrayAtString(const VarValue& array,
         break;
       }
       default:
-        spdlog::error(
-          "GetElementsArrayAtString - Unable to stringify element of type {}",
-          static_cast<int>(type));
-        break;
+        throw std::runtime_error(
+          " Papyrus VM: None of the type values "
+          "​​matched catched exception ::GetElementArrayAtString");
     }
 
-    if (i < array.pArray->size() - 1) {
+    if (i < array.pArray->size() - 1)
       returnValue += ", ";
-    } else {
+    else
       returnValue += "]";
-    }
   }
 
   return VarValue(returnValue);

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -1020,6 +1020,19 @@ VirtualMachine& WorldState::GetPapyrusVm()
           return result;
         });
 
+      pImpl->vm->SetExceptionHandler([this](const VmExceptionInfo& errorData) {
+        std::string sourcePex = errorData.sourcePex;
+        std::string what = errorData.what;
+        std::string loggerMsg = sourcePex + ": " + what;
+        bool methodNotFoundError =
+          what.find("Method not found") != std::string::npos;
+        if (methodNotFoundError) {
+          logger->warn(loggerMsg);
+        } else {
+          logger->error(loggerMsg);
+        }
+      });
+
       pImpl->classes =
         PapyrusClassesFactory::CreateAndRegister(*pImpl->vm, pImpl->policy);
     }

--- a/unit/VarValueTest.cpp
+++ b/unit/VarValueTest.cpp
@@ -79,12 +79,140 @@ TEST_CASE("operator== for objects", "[VarValue]")
           VarValue(std::make_shared<MyObject>(2)));
 }
 
+TEST_CASE("VarValue Identifier", "[VarValue]")
+{
+  VarValue IdentifierConstructor = VarValue(uint8_t(1));
+  VarValue Identifier = VarValue(uint8_t(1), "kType_Identifier");
+  std::string err = "";
+
+  try {
+    auto t = !Identifier;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = Identifier.CastToInt();
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = Identifier.CastToFloat();
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = Identifier.CastToBool();
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+}
+
+TEST_CASE("VarValue with nonexistent Type", "[VarValue]")
+{
+  std::string err = "";
+
+  try {
+    VarValue nonexistent = VarValue(uint8_t(300));
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+}
+
 TEST_CASE("wrong types", "[VarValue]")
 {
-  // Cast Functions
-
   VarValue str1("string1");
   VarValue str2("string2");
+
+  std::string err = "";
+
+  // operators test
+
+  try {
+    bool t = str1 > str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    bool t = str1 >= str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    bool t = str1 < str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    bool t = str1 <= str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = str1 + str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = str1 - str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = str1 * str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = str1 / str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  try {
+    auto t = str1 % str2;
+  } catch (std::exception& e) {
+    err = e.what();
+  }
+  REQUIRE(err != "");
+  err = "";
+
+  // Cast Functions
 
   REQUIRE(str1.CastToInt() == VarValue(0));
   REQUIRE(VarValue("3").CastToInt() == VarValue(3));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts recent Papyrus VM error handling changes, removing exception handling and logging, and restoring previous behavior with direct exception throwing.
> 
>   - **Behavior**:
>     - Reverts exception handling in `ActivePexInstance.cpp`, `VirtualMachine.cpp`, and `VarValue.cpp` to previous behavior by removing `try-catch` blocks and logging.
>     - Restores throwing `std::runtime_error` for error conditions in `ActivePexInstance.cpp` and `VarValue.cpp`.
>   - **Functions**:
>     - Removes `SetExceptionHandler` and `GetExceptionHandler` usage in `VirtualMachine.cpp`.
>     - Reverts `ExecuteOpCode` and `ExecuteAll` in `ActivePexInstance.cpp` to throw exceptions directly.
>   - **Tests**:
>     - Updates `VarValueTest.cpp` to reflect changes in error handling, ensuring exceptions are thrown for invalid operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 3693ba67f0bc272546359d9ac1bcecc80ee4a42b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->