### PR TITLE
Revert "fix(skymp5-client): clear blocked animations array in BlockedAnimationsService"

### DIFF
--- a/skymp5-client/src/services/services/blockedAnimationsService.ts
+++ b/skymp5-client/src/services/services/blockedAnimationsService.ts
@@ -5,7 +5,7 @@ export class BlockedAnimationsService extends ClientListener {
     constructor(private sp: Sp, private controller: CombinedController) {
         super();
 
-        const blockedAnims: string[] = [];
+        const blockedAnims = ["IdleNocturnal*", "IdleCarryBucketFillEnter", "IdleGreybeardMeditateEnter", "IdleWriteTableChairEnterInstant", "Idlelounge", "IdleTGFalmerStatueEnter", "IdleWounded_02", "IdleWounded_03", "IdleWounded_01", "IdleMT_DoorBang", "pa_KillMove2HMStab", "pa_WW_CutWrist"];
 
         const self = this;
 


### PR DESCRIPTION
Reverts skyrim-multiplayer/skymp#2362
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts change in `blockedAnimationsService.ts` to restore original blocked animations list.
> 
>   - **Revert Change**:
>     - Reverts previous change in `blockedAnimationsService.ts` that cleared `blockedAnims` array.
>     - Restores original blocked animations list including "IdleNocturnal*", "IdleCarryBucketFillEnter", and others.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b3f3aee97f6e79fe7dc7d9999299ca72445a049b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->