### PR TITLE
new serialization for js <-> cpp interaction

### DIFF
--- a/serialization/CMakeLists.txt
+++ b/serialization/CMakeLists.txt
@@ -12,6 +12,9 @@ apply_default_settings(TARGETS serialization)
 find_package(slikenet CONFIG REQUIRED)
 target_link_libraries(serialization PUBLIC SLikeNet)
 
+find_package(unofficial-node-addon-api REQUIRED)
+target_link_libraries(serialization PUBLIC unofficial::node-addon-api::node-addon-api)
+
 find_package(simdjson CONFIG REQUIRED)
 target_link_libraries(serialization PUBLIC simdjson::simdjson)
 

--- a/serialization/include/archives/NapiOutputArchive.h
+++ b/serialization/include/archives/NapiOutputArchive.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+#include <exception>
+#include <fmt/format.h>
+#include <limits>
+#include <napi.h>
+#include <optional>
+#include <simdjson.h>
+#include <stdexcept>
+#include <string_view>
+#include <type_traits>
+
+#include "concepts/Concepts.h"
+
+class NapiOutputArchive
+{
+public:
+    explicit NapiOutputArchive(Napi::Env env) : m_env(env) {}
+
+    template <IntegralConstant T>
+    NapiOutputArchive& Serialize(const char* key, T& input)
+    {
+        OutputAsObject().Set(key, Napi::Number::New(m_env, static_cast<int64_t>(input)));
+        return *this;
+    }
+
+    template <StringLike T>
+    NapiOutputArchive& Serialize(const T& input)
+    {
+        static_assert(!sizeof(T), "not string");
+        return *this;
+    }
+
+    NapiOutputArchive& Serialize(const std::string& input)
+    {
+        OutputAsOther() = Napi::String::New(m_env, input);
+        return *this;
+    }
+
+    template <typename T, std::size_t N>
+    NapiOutputArchive& Serialize(const std::array<T, N>& input)
+    {
+        auto array = Napi::Array::New(m_env, N);
+        for (size_t i = 0; i < N; ++i)
+        {
+            NapiOutputArchive elementAr(m_env);
+            elementAr.Serialize(input[i]);
+            array.Set(i, elementAr.extract_output());
+        }
+        OutputAsOther() = array;
+        return *this;
+    }
+
+    template <ContainerLike T>
+    NapiOutputArchive& Serialize(const T& input)
+    {
+        auto array = Napi::Array::New(m_env, input.size());
+        size_t index = 0;
+        for (const auto& element : input)
+        {
+            NapiOutputArchive elementAr(m_env);
+            elementAr.Serialize(element);
+            array.Set(index++, elementAr.extract_output());
+        }
+        OutputAsOther() = array;
+        return *this;
+    }
+
+    template <Arithmetic T>
+    NapiOutputArchive& Serialize(const T& input)
+    {
+        OutputAsOther() = Napi::Number::New(m_env, static_cast<double>(input));
+        return *this;
+    }
+
+    template <NoneOfTheAbove T>
+    NapiOutputArchive& Serialize(const T& input)
+    {
+        input.Serialize(*this);
+        return *this;
+    }
+
+    template <class T>
+    NapiOutputArchive& Serialize(const char* key, const std::optional<T>& input)
+    {
+        if (input.has_value())
+        {
+            NapiOutputArchive ar(m_env);
+            ar.Serialize(input.value());
+            OutputAsObject().Set(key, ar.extract_output());
+        }
+        return *this;
+    }
+
+    template <class T>
+    NapiOutputArchive& Serialize(const char* key, const T& input)
+    {
+        NapiOutputArchive ar(m_env);
+        ar.Serialize(input);
+        OutputAsObject().Set(key, ar.extract_output());
+        return *this;
+    }
+
+    Napi::Value extract_output()
+    {
+        if (m_outputOther)
+        {
+            return std::move(*m_outputOther);
+        }
+
+        if (m_outputObject)
+        {
+            return std::move(*m_outputObject);
+        }
+
+        throw std::runtime_error("Uninitialized field!");
+    }
+
+private:
+    Napi::Object& OutputAsObject()
+    {
+        if (m_outputOther)
+        {
+            throw std::runtime_error("Not object!");
+        }
+
+        if (!m_outputObject)
+        {
+            m_outputObject = Napi::Object::New(m_env);
+        }
+
+        return *m_outputObject;
+    }
+
+    Napi::Value& OutputAsOther()
+    {
+        if (m_outputObject)
+        {
+            throw std::runtime_error("Not other!");
+        }
+
+        if (!m_outputOther)
+        {
+            m_outputOther.emplace(m_env.Undefined());
+        }
+
+        return *m_outputOther;
+    }
+
+    Napi::Env m_env;
+    std::optional<Napi::Value> m_outputOther;
+    std::optional<Napi::Object> m_outputObject;
+};

--- a/skymp5-server/cpp/server_guest_lib/Inventory.cpp
+++ b/skymp5-server/cpp/server_guest_lib/Inventory.cpp
@@ -2,6 +2,8 @@
 #include "archives/JsonInputArchive.h"
 #include "archives/JsonOutputArchive.h"
 #include "archives/SimdJsonInputArchive.h"
+#include "archives/NapiOutputArchive.h"
+#include <napi.h>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <tuple>
@@ -190,4 +192,12 @@ Inventory Inventory::FromJson(const nlohmann::json& j)
   Inventory res;
   res.Serialize(ar);
   return res;
+}
+
+Napi::Value Inventory::ToNapiObject() const
+{
+  auto env = jsEngine;
+  NapiOutputArchive ar();
+  const_cast<Inventory*>(this)->Serialize(ar);
+  return ar.extract_output();
 }

--- a/skymp5-server/cpp/server_guest_lib/Inventory.h
+++ b/skymp5-server/cpp/server_guest_lib/Inventory.h
@@ -1,10 +1,12 @@
 #pragma once
+#include <DevApi.h>
 #include <cstdint>
 #include <nlohmann/json.hpp>
 #include <simdjson.h>
 #include <string>
 #include <tuple>
 #include <vector>
+#include <napi.h>
 
 class Inventory
 {
@@ -24,6 +26,7 @@ public:
   }
 
   // TODO: get rid of this in favor of Serialize
+  Napi::Value ToNapiObject() const;
   nlohmann::json ToJson() const;
   static Inventory FromJson(const simdjson::dom::element& element);
   static Inventory FromJson(const nlohmann::json& j);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `NapiOutputArchive` for C++ to JavaScript serialization and update `Inventory` class and CMake configuration accordingly.
> 
>   - **Serialization**:
>     - Add `NapiOutputArchive` class in `NapiOutputArchive.h` for serializing C++ objects to JavaScript objects using Node-API.
>     - Supports serialization of integral, string, array, container, arithmetic, and optional types.
>   - **Inventory Class**:
>     - Add `ToNapiObject()` method in `Inventory.cpp` to serialize `Inventory` objects to JavaScript objects using `NapiOutputArchive`.
>     - Include `NapiOutputArchive.h` and `<napi.h>` in `Inventory.cpp` and `Inventory.h`.
>   - **CMake Configuration**:
>     - Update `CMakeLists.txt` to find and link `unofficial-node-addon-api`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 9323adca6042badc6285e7cf3d62cdc908a5f794. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->