### PR TITLE
internal: up vcpkg & fix build errors

### DIFF
--- a/overlay_ports/rsm-bsa/fix-static-cast-error.patch
+++ b/overlay_ports/rsm-bsa/fix-static-cast-error.patch
@@ -1,0 +1,29 @@
+From a4d1801fcdf1dabdb3aa86cd69f03d225e1b2dd2 Mon Sep 17 00:00:00 2001
+From: Roman Nikonov <code@nic11.xyz>
+Date: Sun, 13 Apr 2025 17:27:17 +0200
+Subject: [PATCH] fix static_cast compilation error
+
+.../src/bsa/fo4.cpp:680:4: error: static_cast from 'uint8_t *' (aka 'unsigned char *') to 'const std::byte *' is not allowed
+  680 |                         static_cast<const std::byte*>(blob.GetBufferPointer()),
+      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 error generated.
+---
+ src/bsa/fo4.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/bsa/fo4.cpp b/src/bsa/fo4.cpp
+index 5484f13..2d9bbf3 100644
+--- a/src/bsa/fo4.cpp
++++ b/src/bsa/fo4.cpp
+@@ -677,7 +677,7 @@ namespace bsa::fo4
+ 		}
+ 
+ 		a_out.write_bytes({ //
+-			static_cast<const std::byte*>(blob.GetBufferPointer()),
++			reinterpret_cast<const std::byte*>(blob.GetBufferPointer()),
+ 			blob.GetBufferSize() });
+ 		std::vector<std::byte> buffer;
+ 		for (const auto& chunk : *this) {
+-- 
+2.49.0
+

--- a/overlay_ports/rsm-bsa/portfile.cmake
+++ b/overlay_ports/rsm-bsa/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     PATCHES
         variant-emplace-fix.patch
         structural-binding.patch
+        fix-static-cast-error.patch
 )
 
 if (VCPKG_TARGET_IS_LINUX)

--- a/skymp5-server/CMakeLists.txt
+++ b/skymp5-server/CMakeLists.txt
@@ -36,6 +36,7 @@ if(NOT EMSCRIPTEN)
   set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "scam_native" PREFIX "" SUFFIX ".node")
   target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::node-addon-api::node-addon-api)
   target_include_directories(${PROJECT_NAME} PRIVATE ${SKYMP5_SERVER_SOURCE_DIR}/cpp/addon)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC NAPI_CPP_EXCEPTIONS)
 
   if(WIN32)
     find_library(node_api-headers_LIB NAMES node PATHS "${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows-sp/lib/" NO_DEFAULT_PATH REQUIRED)

--- a/skymp5-server/CMakeLists.txt
+++ b/skymp5-server/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT EMSCRIPTEN)
   set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "scam_native" PREFIX "" SUFFIX ".node")
   target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::node-addon-api::node-addon-api)
   target_include_directories(${PROJECT_NAME} PRIVATE ${SKYMP5_SERVER_SOURCE_DIR}/cpp/addon)
-  target_compile_definitions(${PROJECT_NAME} PUBLIC NAPI_CPP_EXCEPTIONS)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE NAPI_CPP_EXCEPTIONS)
 
   if(WIN32)
     find_library(node_api-headers_LIB NAMES node PATHS "${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows-sp/lib/" NO_DEFAULT_PATH REQUIRED)

--- a/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
+++ b/skymp5-server/cpp/server_guest_lib/database_drivers/MongoDatabase.cpp
@@ -12,7 +12,6 @@
 #  include <mongocxx/client.hpp>
 #  include <mongocxx/instance.hpp>
 #  include <mongocxx/pool.hpp>
-#  include <mongocxx/stdx.hpp>
 #  include <mongocxx/uri.hpp>
 #endif
 

--- a/skyrim-platform/src/platform_lib/ThreadPoolWrapper.h
+++ b/skyrim-platform/src/platform_lib/ThreadPoolWrapper.h
@@ -17,7 +17,7 @@ public:
     {
       std::lock_guard l(initMutex);
       if (!pool) {
-        pool = std::make_unique<BS::thread_pool>(numThreads);
+        pool = std::make_unique<BS::light_thread_pool>(numThreads);
       }
     }
     return pool->submit_task(task);
@@ -26,7 +26,7 @@ public:
   void PushAndWait(const std::function<void()>& task) { Push(task).wait(); }
 
 private:
-  std::unique_ptr<BS::thread_pool> pool;
+  std::unique_ptr<BS::light_thread_pool> pool;
   const int32_t numThreads;
   std::mutex initMutex;
 };

--- a/skyrim-platform/src/platform_se/CMakeLists.txt
+++ b/skyrim-platform/src/platform_se/CMakeLists.txt
@@ -233,7 +233,7 @@ if(MSVC)
 
   find_package(unofficial-node-addon-api REQUIRED)
   target_link_libraries(skyrim_platform PRIVATE unofficial::node-addon-api::node-addon-api)
-  target_compile_definitions(skyrim_platform PUBLIC NAPI_CPP_EXCEPTIONS)
+  target_compile_definitions(skyrim_platform PRIVATE NAPI_CPP_EXCEPTIONS)
 
   target_link_libraries(skyrim_platform PUBLIC mhook)
 

--- a/skyrim-platform/src/platform_se/CMakeLists.txt
+++ b/skyrim-platform/src/platform_se/CMakeLists.txt
@@ -233,6 +233,7 @@ if(MSVC)
 
   find_package(unofficial-node-addon-api REQUIRED)
   target_link_libraries(skyrim_platform PRIVATE unofficial::node-addon-api::node-addon-api)
+  target_compile_definitions(skyrim_platform PUBLIC NAPI_CPP_EXCEPTIONS)
 
   target_link_libraries(skyrim_platform PUBLIC mhook)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update vcpkg, add build patch, enable NAPI_CPP_EXCEPTIONS for Node.js addons, and switch to BS::light_thread_pool in ThreadPoolWrapper.
> 
>   - **Dependency and Build System**:
>     - Update `vcpkg` submodule to commit `bc994510d2eb11aac7b43b03f67a7751d5bfe0e4`.
>     - Add `fix-static-cast-error.patch` to `overlay_ports/rsm-bsa/portfile.cmake`.
>   - **CMake Build Fixes**:
>     - Add `NAPI_CPP_EXCEPTIONS` to `target_compile_definitions` for Node.js addon builds in `skymp5-server/CMakeLists.txt` and `skyrim-platform/src/platform_se/CMakeLists.txt`.
>   - **Thread Pool Usage**:
>     - Replace `BS::thread_pool` with `BS::light_thread_pool` in `ThreadPoolWrapper` (constructor and member variable) in `ThreadPoolWrapper.h`.
>   - **Code Cleanup**:
>     - Remove unused `#include <mongocxx/stdx.hpp>` from `MongoDatabase.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 2ea95ac1138bffa308270270e9ef84b306cbe5fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->