### PR TITLE
feat(skymp5-server): slightly reduce cooldown for bows and crossbows

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
+++ b/skymp5-server/cpp/server_guest_lib/AnimationSystem.cpp
@@ -131,11 +131,11 @@ void AnimationSystem::InitAdditionalCallbacks()
         std::chrono::duration<float> elapsedTime =
           std::chrono::steady_clock::now() -
           GetLastAttackReleaseAnimationTime(actor);
-        if (elapsedTime > std::chrono::seconds(2)) {
-          constexpr float defaultModifier = 20.f;
+        if (elapsedTime > std::chrono::seconds(1)) {
+          constexpr float defaultModifier = 10.f;
           HandleAttackAnim(actor, defaultModifier);
         } else {
-          constexpr float defaultModifier = 60.f;
+          constexpr float defaultModifier = 40.f;
           actor->DamageActorValue(espm::ActorValue::Stamina, defaultModifier);
         }
       },


### PR DESCRIPTION
@Pospelove pls check for errors
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `AnimationSystem` attack release timing and stamina modifiers in `InitAdditionalCallbacks`.
> 
>   - **Behavior**:
>     - In `AnimationSystem::InitAdditionalCallbacks`, change attack release timing from 2 seconds to 1 second.
>     - Adjust default stamina modifiers: from 20.f to 10.f for long elapsed time, and from 60.f to 40.f for short elapsed time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 0114a69ccf3502696a990185234a97354f4006d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->