### PR TITLE
feat(skymp5-client): re-enable anims

### DIFF
--- a/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
+++ b/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
@@ -207,8 +207,16 @@ export class SweetCameraEnforcementService extends ClientListener {
 
         if (!animEvent) return;
 
-        logTrace(this, "Starting anims from keyboard is disabled in this version")
-        // this.tryInvokeAnim(animEvent, false);
+        //logTrace(this, "Starting anims from keyboard is disabled in this version")
+        this.tryInvokeAnim(animEvent, {
+            weaponDrawnAllowed: false,
+            furnitureAllowed: false,
+            exitAnimName: null,
+            interruptAnimName: null,
+            timeMs: 0,
+            isPlayExitAnimAfterwardsEnabled: true,
+            parentAnimEventName: null
+        });
     }
 
     private tryInvokeAnim(animEvent: string, options: InvokeAnimOptions): { success: boolean, reason?: string } {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enables animation triggering from keyboard events in `SweetCameraEnforcementService` by uncommenting `tryInvokeAnim` call with specific options.
> 
>   - **Behavior**:
>     - Re-enables animation triggering from keyboard events in `SweetCameraEnforcementService` by uncommenting `tryInvokeAnim` call.
>     - Sets `weaponDrawnAllowed`, `furnitureAllowed`, `exitAnimName`, `interruptAnimName`, `timeMs`, `isPlayExitAnimAfterwardsEnabled`, and `parentAnimEventName` options for `tryInvokeAnim`.
>   - **Misc**:
>     - Commented out a log trace message indicating anims from keyboard were disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 67385fab79c12938d56f54d9f6148d101c535277. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->