### PR TITLE
tests: add UI tag for DistContentsTest

### DIFF
--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -42,6 +42,10 @@ if(BUILD_UNIT_TESTS AND NOT EMSCRIPTEN)
     target_compile_definitions(unit PRIVATE SKYRIM_SE=1)
   endif()
 
+  if(BUILD_FRONT)
+    target_compile_definitions(unit PRIVATE WITH_UI_FRONT=1)
+  endif()
+
   target_compile_definitions(unit PRIVATE
     TEST_PEX_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/papyrus_test_files/standard_scripts\"
     BUILT_PEX_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/papyrus_test_files/pex\"

--- a/unit/DistContentsExpected.json
+++ b/unit/DistContentsExpected.json
@@ -6,8 +6,6 @@
       "client/Data/Platform/Plugins/skymp5-client.js",
       "client/Data/Platform/Plugins/skymp5-client-settings.txt",
       "server/data/scripts/ActiveMagicEffect.pex",
-      "client/Data/Platform/UI/build.js",
-      "client/Data/Platform/UI/index.html",
       "server/dist_back/skymp5-server.js",
       "server/dist_back/skymp5-server.js.map",
       "server/gamemode.js",
@@ -15,6 +13,15 @@
       "server/scam_native.node",
       "server/server-settings.json",
       "server/yarn.lock"
+    ]
+  },
+  {
+    "configurationTags": [
+      "UI"
+    ],
+    "expectedFiles": [
+      "client/Data/Platform/UI/build.js",
+      "client/Data/Platform/UI/index.html"
     ]
   },
   {

--- a/unit/DistContentsTest.cpp
+++ b/unit/DistContentsTest.cpp
@@ -74,6 +74,10 @@ auto GetExpectedPaths(const nlohmann::json& j)
   configurationTags.insert("SkyrimAE");
 #endif
 
+#ifdef WITH_UI_FRONT
+  configurationTags.insert("UI");
+#endif
+
   if (getenv("CI")) {
     configurationTags.insert("CI");
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `UI` configuration tag to build and test processes, updating CMake and distribution expectations.
> 
>   - **Build Configuration**:
>     - Add `WITH_UI_FRONT` definition in `CMakeLists.txt` when `BUILD_FRONT` is enabled.
>   - **Distribution Contents**:
>     - Move `build.js` and `index.html` to a new `UI` configuration tag in `DistContentsExpected.json`.
>   - **Testing**:
>     - Update `GetExpectedPaths()` in `DistContentsTest.cpp` to include `UI` tag when `WITH_UI_FRONT` is defined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 9aab20ab8eea925a284cf5fdaabdc85da24e723d. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->