### PR TITLE
feat(skymp5-client): add password helper for indev

### DIFF
--- a/skymp5-client/src/index.ts
+++ b/skymp5-client/src/index.ts
@@ -52,6 +52,7 @@ import { KeyboardEventsService } from "./services/services/keyboardEventsService
 import { MagicSyncService } from "./services/services/magicSyncService";
 import { ProfilingService } from "./services/services/profilingService";
 import { SettingsService } from "./services/services/settingsService";
+import { RPCClientService } from "./services/services/rpcClientService";
 
 once("update", () => {
   Utility.setINIBool("bAlwaysActive:General", true);
@@ -84,6 +85,7 @@ const main = () => {
       new RemoteServer(sp, controller),
       new SpSnippetService(sp, controller),
       new SettingsService(sp, controller),
+      new RPCClientService(sp, controller),
       new SweetTaffyDynamicPerksService(sp, controller),
       new SweetTaffyStaticPerksService(sp, controller),
       new SweetTaffySweetCantDropService(sp, controller),

--- a/skymp5-client/src/services/messages_http/rpcResponse.ts
+++ b/skymp5-client/src/services/messages_http/rpcResponse.ts
@@ -1,5 +1,5 @@
-export interface RPCResponse {
-  rpcFound: boolean;
-  rpcResult: Record<string, unknown> | null;
-  rpcException: string | Error | null; // not sure about that type
-};
+export interface RPCResponse<RPCResult = Record<string, unknown>> {
+    rpcFound: boolean;
+    rpcResult: RPCResult | null;
+    rpcException: string | null;
+}

--- a/skymp5-client/src/services/messages_http/rpcResponse.ts
+++ b/skymp5-client/src/services/messages_http/rpcResponse.ts
@@ -1,0 +1,5 @@
+export interface RPCResponse {
+  rpcFound: boolean;
+  rpcResult: Record<string, unknown> | null;
+  rpcException: string | Error | null; // not sure about that type
+};

--- a/skymp5-client/src/services/messages_http/rpcResults/rpcResultGetServerPassword.ts
+++ b/skymp5-client/src/services/messages_http/rpcResults/rpcResultGetServerPassword.ts
@@ -1,0 +1,3 @@
+export interface RPCResultGetServerPassword {
+    password: string;
+}

--- a/skymp5-client/src/services/messages_http/targetPeer.ts
+++ b/skymp5-client/src/services/messages_http/targetPeer.ts
@@ -1,0 +1,4 @@
+export interface TargetPeer {
+    host: string;
+    port: number;
+}

--- a/skymp5-client/src/services/services/authService.ts
+++ b/skymp5-client/src/services/services/authService.ts
@@ -19,6 +19,7 @@ import { ConnectionDenied } from "../events/connectionDenied";
 import { SettingsService } from "./settingsService";
 import { RPCResponse } from "../messages_http/rpcResponse";
 import { RPCClientService } from "./rpcClientService";
+import { RPCResultGetServerPassword } from "../messages_http/rpcResults/rpcResultGetServerPassword";
 
 // for browsersideWidgetSetter
 declare const window: any;
@@ -223,7 +224,7 @@ export class AuthService extends ClientListener {
 
         const rpcClientService = this.controller.lookupListener(RPCClientService);
 
-        rpcClientService.callRpc("RPCGetServerPassword", {}, (response) => {
+        rpcClientService.callRpc<RPCResultGetServerPassword>("RPCGetServerPassword", {}, (response) => {
           if (!response) {
             logError(this, `Failed to get server password`);
             return;
@@ -235,8 +236,9 @@ export class AuthService extends ClientListener {
             fs.copyFileSync("Data/Platform/Distribution/password", "Data/Platform/Distribution/password_backup");
           }
 
-          if (response.rpcResult && typeof (response.rpcResult.password) === "string") {
-            const password = response.rpcResult.password;
+          if (response.rpcResult !== null) {
+            const { password } = response.rpcResult;
+
             // TODO: handle filesystem errors
             fs.writeFileSync("Data/Platform/Distribution/password", password);
 

--- a/skymp5-client/src/services/services/authService.ts
+++ b/skymp5-client/src/services/services/authService.ts
@@ -17,7 +17,6 @@ import { CustomPacketMessage2 } from "../messages/customPacketMessage2";
 import { MsgType } from "../../messages";
 import { ConnectionDenied } from "../events/connectionDenied";
 import { SettingsService } from "./settingsService";
-import { RPCResponse } from "../messages_http/rpcResponse";
 import { RPCClientService } from "./rpcClientService";
 import { RPCResultGetServerPassword } from "../messages_http/rpcResults/rpcResultGetServerPassword";
 

--- a/skymp5-client/src/services/services/rpcClientService.ts
+++ b/skymp5-client/src/services/services/rpcClientService.ts
@@ -9,7 +9,7 @@ export class RPCClientService extends ClientListener {
     }
 
     // TODO: rewrite this function to use async/await once Skyrim Platform supports it in main menu
-    callRpc(rpcName: string, payload: Record<string, unknown>, callback: (response: RPCResponse | null) => void): void {
+    callRpc<RPCResult>(rpcName: string, payload: Record<string, unknown>, callback: (response: RPCResponse<RPCResult> | null) => void): void {
         const settingsService = this.controller.lookupListener(SettingsService);
         const client = new this.sp.HttpClient(settingsService.getMasterUrl());
         const serverMasterKey = settingsService.getServerMasterKey();
@@ -26,10 +26,10 @@ export class RPCClientService extends ClientListener {
                 return;
             }
 
-            let response: RPCResponse;
+            let response: RPCResponse<RPCResult>;
             try {
                 // TODO: consider schema validation with zod
-                response = JSON.parse(res.body) as RPCResponse;
+                response = JSON.parse(res.body) as RPCResponse<RPCResult>;
             }
             catch (e) {
                 if (e instanceof SyntaxError) {

--- a/skymp5-client/src/services/services/rpcClientService.ts
+++ b/skymp5-client/src/services/services/rpcClientService.ts
@@ -1,0 +1,48 @@
+import { logError } from "../../logging";
+import { RPCResponse } from "../messages_http/rpcResponse";
+import { ClientListener, CombinedController, Sp } from "./clientListener";
+import { SettingsService } from "./settingsService";
+
+export class RPCClientService extends ClientListener {
+    constructor(private sp: Sp, private controller: CombinedController) {
+        super();
+    }
+
+    // TODO: rewrite this function to use async/await once Skyrim Platform supports it in main menu
+    callRpc(rpcName: string, payload: Record<string, unknown>, callback: (response: RPCResponse | null) => void): void {
+        const settingsService = this.controller.lookupListener(SettingsService);
+        const client = new this.sp.HttpClient(settingsService.getMasterUrl());
+        const serverMasterKey = settingsService.getServerMasterKey();
+
+        client.post(`/api/servers/${serverMasterKey}/rpc/${rpcName}`, {
+            body: JSON.stringify(payload),
+            contentType: 'application/json',
+            headers: {}
+            // @ts-ignore
+        }, (res) => {
+            if (res.status < 200 || res.status >= 300) {
+                logError(this, `Http request status did not indicate success:`, res.status, res.body);
+                callback(null);
+                return;
+            }
+
+            let response: RPCResponse;
+            try {
+                // TODO: consider schema validation with zod
+                response = JSON.parse(res.body) as RPCResponse;
+            }
+            catch (e) {
+                if (e instanceof SyntaxError) {
+                    logError(this, `Failed to parse response body as JSON:`, res.body);
+                    callback(null);
+                    return;
+                }
+                else {
+                    throw e;
+                }
+            }
+
+            callback(response);
+        });
+    }
+};

--- a/skymp5-client/src/services/services/settingsService.ts
+++ b/skymp5-client/src/services/services/settingsService.ts
@@ -4,6 +4,7 @@ import { ClientListener, CombinedController, Sp } from "./clientListener";
 import { Mod, ServerManifest } from "../messages_http/serverManifest";
 import { TimersService } from "./timersService";
 
+// TODO: get rid of this interface once skyrim-platform types gets updated in package.json
 interface IHttpClientWithCallback {
   get(path: string, options?: { headers?: HttpHeaders }): Promise<HttpResponse>;
   post(path: string, options: { body: string, contentType: string, headers?: HttpHeaders }): Promise<HttpResponse>;

--- a/skymp5-client/src/services/services/settingsService.ts
+++ b/skymp5-client/src/services/services/settingsService.ts
@@ -3,6 +3,7 @@ import { AuthService } from "./authService";
 import { ClientListener, CombinedController, Sp } from "./clientListener";
 import { Mod, ServerManifest } from "../messages_http/serverManifest";
 import { TimersService } from "./timersService";
+import { TargetPeer } from "../messages_http/targetPeer";
 
 // TODO: get rid of this interface once skyrim-platform types gets updated in package.json
 interface IHttpClientWithCallback {
@@ -10,11 +11,6 @@ interface IHttpClientWithCallback {
   post(path: string, options: { body: string, contentType: string, headers?: HttpHeaders }): Promise<HttpResponse>;
 
   get(path: string, options: { headers?: HttpHeaders } | undefined, callback: (response: HttpResponse) => void): void;
-}
-
-export interface TargetPeer {
-  host: string;
-  port: number;
 }
 
 export class SettingsService extends ClientListener {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds password helper for indev environments in `skymp5-client` by handling RPC responses and updating server passwords.
> 
>   - **Behavior**:
>     - Adds `RPCResponse` interface in `rpcResponse.ts` for handling RPC call responses.
>     - Modifies `AuthService` in `authService.ts` to handle `updateSkip` event by fetching and updating server password via RPC call.
>     - Handles invalid password errors by showing appropriate widgets based on `serverMasterKey`.
>   - **Widgets**:
>     - Adds `updateSkipWidgetSetter` and modifies `updateRequiredWidgetSetter` in `authService.ts` to handle password correction and update scenarios.
>   - **Misc**:
>     - Adds `fs` import in `authService.ts` for file operations.
>     - Updates `events` object in `authService.ts` to include `updateSkip`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 06dde5213bf26806d7623d9ffd752890faaa3b3a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->