### PR TITLE
refact(skymp5-server): replace deprecated openssl functions

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
@@ -300,11 +300,7 @@ std::string MongoDatabase::BytesToHexString(const uint8_t* bytes,
 std::string MongoDatabase::Sha256(const std::string& str)
 {
   uint8_t hash[SHA256_DIGEST_LENGTH];
-  SHA256_CTX sha256;
-  SHA256_Init(&sha256);
-  SHA256_Update(&sha256, str.c_str(), str.size());
-  SHA256_Final(hash, &sha256);
-
+  SHA256(reinterpret_cast<const uint8_t*>(str.data()), str.size(), hash);
   return BytesToHexString(hash, SHA256_DIGEST_LENGTH);
 }
 


### PR DESCRIPTION
Closes #2251
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces deprecated OpenSSL functions with `SHA256` in `MongoDatabase::Sha256`.
> 
>   - **Behavior**:
>     - Replaces deprecated OpenSSL functions `SHA256_Init`, `SHA256_Update`, and `SHA256_Final` with `SHA256` in `MongoDatabase::Sha256`.
>   - **Misc**:
>     - Closes issue #2251.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b33f6cef1c2a21ff5eb7e2fefbee73dc196364c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->