### PR TITLE
feat(skymp5-server): disable ingredient effects

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/EatItemEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/EatItemEvent.cpp
@@ -36,7 +36,7 @@ void EatItemEvent::OnFireSuccess(WorldState* worldState)
   if (isAlchemyItem) {
     effects = espm::GetData<espm::ALCH>(baseId, worldState).effects;
   } else if (isIngredient) {
-    effects = espm::GetData<espm::INGR>(baseId, worldState).effects;
+    // effects = espm::GetData<espm::INGR>(baseId, worldState).effects;
   } else {
     return;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comments out ingredient effects assignment in `EatItemEvent::OnFireSuccess`, disabling ingredient effect processing.
> 
>   - **Behavior**:
>     - Comments out the line in `EatItemEvent::OnFireSuccess` that assigns effects for ingredients, disabling this functionality.
>     - Only alchemy items will have effects processed in `OnFireSuccess`. Ingredients are ignored.
>   - **Misc**:
>     - No changes to other parts of the file or related files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for dafecaab29d1a2984c94990d9e8d015b4feece2b. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->