### PR TITLE
internal: disable fail-fast for Linux CI matrix

### DIFF
--- a/.github/workflows/pr-linux-variants.yml
+++ b/.github/workflows/pr-linux-variants.yml
@@ -14,6 +14,7 @@ env:
 jobs:
     pr-docker:
         strategy:
+          fail-fast: false
           matrix:
             base_system:
             # The usual container used for all builds within the CI and the one


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable `fail-fast` in `pr-linux-variants.yml` for Linux CI matrix to allow all jobs to run even if one fails.
> 
>   - **CI Configuration**:
>     - Disable `fail-fast` in `pr-linux-variants.yml` for the `pr-docker` job matrix strategy, allowing all matrix jobs to run even if one fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 60f4b82b81759bc84898c1ea2fe87dff1800118c. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->