### PR TITLE
feat(skymp5-client): cherry-pick text sizes update from #2472

### DIFF
--- a/skymp5-client/src/services/services/animDebugService.ts
+++ b/skymp5-client/src/services/services/animDebugService.ts
@@ -1,7 +1,7 @@
 import { logTrace, logError } from "../../logging";
 import { AnimDebugSettings } from "../messages_settings/animDebugSettings";
 import { ClientListener, CombinedController, Sp } from "./clientListener";
-import { ButtonEvent, CameraStateChangedEvent, DxScanCode, Menu } from "skyrimPlatform";
+import { ButtonEvent, CameraStateChangedEvent, DxScanCode, Menu, setTextSize } from "skyrimPlatform";
 
 const playerId = 0x14;
 
@@ -70,6 +70,7 @@ class AnimQueueCollection {
     this.list = new Array<AnimListItem>(arrayLength);
     for (let idx = 0; idx < arrayLength; ++idx) {
       this.list[idx] = { name: "", textId: sp.createText(startPos.x, y, "", animationSucceededTextColor), color: animationSucceededTextColor };
+      setTextSize(this.list[idx].textId, 0.5);
       y += yPosDelta;
     }
   }

--- a/skymp5-client/src/services/services/loadOrderVerificationService.ts
+++ b/skymp5-client/src/services/services/loadOrderVerificationService.ts
@@ -1,4 +1,4 @@
-import { Game, Utility, HttpClient, printConsole, createText } from "skyrimPlatform";
+import { Game, Utility, HttpClient, printConsole, createText, setTextSize } from "skyrimPlatform";
 import { getScreenResolution } from "../../view/formView";
 import { ClientListener, CombinedController, Sp } from "./clientListener";
 import { Mod } from "../messages_http/serverManifest";
@@ -102,6 +102,7 @@ export class LoadOrderVerificationService extends ClientListener {
     const { width, height } = getScreenResolution();
     this.resetText();
     const statusTextId = createText(width / 2, height / 2, text, color);
+    setTextSize(statusTextId, 0.5);
     this.setState({ statusTextId });
     if (clearDelay) {
       Utility.wait(clearDelay).then(() => this.resetText());

--- a/skymp5-client/src/services/services/netInfoService.ts
+++ b/skymp5-client/src/services/services/netInfoService.ts
@@ -1,3 +1,4 @@
+import { setTextSize } from "skyrimPlatform";
 import { logTrace, logError } from "../../logging";
 import { ConnectionMessage } from "../events/connectionMessage";
 import { NewLocalLagValueCalculatedEvent } from "../events/newLocalLagValueCalculatedEvent";
@@ -132,7 +133,16 @@ class NetInfoTexts {
     public readonly sentPacketAmountTextId = sp.createText(250, 430, "", [255, 255, 255, 1]),
     public readonly localPositionLagStaticTextId = sp.createText(90, 470, "local lag:", [255, 255, 255, 1]),
     public readonly localPositionLagAmountTextId = sp.createText(250, 470, "", [255, 255, 255, 1]),
-  ) { }
+  ) {
+    setTextSize(this.connectionStaticTextId, 0.5);
+    setTextSize(this.connectionStateTextId, 0.5);
+    setTextSize(this.receivedPacketStaticTextId, 0.5);
+    setTextSize(this.receivedPacketAmountTextId, 0.5);
+    setTextSize(this.sentPacketStaticTextId, 0.5);
+    setTextSize(this.sentPacketAmountTextId, 0.5);
+    setTextSize(this.localPositionLagStaticTextId, 0.5);
+    setTextSize(this.localPositionLagAmountTextId, 0.5);
+  }
 
   public clear(): void {
     this.sp.destroyText(this.connectionStaticTextId);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set text size to 0.5 for various text elements in `animDebugService.ts`, `loadOrderVerificationService.ts`, and `netInfoService.ts` for consistent UI/UX.
> 
>   - **UI/UX Improvements**:
>     - Use `setTextSize` to set text size to `0.5` for text elements in `animDebugService.ts`, `loadOrderVerificationService.ts`, and `netInfoService.ts`.
>     - Affects text elements like `AnimQueueCollection` in `animDebugService.ts`, `statusTextId` in `loadOrderVerificationService.ts`, and various text IDs in `NetInfoTexts` in `netInfoService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 456b31973c260c9d24a9c2b6a1cef5d618e4ac0f. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->