### PR TITLE
fix(skymp5-server): reset timer id on resolve in RegisterForSingleUpdate

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusForm.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusForm.cpp
@@ -36,9 +36,12 @@ VarValue PapyrusForm::RegisterForSingleUpdate(
       auto promise = worldState->SetTimer(time, &timerId);
       uint32_t formId = form->GetFormId();
       promise.Then([form, formId, worldState](const Viet::Void&) {
-        if (form == worldState->LookupFormById(formId).get()) {
-          form->Update();
+        if (form != worldState->LookupFormById(formId).get()) {
+          spdlog::error("form mismatch on timer resolve: formId={:x}", formId);
+          return;
         }
+        form->SetSingleUpdateTimerId(std::nullopt);
+        form->Update();
       });
 
       form->SetSingleUpdateTimerId(timerId);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes timer ID reset and adds error logging for form mismatches in `PapyrusForm::RegisterForSingleUpdate`.
> 
>   - **Behavior**:
>     - In `PapyrusForm::RegisterForSingleUpdate`, reset timer ID to `std::nullopt` on timer resolution.
>     - Add error logging for form mismatch on timer resolution.
>   - **Logging**:
>     - Log error with `spdlog` if form mismatch occurs during timer resolution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 1b4ffc413ac0c395d5f9adf879354bc09e7b9c1d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->