### PR TITLE
internal: rename codegen target to fix CMake warning

### DIFF
--- a/skyrim-platform/src/platform_se/CMakeLists.txt
+++ b/skyrim-platform/src/platform_se/CMakeLists.txt
@@ -158,11 +158,11 @@ if(NOT "${SKIP_SKYRIM_PLATFORM_BUILDING}")
       "${CONVERT_FILES_DIR}/Definitions.txt"
       "${CMAKE_CURRENT_BINARY_DIR}/_codegen/skyrimPlatform.ts"
     )
-    add_custom_target(codegen ALL COMMAND $<TARGET_FILE:TSConverter> ${CODEGEN_ARGS})
-    add_dependencies(codegen TSConverter)
+    add_custom_target(sp_codegen ALL COMMAND $<TARGET_FILE:TSConverter> ${CODEGEN_ARGS})
+    add_dependencies(sp_codegen TSConverter)
 
-    # force "skyrim-platform" custom target to be built strictly after codegen
-    list(APPEND DEPENDENCIES_FOR_CUSTOM_TARGETS codegen)
+    # force "skyrim-platform" custom target to be built strictly after sp_codegen
+    list(APPEND DEPENDENCIES_FOR_CUSTOM_TARGETS sp_codegen)
   endif()
 
   # this target was originally called pack, now it is called skyrim-platform


### PR DESCRIPTION
closes https://github.com/skyrim-multiplayer/skymp/issues/2267
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames `codegen` target to `sp_codegen` in `CMakeLists.txt` to fix a CMake warning.
> 
>   - **CMake Target Renaming**:
>     - Rename `codegen` to `sp_codegen` in `CMakeLists.txt`.
>     - Update `add_custom_target` and `add_dependencies` to use `sp_codegen`.
>     - Adjust `DEPENDENCIES_FOR_CUSTOM_TARGETS` to reflect the new target name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 9fe27d6c09a7e2e87d6df48084af8c9f00d6bee4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->