### PR TITLE
internal: fix typo in skymp5-front/CMakeLists.txt

### DIFF
--- a/skymp5-front/CMakeLists.txt
+++ b/skymp5-front/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_FRONT)
   )
 else()
   add_custom_target(skymp5-front ALL
-    SOURCES ${source}
+    SOURCES ${sources}
     COMMAND ${CMAKE_COMMAND} -E echo "Building skymp5-front is disabled. To enable it, set BUILD_FRONT to ON."
   )
 endif()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `skymp5-front/CMakeLists.txt` by changing `source` to `sources` in `add_custom_target`.
> 
>   - **Fix**:
>     - Correct typo in `skymp5-front/CMakeLists.txt`: change `source` to `sources` in `add_custom_target` command when `BUILD_FRONT` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 3490eaad45f668e9ac3e7343db8ab398c2234be2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->