### PR TITLE
fix(skymp5-server): fix magicka restore on block in SweetTaffy

### DIFF
--- a/skymp5-server/cpp/addon/property_bindings/PercentagesBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/PercentagesBinding.cpp
@@ -1,4 +1,5 @@
 #include "PercentagesBinding.h"
+#include "MathUtils.h"
 #include "NapiHelper.h"
 #include <cmath>
 
@@ -94,5 +95,22 @@ void PercentagesBinding::Set(Napi::Env env, ScampServer& scampServer,
     }
   }
 
-  actor.NetSetPercentages(actorValues);
+  const ActorValues oldActorValues = actor.GetActorValues();
+
+  std::vector<espm::ActorValue> avFilter;
+
+  if (!MathUtils::IsNearlyEqual(oldActorValues.healthPercentage,
+                                actorValues.healthPercentage)) {
+    avFilter.push_back(espm::ActorValue::Health);
+  }
+  if (!MathUtils::IsNearlyEqual(oldActorValues.magickaPercentage,
+                                actorValues.magickaPercentage)) {
+    avFilter.push_back(espm::ActorValue::Magicka);
+  }
+  if (!MathUtils::IsNearlyEqual(oldActorValues.staminaPercentage,
+                                actorValues.staminaPercentage)) {
+    avFilter.push_back(espm::ActorValue::Stamina);
+  }
+
+  actor.NetSetPercentages(actorValues, nullptr, avFilter);
 }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -638,7 +638,7 @@ void MpActor::SetPercentages(const ActorValues& actorValues,
 
 void MpActor::NetSendChangeValues(
   const ActorValues& actorValues,
-  std::optional<std::vector<espm::ActorValue>> avFilter)
+  const std::optional<std::vector<espm::ActorValue>>& avFilter)
 {
   ChangeValuesMessage message;
   message.idx = GetIdx();
@@ -687,7 +687,7 @@ void MpActor::NetSendChangeValues(
 
 void MpActor::NetSetPercentages(
   const ActorValues& actorValues, MpActor* aggressor,
-  std::optional<std::vector<espm::ActorValue>> avFilter)
+  const std::optional<std::vector<espm::ActorValue>>& avFilter)
 {
   NetSendChangeValues(actorValues, avFilter);
   SetPercentages(actorValues, aggressor);

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -115,7 +115,7 @@ public:
                       MpActor* aggressor = nullptr);
   void NetSendChangeValues(
     const ActorValues& actorValues,
-    std::optional<std::vector<espm::ActorValue>> avFilter);
+    const std::optional<std::vector<espm::ActorValue>>& avFilter);
   void NetSetPercentages(
     const ActorValues& actorValues, MpActor* aggressor,
     std::optional<std::vector<espm::ActorValue>> avFilter);

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -118,7 +118,7 @@ public:
     const std::optional<std::vector<espm::ActorValue>>& avFilter);
   void NetSetPercentages(
     const ActorValues& actorValues, MpActor* aggressor,
-    std::optional<std::vector<espm::ActorValue>> avFilter);
+    const std::optional<std::vector<espm::ActorValue>>& avFilter);
 
   std::chrono::steady_clock::time_point GetLastAttributesPercentagesUpdate();
   std::chrono::steady_clock::time_point GetLastHitTime();

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -113,11 +113,12 @@ public:
   void ResolveSnippet(uint32_t snippetIdx, VarValue v);
   void SetPercentages(const ActorValues& actorValues,
                       MpActor* aggressor = nullptr);
-  void NetSendChangeValues(const ActorValues& actorValues,
-                           std::optional<espm::ActorValue> av = std::nullopt);
-  void NetSetPercentages(const ActorValues& actorValues,
-                         MpActor* aggressor = nullptr,
-                         std::optional<espm::ActorValue> av = std::nullopt);
+  void NetSendChangeValues(
+    const ActorValues& actorValues,
+    std::optional<std::vector<espm::ActorValue>> avFilter);
+  void NetSetPercentages(
+    const ActorValues& actorValues, MpActor* aggressor,
+    std::optional<std::vector<espm::ActorValue>> avFilter);
 
   std::chrono::steady_clock::time_point GetLastAttributesPercentagesUpdate();
   std::chrono::steady_clock::time_point GetLastHitTime();
@@ -146,6 +147,9 @@ public:
   void RestoreActorValue(espm::ActorValue av, float value);
   void DamageActorValue(espm::ActorValue av, float value);
   void SetActorValue(espm::ActorValue actorValue, float value);
+
+  // TODO: only used in legacy MGEF implementation, remove when MGEF is
+  // rewritten
   void SetActorValues(const ActorValues& actorValues);
 
   BaseActorValues GetBaseValues();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize actor value updates in `MpActor` and `ActionListener` by introducing a filtering mechanism for network efficiency.
> 
>   - **Behavior**:
>     - `NetSendChangeValues` and `NetSetPercentages` in `MpActor.cpp` now accept an optional `avFilter` to send only changed actor values.
>     - `OnChangeValues` in `ActionListener.cpp` uses `avFilter` to optimize network updates for health, magicka, and stamina.
>     - `OnSpellHit` and `OnWeaponHit` in `ActionListener.cpp` updated to use `avFilter` for health updates.
>   - **Functions**:
>     - `MpActor::NetSendChangeValues` and `MpActor::NetSetPercentages` refactored to support partial updates using `avFilter`.
>     - `ActionListener::OnChangeValues` refactored to determine changes using `MathUtils::IsNearlyEqual` and apply `avFilter`.
>   - **Misc**:
>     - Added `kDefaultAvFilter` in `MpActor.cpp` for default actor value updates.
>     - Minor refactoring in `ActionListener.cpp` to improve readability and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for c548a5e8d058e58b4e84a099a064d237a1ba63c9. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->