### PR TITLE
fix(skymp5-client): stop checking login state once connected

### DIFF
--- a/skymp5-client/src/services/services/authService.ts
+++ b/skymp5-client/src/services/services/authService.ts
@@ -497,10 +497,6 @@ export class AuthService extends ClientListener {
     window.skyrimPlatform.widgets.set([loginWidget]);
   };
 
-  private handleConnectionAccepted() {
-    this.loginWithSkympIoCredentials();
-  }
-
   private handleConnectionDenied(e: ConnectionDenied) {
     this.authAttemptProgressIndicator = false;
 
@@ -518,7 +514,8 @@ export class AuthService extends ClientListener {
     }
   }
 
-  private loginWithSkympIoCredentials() {
+  private handleConnectionAccepted() {
+    this.isListenBrowserMessage = false;
     this.loggingStartMoment = Date.now();
 
     const authData = this.sp.storage[authGameDataStorageKey] as AuthGameData | undefined;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `AuthService` to stop checking login state after connection acceptance by integrating `loginWithSkympIoCredentials` logic into `handleConnectionAccepted`.
> 
>   - **Behavior**:
>     - `handleConnectionAccepted()` now stops listening to browser messages and logs the start moment in `authService.ts`.
>     - Removes `loginWithSkympIoCredentials()` and integrates its logic into `handleConnectionAccepted()`.
>   - **Misc**:
>     - Removes redundant function call to `loginWithSkympIoCredentials()` in `authService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 5b80c50e667b3773a4b6aa21680f9eda46566319. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->