### PR TITLE
internal: add default port and maxPlayers to server settings generation

### DIFF
--- a/cmake/scripts/generate_server_settings.cmake
+++ b/cmake/scripts/generate_server_settings.cmake
@@ -14,6 +14,8 @@ else()
         string(JSON SERVER_SETTINGS_JSON SET "${SERVER_SETTINGS_JSON}" "loadOrder" ${index} "\"${ESM_PREFIX}${ESM}\"")
     endforeach()
     string(JSON SERVER_SETTINGS_JSON SET "${SERVER_SETTINGS_JSON}" "npcEnabled" "false")
+    string(JSON SERVER_SETTINGS_JSON SET "${SERVER_SETTINGS_JSON}" "port" "7777")
+    string(JSON SERVER_SETTINGS_JSON SET "${SERVER_SETTINGS_JSON}" "maxPlayers" "100")
     string(JSON SERVER_SETTINGS_JSON SET "${SERVER_SETTINGS_JSON}" "npcSettings" "{}")
 endif()
 


### PR DESCRIPTION
closes https://github.com/skyrim-multiplayer/skymp/issues/2371
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add default `port` and `maxPlayers` settings to `generate_server_settings.cmake`.
> 
>   - **Behavior**:
>     - Adds default `port` set to `7777` in `generate_server_settings.cmake`.
>     - Adds default `maxPlayers` set to `100` in `generate_server_settings.cmake`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 16e04165212f56aabcc488577e9eb5c8ae52f3cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->