### PR TITLE
fix(skymp5-client): prevent animation invocation during jump state in `tryInvokeAnim`

### DIFF
--- a/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
+++ b/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
@@ -319,6 +319,8 @@ export class SweetCameraEnforcementService extends ClientListener {
 
         if (player.isWeaponDrawn() && !options.weaponDrawnAllowed) return { success: false, reason: "weapon_drawn" };
 
+        if (player.getAnimationVariableBool("bInJumpState")) return { success: false, reason: "jump_state" };
+
         if (this.sp.Ui.isMenuOpen(Menu.Favorites)) return { success: false, reason: "favorites_menu_open" };
         if (this.sp.Ui.isMenuOpen(Menu.Console)) return { success: false, reason: "console_menu_open" };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add check in `tryInvokeAnim` to prevent animation invocation during jump state in `sweetCameraEnforcementService.ts`.
> 
>   - **Behavior**:
>     - Adds a check in `tryInvokeAnim` in `sweetCameraEnforcementService.ts` to prevent animation invocation if `player` is in `jump_state`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 57e4dd0727ad65899be60f3e079b69c13088b354. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->