### PR TITLE
internal: rewrite NuGet detection in PowerShell & skip it for non-nuget vcpkg caches

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -163,29 +163,34 @@ runs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - name: 'Setup NuGet Credentials'
+    - name: Setup NuGet Credentials (PowerShell)
       if: runner.os == 'Windows'
-      shell: bash
+      shell: powershell
       run: |
-        `C:/vcpkg/vcpkg.exe fetch nuget | tail -n 1`
+        if (-not ($env:VCPKG_BINARY_SOURCES -like '*nuget*')) {
+          Write-Host "Skipping NuGet setup because VCPKG_BINARY_SOURCES does not contain 'nuget'."
+          exit 0
+        }
 
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "Pull request detected."
-          nuget sources add \
-            -source "https://nuget.pkg.github.com/${{ github.actor }}/index.json" \
-            -storepasswordincleartext \
-            -name "GitHub" \
-            -username "${{ github.actor }}" \
+        $nugetPath = & 'C:\vcpkg\vcpkg.exe' fetch nuget | Select-Object -Last 1
+
+        if ("${{ github.event_name }}" -eq "pull_request") {
+          Write-Host "Pull request detected. Adding NuGet source for actor."
+          & $nugetPath sources add `
+            -source "https://nuget.pkg.github.com/${{ github.actor }}/index.json" `
+            -storepasswordincleartext `
+            -name "GitHub" `
+            -username "${{ github.actor }}" `
             -password "${{ inputs.NUGET_GITHUB_TOKEN }}"
-        else
-          echo "Push event detected."
-          nuget sources add \
-            -source "https://nuget.pkg.github.com/skyrim-multiplayer/index.json" \
-            -storepasswordincleartext \
-            -name "GitHub" \
-            -username "skyrim-multiplayer" \
+        } else {
+          Write-Host "Non-pull request event detected. Adding default NuGet source."
+          & $nugetPath sources add `
+            -source "https://nuget.pkg.github.com/skyrim-multiplayer/index.json" `
+            -storepasswordincleartext `
+            -name "GitHub" `
+            -username "skyrim-multiplayer" `
             -password "${{ inputs.NUGET_GITHUB_TOKEN }}"
-        fi
+        }
 
     # Download Skyrim SE data files
     - uses: suisei-cn/actions-download-file@v1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert NuGet credentials setup to PowerShell and update logic for event handling in `action.yml`.
> 
>   - **Setup NuGet Credentials**:
>     - Changed shell from Bash to PowerShell for Windows runners in `action.yml`.
>     - Added check for `VCPKG_BINARY_SOURCES` containing 'nuget' before proceeding.
>     - Differentiated handling for pull request events vs. non-pull request events when adding NuGet sources.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 959025037fdde86c92fe2d1fb02b37b08f547c32. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->