### PR TITLE
feat(skymp5-server): add uiListenHost setting

### DIFF
--- a/docs/docs_server_configuration_reference.md
+++ b/docs/docs_server_configuration_reference.md
@@ -28,12 +28,24 @@ Specify the server key you wish to use for Master API. Client must have the same
 
 ## listenHost
 
-Specifies the IP address to bind to. Applies to the main UDP traffic (RakNet).
+Specifies the IP address to bind to. Applies to the main UDP traffic (RakNet). Binds to `0.0.0.0` if unspecified.
 
 ```json5
 {
   // ...
   "listenHost": "127.0.0.1",
+  // ...
+}
+```
+
+## uiListenHost
+
+Specifies the IP address to bind to. Applies to the `uiPort` (http). Binds to `0.0.0.0` if unspecified.
+
+```json5
+{
+  // ...
+  "uiListenHost": "127.0.0.1",
   // ...
 }
 ```

--- a/skymp5-server/ts/ui.ts
+++ b/skymp5-server/ts/ui.ts
@@ -41,6 +41,7 @@ export const main = (settings: Settings): void => {
 
   const devServerPort = 1234;
 
+  const uiListenHost = settings.allSettings.uiListenHost as (string | undefined);
   const uiPort = settings.port === 7777 ? 3000 : settings.port + 1;
 
   Axios({
@@ -71,13 +72,13 @@ export const main = (settings: Settings): void => {
           })
         );
         console.log(`Server resources folder is listening on ${uiPort}`);
-        http.createServer(appProxy.callback()).listen(uiPort);
+        http.createServer(appProxy.callback()).listen(uiPort, uiListenHost);
       });
     })
     .catch(() => {
       const app = createApp(() => uiPort);
       console.log(`Server resources folder is listening on ${uiPort}`);
-      const server = require("http").createServer(app.callback());
-      server.listen(uiPort);
+      const server = http.createServer(app.callback());
+      server.listen(uiPort, uiListenHost);
     });
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `uiListenHost` setting to `main()` in `ui.ts` for server host binding.
> 
>   - **Behavior**:
>     - Adds `uiListenHost` setting in `main()` in `ui.ts` to specify the host for the server to listen on.
>     - Updates `http.createServer().listen()` calls to use `uiListenHost` in `main()` in `ui.ts`.
>   - **Misc**:
>     - No changes to existing logic or functionality beyond host binding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for ee6ff8e0e4f13bcedd7d10d6be81ef38b8cf3eb2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->