### PR TITLE
feat(skymp5-server): add Book.GetSpell Papyrus function

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.cpp
@@ -36,7 +36,7 @@ VarValue PapyrusBook::GetSpell(VarValue self,
     return VarValue::None();
   }
 
-  return VarValue(std::make_shared<EspmGameObject>(spellOrSkill))
+  return VarValue(std::make_shared<EspmGameObject>(spellOrSkill));
 }
 
 void PapyrusBook::Register(VirtualMachine& vm,

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.cpp
@@ -1,0 +1,47 @@
+#include "PapyrusBook.h"
+#include "script_objects/EspmGameObject.h"
+
+VarValue PapyrusBook::GetSpell(VarValue self,
+                               const std::vector<VarValue>& arguments)
+{
+  auto selfRec = GetRecordPtr(self);
+  auto bookData =
+    espm::GetData<espm::BOOK>(selfRec.ToGlobalId(selfRec.rec->GetFormId()));
+
+  auto spellOrSkillFormId = selfRec.ToGlobalId(bookData.spellOrSkillFormId);
+
+  if (!spellOrSkillFormId) {
+    spdlog::info("Book.GetSpell - Returning None, book contains no formId");
+    return VarValue::None();
+  }
+
+  auto spellOrSkill =
+    compatibilityPolicy->GetWorldState()->GetEspm().GetBrowser().LookupById(
+      spellOrSkillFormId);
+
+  if (!spellOrSkill.rec) {
+    spdlog::warn("Book.GetSpell - Returning None, book contains a formId {:x} "
+                 "which can't be found",
+                 spellOrSkillFormId);
+    return VarValue::None();
+  }
+
+  auto spellOrSkillType = spellOrSkill.rec->GetType();
+
+  if (spellOrSkillType != espm::SPEL::kType) {
+    spdlog::info(
+      "Book.GetSpell - Returning None, book contains not a spell, but {}",
+      spellOrSkillType.ToString());
+    return VarValue::None();
+  }
+
+  return VarValue(std::make_shared<EspmGameObject>(spellOrSkill))
+}
+
+void PapyrusBook::Register(VirtualMachine& vm,
+                           std::shared_ptr<IPapyrusCompatibilityPolicy> policy)
+{
+  compatibilityPolicy = policy;
+
+  AddMethod(vm, "GetSpell", &PapyrusBook::GetSpell);
+}

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.cpp
@@ -6,7 +6,8 @@ VarValue PapyrusBook::GetSpell(VarValue self,
 {
   auto selfRec = GetRecordPtr(self);
   auto bookData =
-    espm::GetData<espm::BOOK>(selfRec.ToGlobalId(selfRec.rec->GetFormId()));
+    espm::GetData<espm::BOOK>(selfRec.ToGlobalId(selfRec.rec->GetId()),
+                              compatibilityPolicy->GetWorldState());
 
   auto spellOrSkillFormId = selfRec.ToGlobalId(bookData.spellOrSkillFormId);
 

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusBook.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "IPapyrusClass.h"
+
+class PapyrusBook final : public IPapyrusClass<PapyrusBook>
+{
+public:
+  const char* GetName() override { return "Book"; }
+
+  VarValue GetSpell(VarValue self, const std::vector<VarValue>& arguments);
+
+  void Register(VirtualMachine& vm,
+                std::shared_ptr<IPapyrusCompatibilityPolicy> policy) override;
+};

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
@@ -1,6 +1,7 @@
 #include "PapyrusClassesFactory.h"
 
 #include "PapyrusActor.h"
+#include "PapyrusBook.h"
 #include "PapyrusCell.h"
 #include "PapyrusDebug.h"
 #include "PapyrusEffectShader.h"
@@ -21,7 +22,6 @@
 #include "PapyrusSound.h"
 #include "PapyrusUtility.h"
 #include "PapyrusVisualEffect.h"
-#include "PapyrusBook.h"
 
 std::vector<std::unique_ptr<IPapyrusClassBase>>
 PapyrusClassesFactory::CreateAndRegister(

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusClassesFactory.cpp
@@ -21,6 +21,7 @@
 #include "PapyrusSound.h"
 #include "PapyrusUtility.h"
 #include "PapyrusVisualEffect.h"
+#include "PapyrusBook.h"
 
 std::vector<std::unique_ptr<IPapyrusClassBase>>
 PapyrusClassesFactory::CreateAndRegister(
@@ -50,6 +51,7 @@ PapyrusClassesFactory::CreateAndRegister(
   result.emplace_back(std::make_unique<PapyrusLeveledActor>());
   result.emplace_back(std::make_unique<PapyrusLeveledItem>());
   result.emplace_back(std::make_unique<PapyrusLeveledSpell>());
+  result.emplace_back(std::make_unique<PapyrusBook>());
 
   for (auto& papyrusClass : result) {
     papyrusClass->Register(vm, compatibilityPolicy);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `GetSpell` function to `PapyrusBook` class to retrieve associated spell, with logging for missing or invalid spells.
> 
>   - **New Functionality**:
>     - Adds `GetSpell` function to `PapyrusBook` class in `PapyrusBook.cpp`.
>     - Retrieves spell associated with a book, returns `None` if no spell or spell not found.
>   - **Registration**:
>     - Registers `PapyrusBook` with `GetSpell` method in `PapyrusClassesFactory.cpp`.
>   - **Logging**:
>     - Logs info and warnings for missing or invalid spell IDs in `PapyrusBook.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 83205cfce8db9923aa9c7debd8a48cf9802cbb8f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->