### PR TITLE
feat(skymp5-client): revert manual host resolution

### DIFF
--- a/skymp5-client/src/services/services/skympClient.ts
+++ b/skymp5-client/src/services/services/skympClient.ts
@@ -17,7 +17,7 @@ import { logTrace } from '../../logging';
 printConsole('Hello Multiplayer!');
 printConsole('settings:', settings['skymp5-client']);
 
-const targetIp = settings['skymp5-client']['server-host'] as string;
+const targetIp = settings['skymp5-client']['server-ip'] as string;
 const targetPort = settings['skymp5-client']['server-port'] as number;
 
 export class SkympClient extends ClientListener {

--- a/skymp5-client/src/services/services/skympClient.ts
+++ b/skymp5-client/src/services/services/skympClient.ts
@@ -13,15 +13,11 @@ import { ConnectionMessage } from '../events/connectionMessage';
 import { CreateActorMessage } from '../messages/createActorMessage';
 import { AuthAttemptEvent } from '../events/authAttemptEvent';
 import { logTrace } from '../../logging';
-import { resolve4 } from 'dns';
-import { promisify } from 'util';
-
-const resolve4Promise = promisify(resolve4);
 
 printConsole('Hello Multiplayer!');
 printConsole('settings:', settings['skymp5-client']);
 
-const targetHost = settings['skymp5-client']['server-host'] as string;
+const targetIp = settings['skymp5-client']['server-host'] as string;
 const targetPort = settings['skymp5-client']['server-port'] as number;
 
 export class SkympClient extends ClientListener {
@@ -90,19 +86,11 @@ export class SkympClient extends ClientListener {
     this.sp.printConsole('SkympClient ctor');
   }
 
-  private async resolveHost(host: string) {
-    if (!host.match(/[a-zA-Z]/g)) {
-      return host;
-    }
-    const addrs = await resolve4Promise(host);
-    return addrs[Math.floor(Math.random() * addrs.length)];
-  }
-
   private async establishConnectionConditional() {
     const isConnected = this.controller.lookupListener(networking.NetworkingService).isConnected();
 
     if (!isConnected) {
-      storage.targetIp = await this.resolveHost(targetHost);
+      storage.targetIp = targetIp;
       storage.targetPort = targetPort;
 
       logTrace(this, `Connecting to`, storage.targetIp + ':' + storage.targetPort);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes manual DNS resolution in `skympClient.ts`, using `server-ip` directly for connections.
> 
>   - **Behavior**:
>     - Removes manual DNS resolution logic in `skympClient.ts`.
>     - Directly uses `server-ip` from settings for connection.
>   - **Functions**:
>     - Deletes `resolveHost()` function in `SkympClient` class.
>     - Updates `establishConnectionConditional()` to use `targetIp` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 81b6db1c12e05e1adeecb15c86db263e91073c01. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->