### PR TITLE
refact(skymp5-server): simplify optional listenHost parsing

### DIFF
--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -177,9 +177,11 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
     auto serverSettings = nlohmann::json::parse(serverSettingsJson);
 
     // TODO: rework parsing with archives?
-    std::string listenHost = serverSettings.contains("listenHost")
-      ? serverSettings.at("listenHost").get<std::string>()
-      : std::string();
+    std::string listenHost;
+    if (auto it = serverSettings.find("listenHost");
+        it != serverSettings.end()) {
+      listenHost = it.value().get<std::string>();
+    }
     uint32_t listenPort = serverSettings.at("port").get<uint32_t>();
     uint32_t maxPlayers = serverSettings.at("maxPlayers").get<uint32_t>();
 
@@ -322,9 +324,8 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
       ? std::string(kNetworkingPasswordPrefix) +
         static_cast<std::string>(serverSettings["password"])
       : std::string(kNetworkingPasswordPrefix);
-    auto realServer = Networking::CreateServer(
-      listenHost.empty() ? nullptr : listenHost.c_str(), listenPort,
-      maxPlayers, password.data());
+    auto realServer = Networking::CreateServer(listenHost.c_str(), listenPort,
+                                               maxPlayers, password.data());
 
     static_assert(kMockServerIdx == 1);
     server = Networking::CreateCombinedServer({ realServer, serverMock });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies `listenHost` parsing in `ScampServer.cpp` by using `find` method and removing empty string check before server creation.
> 
>   - **Behavior**:
>     - Simplifies `listenHost` parsing in `ScampServer::ScampServer` constructor by using `find` and `end` methods of `nlohmann::json`.
>     - Removes check for empty `listenHost` before passing to `Networking::CreateServer`.
>   - **Code Changes**:
>     - Replaces ternary operator with `find` method for `listenHost` extraction.
>     - Directly passes `listenHost.c_str()` to `CreateServer` without checking for empty string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for dd727f143b371fde58b0306a1a7777804dd2d811. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->