### PR TITLE
feat(skymp5-server): remove "already removed" warning in Actor.RemoveSpell

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/script_classes/PapyrusActor.cpp
@@ -558,9 +558,7 @@ VarValue PapyrusActor::RemoveSpell(VarValue self,
     if (actor->IsSpellLearnedFromBase(spellId)) {
       spdlog::warn("Actor.RemoveSpell - can't remove spells inherited from "
                    "RACE/NPC_ records");
-    } else if (!actor->IsSpellLearned(spellId)) {
-      spdlog::warn("Actor.RemoveSpell - spell already removed/not learned");
-    } else {
+    } else if (actor->IsSpellLearned(spellId)) {
       actor->RemoveSpell(spellId);
 
       SpSnippet(GetName(), "RemoveSpell",


### PR DESCRIPTION
reflecting addspell behavior. honestly, i'd rather emit it once per actor/spell pair but this adds up even more complexity