### PR TITLE
internal: update fmt port to fix clang 20 build

### DIFF
--- a/overlay_ports/fmt/portfile.cmake
+++ b/overlay_ports/fmt/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fmtlib/fmt
+    REF "${VERSION}"
+    SHA512 46974efd36e613477351aa357c451cee434da797c2a505f9f86d73e394dcb35dc2dc0cda66abb98c023e8f24deac9d8e3ee6f9f6c0971cc4c00e37c34aa7f15f
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFMT_CMAKE_DIR=share/fmt
+        -DFMT_TEST=OFF
+        -DFMT_DOC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/overlay_ports/fmt/usage
+++ b/overlay_ports/fmt/usage
@@ -1,0 +1,8 @@
+The package fmt provides CMake targets:
+
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt)
+
+    # Or use the header-only version
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt-header-only)

--- a/overlay_ports/fmt/vcpkg.json
+++ b/overlay_ports/fmt/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "fmt",
+  "version": "11.2.0",
+  "description": "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.",
+  "homepage": "https://github.com/fmtlib/fmt",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
Workaround before https://github.com/microsoft/vcpkg/pull/45295 is merged
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add fmt port configuration to vcpkg to fix clang 20 build issues.
> 
>   - **New Files**:
>     - `portfile.cmake`: Configures fmt port with `vcpkg_from_github`, disables tests and docs, and installs necessary files.
>     - `usage`: Provides CMake target usage instructions for fmt.
>     - `vcpkg.json`: Defines fmt package metadata, version 11.2.0, with dependencies on `vcpkg-cmake` and `vcpkg-cmake-config`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 1e8ea450d12d4f56745112621a3877954cea0275. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->