### PR TITLE
fix(skymp5-server): use JSON dump in GetArgumentsJsonArray for string conversion

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateEquipmentAttemptEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/UpdateEquipmentAttemptEvent.cpp
@@ -22,7 +22,7 @@ std::string UpdateEquipmentAttemptEvent::GetArgumentsJsonArray() const
   result += "[";
   result += std::to_string(actor->GetFormId());
   result += ",";
-  result += equipment.ToJson();
+  result += equipment.ToJson().dump();
   result += ",";
   result += isAllowed ? "true" : "false";
   result += "]";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `GetArgumentsJsonArray()` in `UpdateEquipmentAttemptEvent.cpp` to use `equipment.ToJson().dump()` for JSON string conversion.
> 
>   - **Behavior**:
>     - Modify `GetArgumentsJsonArray()` in `UpdateEquipmentAttemptEvent.cpp` to use `equipment.ToJson().dump()` instead of `equipment.ToJson()` for JSON string conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 09d8a9378918af128caadecd6add8648fb6530d1. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->