### PR TITLE
fix(skymp5-client): de-hardcode server id and master url

### DIFF
--- a/skymp5-client/src/services/services/authService.ts
+++ b/skymp5-client/src/services/services/authService.ts
@@ -53,6 +53,27 @@ export class AuthService extends ClientListener {
     this.controller.once("update", () => this.onceUpdate());
   }
 
+  // TODO: consider moving to a separate service called SettingsService
+  public getServerMasterKey() {
+    let masterKey = this.sp.settings["skymp5-client"]["server-master-key"];
+    if (!masterKey) {
+      masterKey = this.sp.settings["skymp5-client"]["master-key"];
+    }
+    if (!masterKey) {
+      masterKey = this.sp.settings["skymp5-client"]["server-ip"] + ":" + this.sp.settings["skymp5-client"]["server-port"];
+    }
+    return masterKey;
+  }
+
+  // TODO: consider moving to a separate service called SettingsService
+  public getMasterUrl() {
+    return this.normalizeUrl((this.sp.settings["skymp5-client"]["master"] as string) || "https://gateway.skymp.net");
+  }
+
+  public getMasterApiId() {
+    return authData?.masterApiId;
+  }
+  
   private onAuthNeeded(e: AuthNeededEvent) {
     logTrace(this, `Received authNeeded event`);
 
@@ -223,15 +244,8 @@ export class AuthService extends ClientListener {
 
   private createPlaySession(token: string, callback: (res: string, err: string) => void) {
     const client = new this.sp.HttpClient(this.getMasterUrl());
-    let masterKey = this.sp.settings["skymp5-client"]["server-master-key"];
-    if (!masterKey) {
-      masterKey = this.sp.settings["skymp5-client"]["master-key"];
-    }
-    if (!masterKey) {
-      masterKey = this.sp.settings["skymp5-client"]["server-ip"] + ":" + this.sp.settings["skymp5-client"]["server-port"];
-    }
 
-    const route = `/api/users/me/play/${masterKey}`;
+    const route = `/api/users/me/play/${this.getServerMasterKey()}`;
 
     logTrace(this, `Creating play session ${route}`);
 
@@ -356,10 +370,6 @@ export class AuthService extends ClientListener {
       logError(this, `Error writing`, this.pluginAuthDataName, `to disk:`, e, `, will not remember user`);
     }
   };
-
-  private getMasterUrl() {
-    return this.normalizeUrl((this.sp.settings["skymp5-client"]["master"] as string) || "https://gateway.skymp.net");
-  }
 
   private normalizeUrl(url: string) {
     if (url.endsWith('/')) {

--- a/skymp5-client/src/services/services/loadOrderVerificationService.ts
+++ b/skymp5-client/src/services/services/loadOrderVerificationService.ts
@@ -3,6 +3,7 @@ import { getScreenResolution } from "../../view/formView";
 import { ClientListener, CombinedController, Sp } from "./clientListener";
 import { Mod, ServerManifest } from "../messages_http/serverManifest";
 import { logTrace } from "../../logging";
+import { AuthService } from "./authService";
 
 const STATE_KEY = 'loadOrderCheckState';
 
@@ -106,12 +107,15 @@ export class LoadOrderVerificationService extends ClientListener {
   }
 
   private getServerMods(retriesLeft: number): Promise<Mod[]> {
-    // TODO: unhardcode master address
-    // TODO: unhardcode serverId (sweetpie)
-    let addr = "https://gateway.skymp.net";
+    const authService = this.controller.lookupListener(AuthService);
+
+    const addr = authService.getMasterUrl();
+    const masterKey = authService.getServerMasterKey();
     printConsole(addr);
+    printConsole(masterKey);
+
     return new HttpClient(addr)
-      .get('/api/servers/sweetpie/manifest.json')
+      .get(`/api/servers/${masterKey}/manifest.json`)
       .then((res) => {
         if (res.status != 200) {
           throw new Error(`Status code ${res.status}, error ${res.error}`);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> De-hardcoded server details in `AuthService` and `LoadOrderVerificationService` by dynamically fetching them from settings.
> 
>   - **Behavior**:
>     - `AuthService` now dynamically retrieves `server-master-key` and `master` URL from settings using `getServerMasterKey()` and `getMasterUrl()`.
>     - `LoadOrderVerificationService` uses `AuthService` to get server details for mod verification.
>   - **Functions**:
>     - Added `getServerMasterKey()` and `getMasterUrl()` in `AuthService` to fetch server details from settings.
>     - Updated `createPlaySession()` in `AuthService` to use `getServerMasterKey()`.
>     - Updated `getServerMods()` in `LoadOrderVerificationService` to use `AuthService` for server details.
>   - **Misc**:
>     - Removed hardcoded server address and server ID in `authService.ts` and `loadOrderVerificationService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 51bbc2da3851a4364863a4a54a67683629d2b5b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->