### PR TITLE
fix(skymp5-server): use GetData in GetNthForm for valid record retrieval

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
@@ -24,9 +24,9 @@ VarValue PapyrusLeveledItem::GetNthForm(VarValue self,
     int index = static_cast<int>(arguments[0]);
     if (static_cast<int>(data.numEntries) > index) {
       auto formId = itemRecord.ToGlobalId(data.entries[index].formId);
-      auto record = loader->GetBrowser().LookupById(formId);
-      if (record) {
-        return VarValue(std::make_shared<EspmGameObject>(record));
+      auto lookupRes = loader.GetBrowser().LookupById(formId);
+      if (lookupRes.rec) {
+        return VarValue(std::make_shared<EspmGameObject>(lookupRes));
       }
     }
   }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
@@ -22,7 +22,7 @@ VarValue PapyrusLeveledItem::GetNthForm(VarValue self,
     auto data = leveledItem->GetData(
       compatibilityPolicy->GetWorldState()->GetEspmCache());
     int index = static_cast<int>(arguments[0]);
-    if (static_cast<int>(data.numEntries) > index) {
+    if (data.numEntries > static_cast<size_t>(index)) {
       auto formId = itemRecord.ToGlobalId(data.entries[index].formId);
       auto lookupRes = loader.GetBrowser().LookupById(formId);
       if (lookupRes.rec) {

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.cpp
@@ -19,13 +19,15 @@ VarValue PapyrusLeveledItem::GetNthForm(VarValue self,
   auto& loader = compatibilityPolicy->GetWorldState()->GetEspm();
   auto leveledItem = espm::Convert<espm::LVLI>(itemRecord.rec);
   if (leveledItem) {
-    auto vec =
-      LeveledListUtils::EvaluateList(loader.GetBrowser(), itemRecord, 1);
+    auto data = leveledItem->GetData(
+      compatibilityPolicy->GetWorldState()->GetEspmCache());
     int index = static_cast<int>(arguments[0]);
-    if (vec.size() > index) {
-      auto formId = itemRecord.ToGlobalId(vec[index].formId);
-      auto record = itemRecord.parent->LookupById(formId);
-      return VarValue(std::make_shared<EspmGameObject>(record));
+    if (static_cast<int>(data.numEntries) > index) {
+      auto formId = itemRecord.ToGlobalId(data.entries[index].formId);
+      auto record = loader->GetBrowser().LookupById(formId);
+      if (record) {
+        return VarValue(std::make_shared<EspmGameObject>(record));
+      }
     }
   }
   return VarValue::None();

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusLeveledItem.h
@@ -6,7 +6,7 @@ class PapyrusLeveledItem final : public IPapyrusClass<PapyrusLeveledItem>
 public:
   const char* GetName() override { return "LeveledItem"; }
 
-  VarValue GetNthForm(VarValue slef, const std::vector<VarValue>& arguments);
+  VarValue GetNthForm(VarValue self, const std::vector<VarValue>& arguments);
 
   void Register(VirtualMachine& vm,
                 std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `GetNthForm` in `PapyrusLeveledItem.cpp` now uses `GetData` for valid record retrieval and fixes a typo in `PapyrusLeveledItem.h`.
> 
>   - **Behavior**:
>     - `GetNthForm` in `PapyrusLeveledItem.cpp` now uses `GetData` for retrieving leveled item data, ensuring valid record retrieval.
>     - Checks if `lookupRes.rec` exists before returning a `VarValue` to prevent errors.
>   - **Misc**:
>     - Fix typo in `PapyrusLeveledItem.h` from `slef` to `self`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for bdaa58e022a73a742886ac260f88aa6560245098. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->