### PR TITLE
feat(skymp5-server): log guid on connection in ServerState

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ServerState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ServerState.cpp
@@ -1,14 +1,24 @@
 #include "ServerState.h"
-#include "Exceptions.h"
-#include "JsonUtils.h"
-#include "MpActor.h"
-#include "MsgType.h"
+
 #include <algorithm>
+
+#include <spdlog/spdlog.h>
+
+#include "MpActor.h"
 
 void ServerState::Connect(Networking::UserId userId, const std::string& guid)
 {
+  if (userInfo[userId] != nullptr) {
+    spdlog::error("ServerState::Connect: overwritten userInfo for userId={}, "
+                  "old guid: {}, new guid: {}",
+                  userId, userInfo[userId]->guid, guid);
+  }
+
   userInfo[userId] = std::make_unique<UserInfo>();
   userInfo[userId]->guid = guid;
+
+  spdlog::error("ServerState::Connect: assigning guid for userId={}: guid={}",
+                userId, guid);
 
   if (maxConnectedId < userId) {
     maxConnectedId = userId;

--- a/skymp5-server/cpp/server_guest_lib/ServerState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ServerState.cpp
@@ -17,8 +17,8 @@ void ServerState::Connect(Networking::UserId userId, const std::string& guid)
   userInfo[userId] = std::make_unique<UserInfo>();
   userInfo[userId]->guid = guid;
 
-  spdlog::error("ServerState::Connect: assigning guid for userId={}: guid={}",
-                userId, guid);
+  spdlog::info("ServerState::Connect: assigning guid for userId={}: guid={}",
+               userId, guid);
 
   if (maxConnectedId < userId) {
     maxConnectedId = userId;

--- a/skymp5-server/ts/systems/login.ts
+++ b/skymp5-server/ts/systems/login.ts
@@ -93,7 +93,8 @@ export class Login implements System {
     if (type !== "loginWithSkympIo") return;
 
     const ip = ctx.svr.getUserIp(userId);
-    console.log(`Connecting a user ${userId} with ip ${ip}`);
+    const guid = ctx.svr.getUserGuid(userId);
+    console.log(`Connecting a user ${userId} with ip ${ip}, guid ${guid}`);
 
     let discordAuth = this.settingsObject.discordAuth;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add logging for GUIDs during user connection in `ServerState.cpp` and `login.ts`.
> 
>   - **C++ Changes**:
>     - In `ServerState.cpp`, `ServerState::Connect` now logs GUID assignment and overwrites using `spdlog`.
>   - **TypeScript Changes**:
>     - In `login.ts`, `customPacket` logs the user's GUID when connecting, using `console.log`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for fda94337118070faa52380a913b38c9a6384b067. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->