### PR TITLE
fix(skymp5-server): separate spell and weapon hit logic in ActionListener, enhance damage calculation

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ActionListener.h
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.h
@@ -99,6 +99,12 @@ public:
   virtual void OnUnknown(const RawMessageData& rawMsgData);
 
 private:
+  void OnSpellHit(MpActor* aggressor, const HitData& hitData) const;
+  void OnWeaponHit(MpActor* aggressor, HitData hitData, bool isUnarmed) const;
+
+  std::shared_ptr<MpObjectReference> TrySendPapyrusOnHitEvent(
+    const MpActor* aggressor, const HitData& hitData) const;
+
   // Returns user's actor if there is attached one
   MpActor* SendToNeighbours(uint32_t idx,
                             const simdjson::dom::element& jMessage,

--- a/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/TES5DamageFormula.cpp
@@ -211,7 +211,11 @@ float TES5SpellDamageFormulaImpl::GetBaseSpellDamage() const
     auto magicEffect =
       espm::GetData<espm::MGEF>(effect.effectFormId, espmProvider);
 
-    if (magicEffect.data.IsFlagSet(espm::MGEF::Flags::Hostile) &&
+    const bool needAddDamage =
+      magicEffect.data.IsFlagSet(espm::MGEF::Flags::Hostile) ||
+      magicEffect.data.IsFlagSet(espm::MGEF::Flags::Detrimental);
+
+    if (needAddDamage &&
         magicEffect.data.primaryAV == espm::ActorValue::Health) {
 
       damage += effect.effectItem->magnitude;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `ActionListener` to separate spell and weapon hit logic, enhance damage calculation in `TES5DamageFormulaImpl`, and improve logging and error handling.
> 
>   - **Behavior**:
>     - Refactor `OnHit` in `ActionListener.cpp` to separate logic for spell and weapon hits.
>     - Add `OnSpellHit` and `OnWeaponHit` methods to handle specific hit types.
>     - Improve logging for unhandled messages in `OnUnknown`.
>   - **Damage Calculation**:
>     - Update `TES5DamageFormulaImpl` in `TES5DamageFormula.cpp` to include logic for determining damage from spells and weapons.
>     - Add `GetBaseSpellDamage` method to calculate base spell damage considering hostile and detrimental effects.
>   - **Misc**:
>     - Remove unused variable `currentHitTime` in `OnHit`.
>     - Add `TrySendPapyrusOnHitEvent` to encapsulate Papyrus event sending logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 4d9d84532cb92e83049ea4ad256240e6fe93fb6e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->