### PR TITLE
refact(skymp5-server): rename and update function usage for SpSnippet execution

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/script_classes/IPapyrusClass.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/IPapyrusClass.cpp
@@ -1,11 +1,11 @@
 #include "IPapyrusClass.h"
 #include "SpSnippetFunctionGen.h"
 
-VarValue IPapyrusClassBase::MakeSPSnippetPromise(
+VarValue IPapyrusClassBase::ExecuteSpSnippetAndGetPromise(
   const char* script, const char* name,
   std::shared_ptr<IPapyrusCompatibilityPolicy> policy, VarValue self,
-  const std::vector<VarValue>& arguments, bool method, bool returns,
-  VarValue defaultResult)
+  const std::vector<VarValue>& arguments, bool method, SpSnippetMode mode,
+  const VarValue& defaultResult)
 {
   if (auto actor =
         policy->GetDefaultActor(script, name, self.GetMetaStackId())) {
@@ -13,11 +13,10 @@ VarValue IPapyrusClassBase::MakeSPSnippetPromise(
     auto promise =
       SpSnippet(script, name, s.data(),
                 method ? SpSnippetFunctionGen::GetFormId(self) : 0)
-        .Execute(actor,
-                 (returns ? SpSnippetMode::kReturnResult
-                          : SpSnippetMode::kNoReturnResult));
-    if (returns)
+        .Execute(actor, mode);
+    if (mode == SpSnippetMode::kReturnResult) {
       return VarValue(promise);
+    }
   }
   return defaultResult;
 }

--- a/skymp5-server/cpp/server_guest_lib/script_classes/IPapyrusClass.h
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/IPapyrusClass.h
@@ -13,11 +13,13 @@ public:
     std::shared_ptr<IPapyrusCompatibilityPolicy> policy) = 0;
 
   virtual ~IPapyrusClassBase() = default;
-  static VarValue MakeSPSnippetPromise(
+
+  static VarValue ExecuteSpSnippetAndGetPromise(
     const char* script, const char* name,
     std::shared_ptr<IPapyrusCompatibilityPolicy> policy, VarValue self,
     const std::vector<VarValue>& arguments, bool method = false,
-    bool returns = false, VarValue defaultResult = VarValue::None());
+    SpSnippetMode mode = SpSnippetMode::kNoReturnResult,
+    const VarValue& defaultResult = VarValue::None());
 
 public:
   std::shared_ptr<IPapyrusCompatibilityPolicy> compatibilityPolicy;

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
@@ -28,29 +28,37 @@ espm::ActorValue ConvertToAV(CIString actorValueName)
 VarValue PapyrusActor::DrawWeapon(VarValue self,
                                   const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "DrawWeapon", compatibilityPolicy,
-                              self, arguments, true, true);
+  // TODO: consider making this SpSnippetMode::kNoReturnResult
+  return ExecuteSpSnippetAndGetPromise(GetName(), "DrawWeapon",
+                                       compatibilityPolicy, self, arguments,
+                                       true, SpSnippetMode::kReturnResult);
 }
 
 VarValue PapyrusActor::UnequipAll(VarValue self,
                                   const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "UnequipAll", compatibilityPolicy,
-                              self, arguments, true, true);
+  // TODO: consider making this SpSnippetMode::kNoReturnResult
+  return ExecuteSpSnippetAndGetPromise(GetName(), "UnequipAll",
+                                       compatibilityPolicy, self, arguments,
+                                       true, SpSnippetMode::kReturnResult);
 }
 
 VarValue PapyrusActor::PlayIdle(VarValue self,
                                 const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "PlayIdle", compatibilityPolicy, self,
-                              arguments, true, true);
+  // TODO: consider making this SpSnippetMode::kNoReturnResult
+  return ExecuteSpSnippetAndGetPromise(GetName(), "PlayIdle",
+                                       compatibilityPolicy, self, arguments,
+                                       true, SpSnippetMode::kReturnResult);
 }
 
 VarValue PapyrusActor::GetSitState(VarValue self,
                                    const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "GetSitState", compatibilityPolicy,
-                              self, arguments, true, true);
+  // TODO: make this non-latent
+  return ExecuteSpSnippetAndGetPromise(GetName(), "GetSitState",
+                                       compatibilityPolicy, self, arguments,
+                                       true, SpSnippetMode::kReturnResult);
 }
 
 VarValue PapyrusActor::IsWeaponDrawn(VarValue self,

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusDebug.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusDebug.cpp
@@ -7,15 +7,15 @@
 VarValue PapyrusDebug::Notification(VarValue self,
                                     const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "Notification", compatibilityPolicy,
-                              self, arguments);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "Notification",
+                                       compatibilityPolicy, self, arguments);
 }
 
 VarValue PapyrusDebug::MessageBox(VarValue self,
                                   const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "MessageBox", compatibilityPolicy,
-                              self, arguments);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "MessageBox",
+                                       compatibilityPolicy, self, arguments);
 }
 
 VarValue PapyrusDebug::SendAnimationEvent(

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusGame.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusGame.cpp
@@ -10,22 +10,22 @@
 VarValue PapyrusGame::ForceThirdPerson(VarValue self,
                                        const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "ForceThirdPerson",
-                              compatibilityPolicy, self, arguments);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "ForceThirdPerson",
+                                       compatibilityPolicy, self, arguments);
 }
 
 VarValue PapyrusGame::DisablePlayerControls(
   VarValue self, const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "DisablePlayerControls",
-                              compatibilityPolicy, self, arguments);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "DisablePlayerControls",
+                                       compatibilityPolicy, self, arguments);
 }
 
 VarValue PapyrusGame::EnablePlayerControls(
   VarValue self, const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "EnablePlayerControls",
-                              compatibilityPolicy, self, arguments);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "EnablePlayerControls",
+                                       compatibilityPolicy, self, arguments);
 }
 
 VarValue PapyrusGame::IncrementStat(VarValue self,
@@ -160,8 +160,10 @@ VarValue PapyrusGame::ShowLimitedRaceMenu(
 VarValue PapyrusGame::GetCameraState(VarValue self,
                                      const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "GetCameraState", compatibilityPolicy,
-                              self, arguments, false, true, VarValue(-1));
+  // TODO: make this non-latent
+  return ExecuteSpSnippetAndGetPromise(
+    GetName(), "GetCameraState", compatibilityPolicy, self, arguments, false,
+    SpSnippetMode::kReturnResult, VarValue(-1));
 }
 
 void PapyrusGame::RaceMenuHelper(VarValue& self, const char* funcName,
@@ -219,8 +221,8 @@ VarValue PapyrusGame::GetFormEx(
 VarValue PapyrusGame::ShakeController(VarValue self,
                                       const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "ShakeController",
-                              compatibilityPolicy, self, arguments);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "ShakeController",
+                                       compatibilityPolicy, self, arguments);
 }
 
 void PapyrusGame::Register(VirtualMachine& vm,

--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusMessage.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusMessage.cpp
@@ -3,8 +3,9 @@
 VarValue PapyrusMessage::Show(VarValue self,
                               const std::vector<VarValue>& arguments)
 {
-  return MakeSPSnippetPromise(GetName(), "Show", compatibilityPolicy, self,
-                              arguments, true, true);
+  return ExecuteSpSnippetAndGetPromise(GetName(), "Show", compatibilityPolicy,
+                                       self, arguments, true,
+                                       SpSnippetMode::kReturnResult);
 }
 
 void PapyrusMessage::Register(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed `MakeSPSnippetPromise` to `ExecuteSpSnippetAndGetPromise` and updated its usage across multiple classes with a new parameter `SpSnippetMode`.
> 
>   - **Function Renaming and Parameter Update**:
>     - Rename `MakeSPSnippetPromise` to `ExecuteSpSnippetAndGetPromise` in `IPapyrusClass.cpp` and `IPapyrusClass.h`.
>     - Replace `bool returns` with `SpSnippetMode mode` in `ExecuteSpSnippetAndGetPromise`.
>   - **Class Updates**:
>     - Update `PapyrusActor`, `PapyrusDebug`, `PapyrusGame`, and `PapyrusMessage` to use `ExecuteSpSnippetAndGetPromise` with `SpSnippetMode`.
>     - Add TODO comments in `PapyrusActor.cpp` and `PapyrusGame.cpp` for potential changes to `SpSnippetMode` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 93023e469fd1a900b12f7fe42912b99a78aa746b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->