### PR TITLE
fix(skymp5-client): clear blocked animations array in BlockedAnimationsService

### DIFF
--- a/skymp5-client/src/services/services/blockedAnimationsService.ts
+++ b/skymp5-client/src/services/services/blockedAnimationsService.ts
@@ -5,7 +5,7 @@ export class BlockedAnimationsService extends ClientListener {
     constructor(private sp: Sp, private controller: CombinedController) {
         super();
 
-        const blockedAnims = ["IdleNocturnal*", "IdleCarryBucketFillEnter", "IdleGreybeardMeditateEnter", "IdleWriteTableChairEnterInstant", "Idlelounge", "IdleTGFalmerStatueEnter", "IdleWounded_02", "IdleWounded_03", "IdleWounded_01", "IdleMT_DoorBang", "pa_KillMove2HMStab", "pa_WW_CutWrist"];
+        const blockedAnims = [];
 
         const self = this;
 

--- a/skymp5-client/src/services/services/blockedAnimationsService.ts
+++ b/skymp5-client/src/services/services/blockedAnimationsService.ts
@@ -5,7 +5,7 @@ export class BlockedAnimationsService extends ClientListener {
     constructor(private sp: Sp, private controller: CombinedController) {
         super();
 
-        const blockedAnims = [];
+        const blockedAnims: string[] = [];
 
         const self = this;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clears `blockedAnims` array in `BlockedAnimationsService`, resulting in no animations being blocked by default.
> 
>   - **Behavior**:
>     - Clears `blockedAnims` array in `BlockedAnimationsService` constructor in `blockedAnimationsService.ts`, resulting in no animations being blocked by default.
>     - Affects `sendAnimationEvent` hook, which will not modify `ctx.animEventName` since no animations are specified to be blocked.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 2db529b6c83fb2d33cef3f4da49118939c4a0466. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->