### PR TITLE
feat(skymp5-client): add exitAnimNotificationIntervalMs for animation exit notifications

### DIFF
--- a/skymp5-client/src/services/messages_settings/animDebugSettings.ts
+++ b/skymp5-client/src/services/messages_settings/animDebugSettings.ts
@@ -9,4 +9,5 @@ export interface AnimDebugSettings {
   isActive?: boolean;
   textOutput?: AnimTextOutput,
   animKeys?: { [index: number]: string | undefined };
+  exitAnimNotificationIntervalMs?: number;
 }

--- a/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
+++ b/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
@@ -230,7 +230,11 @@ export class SweetCameraEnforcementService extends ClientListener {
         }
         else {
             if (this.needsExitingAnim) {
-                this.sp.Debug.notification("Пробел, чтобы выйти из анимации");
+                const intervalMs = this.settings?.exitAnimNotificationIntervalMs;
+                if (!intervalMs || (Date.now() - this.lastNotificationMoment) >= intervalMs) {
+                    this.lastNotificationMoment = Date.now();
+                    this.sp.Debug.notification("Пробел, чтобы выйти из анимации");
+                }
             }
         }
 
@@ -385,5 +389,6 @@ export class SweetCameraEnforcementService extends ClientListener {
     private exitAnimName: string | null = null;
     private interruptAnimName: string | null = null;
     private tryInvokeAnimCount: number = 0;
+    private lastNotificationMoment: number = 0;
     private readonly tryInvokeAnimCountMax: number = 1000000000;
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `exitAnimNotificationIntervalMs` to control animation exit notification frequency in `SweetCameraEnforcementService`.
> 
>   - **Behavior**:
>     - Add `exitAnimNotificationIntervalMs` to `AnimDebugSettings` in `animDebugSettings.ts` to control notification frequency.
>     - Modify `SweetCameraEnforcementService` in `sweetCameraEnforcementService.ts` to respect `exitAnimNotificationIntervalMs` when notifying about animation exit.
>   - **Misc**:
>     - Add `lastNotificationMoment` to track last notification time in `SweetCameraEnforcementService`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 315edf93fdbfdb4e75fbcde648d4c3fc39e63426. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->