### PR TITLE
fix(skymp5-server): make listenHost arg optional

### DIFF
--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -177,8 +177,9 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
     auto serverSettings = nlohmann::json::parse(serverSettingsJson);
 
     // TODO: rework parsing with archives?
-    std::string listenHost =
-      serverSettings.at("listenHost").get<std::string>();
+    std::string listenHost = serverSettings.contains("listenHost")
+      ? serverSettings.at("listenHost").get<std::string>()
+      : std::string();
     uint32_t listenPort = serverSettings.at("port").get<uint32_t>();
     uint32_t maxPlayers = serverSettings.at("maxPlayers").get<uint32_t>();
 
@@ -321,8 +322,9 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
       ? std::string(kNetworkingPasswordPrefix) +
         static_cast<std::string>(serverSettings["password"])
       : std::string(kNetworkingPasswordPrefix);
-    auto realServer = Networking::CreateServer(listenHost.c_str(), listenPort,
-                                               maxPlayers, password.data());
+    auto realServer = Networking::CreateServer(
+      listenHost.empty() ? nullptr : listenHost.c_str(), listenPort,
+      maxPlayers, password.data());
 
     static_assert(kMockServerIdx == 1);
     server = Networking::CreateCombinedServer({ realServer, serverMock });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `listenHost` argument optional in `ScampServer` constructor, defaulting to empty string if not provided.
> 
>   - **Behavior**:
>     - `listenHost` argument in `ScampServer` constructor is now optional. Defaults to an empty string if not provided in `serverSettings`.
>     - In `ScampServer.cpp`, `Networking::CreateServer` now receives `nullptr` for `listenHost` if it is empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 43bc01767eb4f192ba3efae88c637c71c77528d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->