### PR TITLE
feat(skymp5-server): add lastAnimEvent property

### DIFF
--- a/skymp5-server/cpp/addon/property_bindings/LastAnimEventBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/LastAnimEventBinding.cpp
@@ -1,0 +1,19 @@
+#include "LastAnimEventBinding.h"
+
+Napi::Value LastAnimEventBinding::Get(Napi::Env env, ScampServer& scampServer,
+                                      uint32_t formId)
+{
+  auto& partOne = scampServer.GetPartOne();
+
+  auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
+
+  if (auto actor = refr.AsActor()) {
+    auto animData = actor->GetLastAnimEvent();
+    if (animData.has_value()) {
+      return Napi::String::New(env, animData->animEventName);
+    }
+    return env.Null();
+  }
+
+  return env.Undefined();
+}

--- a/skymp5-server/cpp/addon/property_bindings/LastAnimEventBinding.h
+++ b/skymp5-server/cpp/addon/property_bindings/LastAnimEventBinding.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "PropertyBinding.h"
+
+class LastAnimEventBinding : public PropertyBinding
+{
+public:
+  std::string GetPropertyName() const override { return "lastAnimEvent"; }
+  Napi::Value Get(Napi::Env env, ScampServer& scampServer,
+                  uint32_t formId) override;
+};

--- a/skymp5-server/cpp/addon/property_bindings/PropertyBindingFactory.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/PropertyBindingFactory.cpp
@@ -13,6 +13,7 @@
 #include "IsDisabledBinding.h"
 #include "IsOnlineBinding.h"
 #include "IsOpenBinding.h"
+#include "LastAnimEventBinding.h"
 #include "LocationalDataBinding.h"
 #include "NeighborsBinding.h"
 #include "OnlinePlayersBinding.h"
@@ -24,7 +25,6 @@
 #include "TemplateChainBinding.h"
 #include "TypeBinding.h"
 #include "WorldOrCellDescBinding.h"
-#include "LastAnimEventBinding.h"
 
 std::map<std::string, std::shared_ptr<PropertyBinding>>
 PropertyBindingFactory::CreateStandardPropertyBindings()

--- a/skymp5-server/cpp/addon/property_bindings/PropertyBindingFactory.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/PropertyBindingFactory.cpp
@@ -24,6 +24,7 @@
 #include "TemplateChainBinding.h"
 #include "TypeBinding.h"
 #include "WorldOrCellDescBinding.h"
+#include "LastAnimEventBinding.h"
 
 std::map<std::string, std::shared_ptr<PropertyBinding>>
 PropertyBindingFactory::CreateStandardPropertyBindings()
@@ -53,6 +54,7 @@ PropertyBindingFactory::CreateStandardPropertyBindings()
     std::make_shared<ConsoleCommandsAllowedBinding>();
   result["spawnDelay"] = std::make_shared<SpawnDelayBinding>();
   result["templateChain"] = std::make_shared<TemplateChainBinding>();
+  result["lastAnimEvent"] = std::make_shared<LastAnimEventBinding>();
   return result;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `lastAnimEvent` property binding to retrieve the last animation event for actors in `skymp5-server`.
> 
>   - **New Feature**:
>     - Adds `LastAnimEventBinding` class in `LastAnimEventBinding.cpp` and `LastAnimEventBinding.h` to handle `lastAnimEvent` property.
>     - Implements `Get` method to return the last animation event name for an actor or `null`/`undefined` if not applicable.
>   - **Factory Update**:
>     - Registers `lastAnimEvent` in `PropertyBindingFactory::CreateStandardPropertyBindings()` in `PropertyBindingFactory.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for bc5997f72e11155fdfa080eafb016d9f5d96129a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->