### PR TITLE
fix: enable logging for damage multipliers in CalculateDamage

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/formulas/DamageMultConditionalFormula.cpp
+++ b/skymp5-server/cpp/server_guest_lib/formulas/DamageMultConditionalFormula.cpp
@@ -50,7 +50,7 @@ float DamageMultConditionalFormula::CalculateDamage(
   for (auto [key, value] : settings->entries) {
     if (value.physicalDamageMultiplier.has_value()) {
       // TODO
-      bool enableLogging = false;
+      bool enableLogging = true;
 
       std::vector<int> conditionResolutions;
 
@@ -98,7 +98,7 @@ float DamageMultConditionalFormula::CalculateDamage(
   for (auto [key, value] : settings->entries) {
     if (value.magicDamageMultiplier.has_value()) {
       // TODO
-      bool enableLogging = false;
+      bool enableLogging = true;
 
       std::vector<int> conditionResolutions;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable logging for both physical and magic damage multipliers in `CalculateDamage` in `DamageMultConditionalFormula.cpp`.
> 
>   - **Logging**:
>     - Enable logging in `CalculateDamage` for physical damage multipliers in `DamageMultConditionalFormula.cpp`.
>     - Enable logging in `CalculateDamage` for magic damage multipliers in `DamageMultConditionalFormula.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 5a88beabf677f70e782e38eba33a341c8e90a87c. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->