### PR TITLE
Fix a case sensitivity issue with base class names

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/assets/sp3.js
+++ b/skyrim-platform/src/platform_se/skyrim_platform/assets/sp3.js
@@ -171,7 +171,7 @@
     console.log({ classes })
 
     classes.forEach(className => {
-      const baseClassName = api._sp3GetBaseClass(className);
+      const baseClassName = prettifyUpperCase(api._sp3GetBaseClass(className));
       let staticFunctions = api._sp3ListStaticFunctions(className);
       const methods = api._sp3ListMethods(className);
 


### PR DESCRIPTION
Convert the case of base class names to avoid issues with cases like `sslSystemLibrary` (should be `SslSystemLibrary`).

(It was @Pospelove who actually fixed the issue! I just tested it to ensure it works on Skyrim VR. 😅) 