### PR TITLE
feat(skymp5-client): disable animation invocation from keyboard in SweetCameraEnforcementService

### DIFF
--- a/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
+++ b/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
@@ -242,18 +242,18 @@ export class SweetCameraEnforcementService extends ClientListener {
 
         if (!animEvent) return;
 
-        //logTrace(this, "Starting anims from keyboard is disabled in this version")
-        this.tryInvokeAnim(animEvent, {
-            weaponDrawnAllowed: false,
-            furnitureAllowed: false,
-            exitAnimName: null,
-            interruptAnimName: null,
-            timeMs: 0,
-            isPlayExitAnimAfterwardsEnabled: true,
-            parentAnimEventName: null,
-            enablePlayerControlsDelayMs: null,
-            preferInterruptAnimAsExitAnimTimeMs: null
-        });
+        logTrace(this, "Starting anims from keyboard is disabled in this version")
+        // this.tryInvokeAnim(animEvent, {
+        //     weaponDrawnAllowed: false,
+        //     furnitureAllowed: false,
+        //     exitAnimName: null,
+        //     interruptAnimName: null,
+        //     timeMs: 0,
+        //     isPlayExitAnimAfterwardsEnabled: true,
+        //     parentAnimEventName: null,
+        //     enablePlayerControlsDelayMs: null,
+        //     preferInterruptAnimAsExitAnimTimeMs: null
+        // });
     }
 
     private tryInvokeAnim(animEvent: string, options: InvokeAnimOptions): { success: boolean, reason?: string } {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comment out `tryInvokeAnim` call in `SweetCameraEnforcementService` to disable animation invocation from keyboard events and add a log statement.
> 
>   - **Behavior**:
>     - In `SweetCameraEnforcementService`, the call to `tryInvokeAnim` is commented out in `onButtonEvent`, disabling animation invocation from keyboard events.
>     - Adds a log statement in `onButtonEvent` to indicate that starting animations from the keyboard is disabled.
>   - **Misc**:
>     - No other changes or refactoring are present in this commit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for fafe7bb7f3f1719697c3d7fd26a59268b12e8fac. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->