### PR TITLE
internal: check OpenCppCoverage installation before installing in GitHub Actions

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -87,10 +87,15 @@ runs:
         yarn build
       shell: powershell
 
-    - name: Install tools
+    - name: Install OpenCppCoverage if not present
       if: runner.os == 'Windows'
-      run: choco install opencppcoverage
       shell: powershell
+      run: |
+        if (-not (Get-Command OpenCppCoverage -ErrorAction SilentlyContinue)) {
+          choco install opencppcoverage -y
+        } else {
+          Write-Output "OpenCppCoverage is already installed."
+        }
 
     - name: Move vcpkg submodule to a larger drive
       if: runner.os == 'Windows'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify GitHub Actions to check for OpenCppCoverage installation before installing on Windows runners.
> 
>   - **GitHub Actions**:
>     - Modify `Install OpenCppCoverage if not present` step in `action.yml` to check if OpenCppCoverage is already installed before installing.
>     - Uses PowerShell command `Get-Command` to verify installation status on Windows runners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 5882969e6420db960334a15d6ea9a6b0544d601e. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->