### PR TITLE
feat: handle actor percentages during death events

### DIFF
--- a/skymp5-server/cpp/addon/ScampServer.h
+++ b/skymp5-server/cpp/addon/ScampServer.h
@@ -83,6 +83,11 @@ public:
     return gamemodeApiState;
   }
 
+  bool IsGameModeInsideDeathEventHandler(
+    uint32_t dyingFormId, float* outHealthPercentageBeforeDeath = nullptr,
+    float* outMagickaPercentageBeforeDeath = nullptr,
+    float* outStaminaPercentageBeforeDeath = nullptr) const;
+
 private:
   std::shared_ptr<PartOne> partOne;
   std::shared_ptr<Networking::IServer> server;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1213,7 +1213,7 @@ void MpActor::Kill(MpActor* killer, bool shouldTeleport)
   // Keep in sync with MpActor::SetIsDead
   SendAndSetDeathState(true, shouldTeleport);
 
-  DeathEvent deathEvent(this, killer, healhPercentageBeforeDeath,
+  DeathEvent deathEvent(this, killer, healthPercentageBeforeDeath,
                         magickaPercentageBeforeDeath,
                         staminaPercentageBeforeDeath);
   deathEvent.Fire(GetParent());
@@ -1404,11 +1404,20 @@ void MpActor::SetIsDead(bool isDead)
 
   if (isDead) {
     if (IsDead() == false) {
+      auto& changeForm = ChangeForm();
+      const float healthPercentageBeforeDeath =
+        changeForm.actorValues.healthPercentage;
+      const float magickaPercentageBeforeDeath =
+        changeForm.actorValues.magickaPercentage;
+      const float staminaPercentageBeforeDeath =
+        changeForm.actorValues.staminaPercentage;
 
       // Keep in sync with MpActor::Kill
       SendAndSetDeathState(isDead, kShouldTeleport);
 
-      DeathEvent deathEvent(this, nullptr);
+      DeathEvent deathEvent(this, nullptr, healthPercentageBeforeDeath,
+                            magickaPercentageBeforeDeath,
+                            staminaPercentageBeforeDeath);
       deathEvent.Fire(GetParent());
 
       AddDeathItem();

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1203,7 +1203,7 @@ void MpActor::Kill(MpActor* killer, bool shouldTeleport)
                 killer ? killer->GetFormId() : 0);
 
   auto& changeForm = ChangeForm();
-  const float healhPercentageBeforeDeath =
+  const float healthPercentageBeforeDeath =
     changeForm.actorValues.healthPercentage;
   const float magickaPercentageBeforeDeath =
     changeForm.actorValues.magickaPercentage;

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1202,10 +1202,20 @@ void MpActor::Kill(MpActor* killer, bool shouldTeleport)
   spdlog::trace("MpActor::Kill {:x} - killer is {:x}", GetFormId(),
                 killer ? killer->GetFormId() : 0);
 
+  auto& changeForm = ChangeForm();
+  const float healhPercentageBeforeDeath =
+    changeForm.actorValues.healthPercentage;
+  const float magickaPercentageBeforeDeath =
+    changeForm.actorValues.magickaPercentage;
+  const float staminaPercentageBeforeDeath =
+    changeForm.actorValues.staminaPercentage;
+
   // Keep in sync with MpActor::SetIsDead
   SendAndSetDeathState(true, shouldTeleport);
 
-  DeathEvent deathEvent(this, killer);
+  DeathEvent deathEvent(this, killer, healhPercentageBeforeDeath,
+                        magickaPercentageBeforeDeath,
+                        staminaPercentageBeforeDeath);
   deathEvent.Fire(GetParent());
 
   AddDeathItem();

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -32,6 +32,7 @@ class FormCallbacks;
 class MpChangeForm;
 class ISaveStorage;
 class IScriptStorage;
+class GameModeEvent;
 
 class WorldState
 {
@@ -256,6 +257,8 @@ public:
     /* Mannequin */
     0x0010760a
   };
+
+  std::vector<GameModeEvent*> currentGameModeEventsStack;
 
 private:
   bool AttachEspmRecord(const espm::CombineBrowser& br,

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/DeathEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/DeathEvent.cpp
@@ -3,9 +3,15 @@
 #include "MpActor.h"
 #include <spdlog/spdlog.h>
 
-DeathEvent::DeathEvent(MpActor* actor_, MpActor* optionalKiller_)
+DeathEvent::DeathEvent(MpActor* actor_, MpActor* optionalKiller_,
+                       float healthPercentageBeforeDeath_,
+                       float magickaPercentageBeforeDeath_,
+                       float staminaPercentageBeforeDeath_)
   : actor(actor_)
   , optionalKiller(optionalKiller_)
+  , healthPercentageBeforeDeath(healthPercentageBeforeDeath_)
+  , magickaPercentageBeforeDeath(magickaPercentageBeforeDeath_)
+  , staminaPercentageBeforeDeath(staminaPercentageBeforeDeath_)
 {
   if (!actor_) {
     spdlog::error("DeathEvent::DeathEvent - actor is nullptr");
@@ -14,6 +20,7 @@ DeathEvent::DeathEvent(MpActor* actor_, MpActor* optionalKiller_)
 
 const char* DeathEvent::GetName() const
 {
+  // keep in sync with ScampServer::IsGameModeInsideDeathEventHandler
   return "onDeath";
 }
 
@@ -29,6 +36,30 @@ std::string DeathEvent::GetArgumentsJsonArray() const
   result += std::to_string(killerId);
   result += "]";
   return result;
+}
+
+uint32_t DeathEvent::GetDyingActorId() const
+{
+  if (!actor) {
+    spdlog::error("DeathEvent::GetDyingActorId - actor is nullptr");
+    return 0;
+  }
+  return actor->GetFormId();
+}
+
+float DeathEvent::GetHealthPercentageBeforeDeath() const noexcept
+{
+  return healthPercentageBeforeDeath;
+}
+
+float DeathEvent::GetMagickaPercentageBeforeDeath() const noexcept
+{
+  return magickaPercentageBeforeDeath;
+}
+
+float DeathEvent::GetStaminaPercentageBeforeDeath() const noexcept
+{
+  return staminaPercentageBeforeDeath;
 }
 
 void DeathEvent::OnFireSuccess(WorldState*)

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/DeathEvent.h
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/DeathEvent.h
@@ -6,15 +6,26 @@ class MpActor;
 class DeathEvent : public GameModeEvent
 {
 public:
-  DeathEvent(MpActor* actor_, MpActor* optionalKiller_);
+  DeathEvent(MpActor* actor_, MpActor* optionalKiller_,
+             float healthPercentageBeforeDeath_,
+             float magickaPercentageBeforeDeath_,
+             float staminaPercentageBeforeDeath_);
 
   const char* GetName() const override;
 
   std::string GetArgumentsJsonArray() const override;
+
+  uint32_t GetDyingActorId() const;
+  float GetHealthPercentageBeforeDeath() const noexcept;
+  float GetMagickaPercentageBeforeDeath() const noexcept;
+  float GetStaminaPercentageBeforeDeath() const noexcept;
 
 private:
   void OnFireSuccess(WorldState*) override;
 
   MpActor* actor = nullptr;
   MpActor* optionalKiller = nullptr;
+  float healthPercentageBeforeDeath = 0.f;
+  float magickaPercentageBeforeDeath = 0.f;
+  float staminaPercentageBeforeDeath = 0.f;
 };

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/GameModeEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/GameModeEvent.cpp
@@ -1,17 +1,26 @@
 #include "GameModeEvent.h"
 
+#include "ScopedTask.h"
 #include "WorldState.h"
 #include <spdlog/spdlog.h>
 
 bool GameModeEvent::Fire(WorldState* worldState)
 {
+  const char* eventName = GetName();
+
+  worldState->currentGameModeEventsStack.push_back(this);
+
+  Viet::ScopedTask<std::vector<GameModeEvent*>> stackPopTask(
+    [](std::vector<GameModeEvent*>& stack) { stack.pop_back(); },
+    worldState->currentGameModeEventsStack);
+
   if (!worldState) {
     spdlog::error("GameModeEvent::Fire - worldState is nullptr");
     return true;
   }
 
   if (spdlog::should_log(spdlog::level::trace)) {
-    spdlog::trace("GameModeEvent::Fire {} {}", GetName(),
+    spdlog::trace("GameModeEvent::Fire {} {}", eventName,
                   GetArgumentsJsonArray());
   }
 
@@ -23,7 +32,7 @@ bool GameModeEvent::Fire(WorldState* worldState)
     };
   }
 
-  spdlog::trace("GameModeEvent::Fire {} {} - isBlocked: {}", GetName(),
+  spdlog::trace("GameModeEvent::Fire {} {} - isBlocked: {}", eventName,
                 GetArgumentsJsonArray(), isBlocked);
 
   if (isBlocked) {

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/GameModeEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/GameModeEvent.cpp
@@ -6,6 +6,11 @@
 
 bool GameModeEvent::Fire(WorldState* worldState)
 {
+  if (!worldState) {
+    spdlog::error("GameModeEvent::Fire - worldState is nullptr");
+    return true;
+  }
+
   const char* eventName = GetName();
 
   worldState->currentGameModeEventsStack.push_back(this);
@@ -13,11 +18,6 @@ bool GameModeEvent::Fire(WorldState* worldState)
   Viet::ScopedTask<std::vector<GameModeEvent*>> stackPopTask(
     [](std::vector<GameModeEvent*>& stack) { stack.pop_back(); },
     worldState->currentGameModeEventsStack);
-
-  if (!worldState) {
-    spdlog::error("GameModeEvent::Fire - worldState is nullptr");
-    return true;
-  }
 
   if (spdlog::should_log(spdlog::level::trace)) {
     spdlog::trace("GameModeEvent::Fire {} {}", eventName,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces handling of actor's health, magicka, and stamina percentages during death events in `ScampServer` and `MpActor`, with updates to `DeathEvent` and `WorldState`.
> 
>   - **Behavior**:
>     - Added `IsGameModeInsideDeathEventHandler` to `ScampServer` to check if a death event is active for an actor and retrieve health, magicka, and stamina percentages before death.
>     - Updated `PercentagesBinding::Get` and `Set` to use `IsGameModeInsideDeathEventHandler` to handle percentages during death events.
>     - Modified `MpActor::Kill` to pass health, magicka, and stamina percentages to `DeathEvent`.
>   - **Events**:
>     - `DeathEvent` now stores and provides access to health, magicka, and stamina percentages before death.
>     - `GameModeEvent::Fire` pushes events to `currentGameModeEventsStack` in `WorldState`.
>   - **WorldState**:
>     - Added `currentGameModeEventsStack` to track active game mode events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for b3af01007db4dbaada4146a38ebdfda76f6072bd. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->