### PR TITLE
fix(skymp5-server): prevent visually removing already learned spells in ReadBookEvent

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/ReadBookEvent.cpp
@@ -89,9 +89,7 @@ void ReadBookEvent::OnFireBlocked(WorldState* worldState)
 
   std::vector<VarValue> arguments = { aSpell };
 
-  auto& spellList = actor->GetSpellList();
-  if (std::find(spellList.begin(), spellList.end(), spellOrSkillFormId) !=
-      spellList.end()) {
+  if (actor->IsSpellLearned(spellOrSkillFormId)) {
     spdlog::info(
       "ReadBookEvent::OnFireBlocked - Actor {:x} reading book {:x}: "
       "Spell already learned {:x}, not executing RemoveSpell SpSnippet",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add check in `ReadBookEvent::OnFireBlocked` to prevent removing already learned spells.
> 
>   - **Behavior**:
>     - In `ReadBookEvent::OnFireBlocked`, added a check to prevent executing `RemoveSpell` if the spell is already learned by the actor.
>     - Logs a message when a spell is already learned, avoiding `RemoveSpell` execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 42e86ed496c452107d10c45201dc9a7113834cdf. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->