### PR TITLE
fix(skymp5-server): bring back actor-specific checks to movement validation

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -109,12 +109,10 @@ void ActionListener::OnUpdateMovement(const RawMessageData& rawMsgData,
 {
   auto actor = SendToNeighbours(idx, rawMsgData);
   if (actor) {
-    bool isMe = partOne.serverState.ActorByUser(rawMsgData.userId) == actor;
-
     bool teleportFlag = actor->GetTeleportFlag();
     actor->SetTeleportFlag(false);
 
-    static const NiPoint3 reallyWrongPos = {
+    static const NiPoint3 kInfinityPos = {
       std::numeric_limits<float>::infinity(),
       std::numeric_limits<float>::infinity(),
       std::numeric_limits<float>::infinity()
@@ -127,10 +125,10 @@ void ActionListener::OnUpdateMovement(const RawMessageData& rawMsgData,
     const auto& currentCellOrWorld = actor->GetCellOrWorld();
 
     if (!MovementValidation::Validate(
-          currentPos, currentRot, currentCellOrWorld,
-          teleportFlag ? reallyWrongPos : pos,
+          partOne, currentPos, currentRot, currentCellOrWorld,
+          teleportFlag ? kInfinityPos : pos,
           FormDesc::FromFormId(worldOrCell, espmFiles), rawMsgData.userId,
-          partOne.GetSendTarget(), espmFiles)) {
+          actor, espmFiles)) {
       return;
     }
 

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
@@ -8,20 +8,28 @@
 
 namespace MovementValidation {
 
-bool Validate(const NiPoint3& currentPos, const NiPoint3& currentRot,
-              const FormDesc& currentCellOrWorld, const NiPoint3& newPos,
-              const FormDesc& newCellOrWorld, Networking::UserId userId,
-              PartOneSendTargetWrapper& sendTarget,
+bool Validate(PartOne& partOne, const NiPoint3& currentPos,
+              const NiPoint3& currentRot, const FormDesc& currentCellOrWorld,
+              const NiPoint3& newPos, const FormDesc& newCellOrWorld,
+              Networking::UserId userId, MpActor* actor,
               const std::vector<std::string>& espmFiles)
 {
-  float maxDistance = 4096;
+  constexpr float kSqrMaxDistance = 4096.f * 4096.f;
+
+  PartOneSendTargetWrapper& sendTarget = partOne.GetSendTarget();
+
   if (currentCellOrWorld != newCellOrWorld ||
-      (currentPos - newPos).Length() >= maxDistance) {
-    TeleportMessage2 msg;
-    msg.pos = { currentPos[0], currentPos[1], currentPos[2] };
-    msg.rot = { currentRot[0], currentRot[1], currentRot[2] };
-    msg.worldOrCell = currentCellOrWorld.ToFormId(espmFiles);
-    sendTarget.Send(userId, msg, true);
+      (currentPos - newPos).SqrLength() >= kSqrMaxDistance) {
+
+    // Not doing this to any NPCs at this moment, yet we might consider to
+    bool isMe = partOne.serverState.ActorByUser(userId) == actor;
+    if (isMe) {
+      TeleportMessage2 msg;
+      msg.pos = { currentPos[0], currentPos[1], currentPos[2] };
+      msg.rot = { currentRot[0], currentRot[1], currentRot[2] };
+      msg.worldOrCell = currentCellOrWorld.ToFormId(espmFiles);
+      sendTarget.Send(userId, msg, true);
+    }
     return false;
   }
   return true;

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
@@ -22,7 +22,7 @@ bool Validate(PartOne& partOne, const NiPoint3& currentPos,
       (currentPos - newPos).SqrLength() >= kSqrMaxDistance) {
 
     // Not doing this to any NPCs at this moment, yet we might consider to
-    bool isMe = partOne.serverState.ActorByUser(userId) == actor;
+    bool isMe = actor && partOne.serverState.ActorByUser(userId) == actor;
     if (isMe) {
       TeleportMessage2 msg;
       msg.pos = { currentPos[0], currentPos[1], currentPos[2] };

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.h
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.h
@@ -6,10 +6,12 @@
 #include <string>
 #include <vector>
 
+class MpActor;
+
 namespace MovementValidation {
-bool Validate(const NiPoint3& currentPos, const NiPoint3& currentRot,
-              const FormDesc& currentCellOrWorld, const NiPoint3& newPos,
-              const FormDesc& newCellOrWorld, Networking::UserId userId,
-              PartOneSendTargetWrapper& sendTarget,
+bool Validate(PartOne& partOne, const NiPoint3& currentPos,
+              const NiPoint3& currentRot, const FormDesc& currentCellOrWorld,
+              const NiPoint3& newPos, const FormDesc& newCellOrWorld,
+              Networking::UserId userId, MpActor* actor,
               const std::vector<std::string>& espmFiles);
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhanced movement validation with actor-specific checks and updated tests in `ActionListener.cpp`, `MovementValidation.cpp`, and `MovementValidationTest.cpp`.
> 
>   - **Behavior**:
>     - Updated `OnUpdateMovement` in `ActionListener.cpp` to use `MovementValidation::Validate` with actor-specific checks.
>     - `MovementValidation::Validate` now checks if the actor is the user and sends a teleport message if the movement is invalid.
>   - **Validation Logic**:
>     - Added `actor` parameter to `MovementValidation::Validate` in `MovementValidation.cpp` and `MovementValidation.h`.
>     - Changed distance check to use squared distance for performance.
>   - **Tests**:
>     - Updated `MovementValidationTest.cpp` to include actor-specific validation in test cases.
>     - Added checks for teleport message content and user ID in test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 40734304b4e16022dcfb31c54cef71a4eedf60ba. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->