### PR TITLE
fix(skymp5-server): adjust user ID handling in ServerCombined and update tests

### DIFF
--- a/skymp5-server/cpp/mp_common/NetworkingCombined.h
+++ b/skymp5-server/cpp/mp_common/NetworkingCombined.h
@@ -17,7 +17,15 @@ public:
   ServerCombined(const Networking::ServersVec& childs_)
     : childs(childs_)
   {
-    makeId.reset(new MakeID(std::numeric_limits<uint32_t>::max()));
+    makeId = std::make_unique<MakeID>(std::numeric_limits<uint32_t>::max());
+
+    // See also login.ts
+    uint32_t id0;
+    bool id0CreateSuccess = makeId->CreateID(id0);
+    if (id0 != 0 || !id0CreateSuccess) {
+      std::terminate();
+    }
+
     childData.resize(childs_.size());
   }
 

--- a/skymp5-server/cpp/mp_common/NetworkingCombined.h
+++ b/skymp5-server/cpp/mp_common/NetworkingCombined.h
@@ -22,7 +22,7 @@ public:
     // See also login.ts
     uint32_t id0;
     bool id0CreateSuccess = makeId->CreateID(id0);
-    if (id0 != 0 || !id0CreateSuccess) {
+    if (!id0CreateSuccess || id0 != 0) {
       std::terminate();
     }
 

--- a/skymp5-server/ts/systems/login.ts
+++ b/skymp5-server/ts/systems/login.ts
@@ -19,6 +19,9 @@ namespace DiscordErrors {
   export const unknownMember = 10007;
 }
 
+// See also NetworkingCombined.h
+// In NetworkingCombined.h, we implement a hack to prevent the soul-transmission bug
+// TODO: reimplement Login system. Preferably, in C++ with clear data flow.
 export class Login implements System {
   systemName = "Login";
 

--- a/unit/Networking_CombinedTest.cpp
+++ b/unit/Networking_CombinedTest.cpp
@@ -31,13 +31,13 @@ TEST_CASE("Combined: connect/dsconnect", "[Networking]")
   auto cl1 = s1->CreateClient().first;
   auto cl2 = s2->CreateClient().first;
   svr->Tick(tickCb, nullptr);
-  REQUIRE(connected == std::vector<UserId>({ 0, 1 }));
+  REQUIRE(connected == std::vector<UserId>({ 1, 2 }));
   REQUIRE(disconnected == std::vector<UserId>());
 
   cl1.reset();
   cl2.reset();
   svr->Tick(tickCb, nullptr);
-  REQUIRE(disconnected == std::vector<UserId>({ 0, 1 }));
+  REQUIRE(disconnected == std::vector<UserId>({ 1, 2 }));
 }
 
 TEST_CASE("Combined: order of disconnection", "[Networking]")
@@ -61,7 +61,7 @@ TEST_CASE("Combined: order of disconnection", "[Networking]")
   c1.reset();
   c0.reset();
   svr->Tick(tickCb, nullptr);
-  REQUIRE(disconnected == std::vector<UserId>({ 1, 0, 3, 2 }));
+  REQUIRE(disconnected == std::vector<UserId>({ 2, 1, 4, 3 }));
 }
 
 TEST_CASE("Combined: ids are freed", "[Networking]")
@@ -81,8 +81,8 @@ TEST_CASE("Combined: ids are freed", "[Networking]")
     svr->Tick(tickCb, nullptr);
   }
 
-  REQUIRE(connected == std::vector<Networking::UserId>({ 0, 0, 0 }));
-  REQUIRE(disconnected == std::vector<Networking::UserId>({ 0, 0, 0 }));
+  REQUIRE(connected == std::vector<Networking::UserId>({ 1, 1, 1 }));
+  REQUIRE(disconnected == std::vector<Networking::UserId>({ 1, 1, 1 }));
 }
 
 TEST_CASE("Combined: Messages from clients are received")
@@ -98,7 +98,7 @@ TEST_CASE("Combined: Messages from clients are received")
   svr->Tick(tickCb, nullptr);
 
   REQUIRE(messages.size() == 1);
-  REQUIRE(messages[0].first == 0);
+  REQUIRE(messages[0].first == 1);
   REQUIRE(messages[0].second == "dd");
 }
 
@@ -115,7 +115,7 @@ TEST_CASE("Combined: Messages are transferred to clients")
   DECLARE_CB;
 
   svr->Tick(tickCb, nullptr);
-  svr->Send(1, (PacketData) "df", 2, true);
+  svr->Send(2, (PacketData) "df", 2, true);
 
   static bool received = false;
   cl1->Tick(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix user ID handling in `ServerCombined` to start from 1 and update tests accordingly.
> 
>   - **Behavior**:
>     - In `NetworkingCombined.h`, `ServerCombined` constructor now ensures the first created ID is 0 and terminates if not successful.
>     - User IDs now start from 1 instead of 0 in `ServerCombined`.
>   - **Tests**:
>     - Updated `Networking_CombinedTest.cpp` to expect user IDs starting from 1 instead of 0 in various test cases.
>   - **Misc**:
>     - Added comments in `login.ts` about a hack in `NetworkingCombined.h` to prevent a bug, with a note to reimplement the login system in C++.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for f78fc1b808365cd968f8e6cd9010a9285a0853f5. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->