### PR TITLE
internal: add fallback for cross-device file moves in GitHub Action

### DIFF
--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -134,6 +134,7 @@ runs:
               if (err.code === 'EXDEV') {
                 console.log('Falling back to copy and delete due to cross-device link error.');
                 await fsp.cp(sourcePath_, targetPath_, { recursive: true });
+                await fsp.rm(sourcePath_, { recursive: true, force: true });
               }
               else {
                 throw err;

--- a/.github/actions/pr_base/action.yml
+++ b/.github/actions/pr_base/action.yml
@@ -127,6 +127,20 @@ runs:
           const targetPath = 'C:\\vcpkg';
           const sourcePath = path.join(process.env.GITHUB_WORKSPACE, 'vcpkg');
 
+          async function moveWithFallback(sourcePath_, targetPath_) {
+            try {
+              await fsp.rename(sourcePath_, targetPath_);
+            } catch (err) {
+              if (err.code === 'EXDEV') {
+                console.log('Falling back to copy and delete due to cross-device link error.');
+                await fsp.cp(sourcePath_, targetPath_, { recursive: true });
+              }
+              else {
+                throw err;
+              }
+            }
+          }
+
           async function moveVcpkg() {
             try {
               if (fs.existsSync(targetPath)) {
@@ -135,7 +149,8 @@ runs:
               }
 
               console.log(`Moving ${sourcePath} to ${targetPath}...`);
-              await fsp.rename(sourcePath, targetPath);
+              await moveWithFallback(sourcePath, targetPath);
+              console.log(`Successfully moved vcpkg to ${targetPath}`);
             } catch (err) {
               core.setFailed(`Error moving vcpkg: ${err.message}`);
             }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds fallback for cross-device file moves in GitHub Action by introducing `moveWithFallback()` in `action.yml`.
> 
>   - **Behavior**:
>     - Adds `moveWithFallback()` function in `action.yml` to handle cross-device file move errors by falling back to copy and delete.
>     - Updates `moveVcpkg()` to use `moveWithFallback()` for moving `vcpkg` submodule.
>   - **Error Handling**:
>     - Catches `EXDEV` error during `fsp.rename()` and logs a message before performing fallback operations.
>     - Throws other errors if they occur during the move operation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 1cc907bb01f9dcfebf1e1cf5931dddfae604d0cd. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->