### PR TITLE
fix(skymp5-client): fix exit anim exploit in SweetCameraEnforcementService

### DIFF
--- a/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
+++ b/skymp5-client/src/services/services/sweetCameraEnforcementService.ts
@@ -8,12 +8,6 @@ import { ButtonEvent, CameraStateChangedEvent, DxScanCode, Menu, Message } from 
 
 const playerId = 0x14;
 
-interface AnimOptions {
-    playExitAnim: boolean;
-    useInterruptAnimAsExitAnim?: boolean;
-    enablePlayerControlsDelayMs: unknown;
-}
-
 interface InvokeAnimOptions {
     weaponDrawnAllowed: unknown;
     furnitureAllowed: unknown;
@@ -24,6 +18,12 @@ interface InvokeAnimOptions {
     parentAnimEventName: unknown;
     enablePlayerControlsDelayMs: unknown;
     preferInterruptAnimAsExitAnimTimeMs: unknown;
+}
+
+interface ExitAnimOptions {
+    playExitAnim: boolean;
+    useInterruptAnimAsExitAnim?: boolean;
+    enablePlayerControlsDelayMs: unknown;
 }
 
 // ex AnimDebugService part
@@ -147,7 +147,7 @@ export class SweetCameraEnforcementService extends ClientListener {
         }
     }
 
-    private exitAnim(options: { playExitAnim: boolean, useInterruptAnimAsExitAnim?: boolean, enablePlayerControlsDelayMs: unknown }) {
+    private exitAnim(options: ExitAnimOptions) {
         // TODO(1): See another TODO(1) in this file
         if (options.playExitAnim) {
             let useInterruptAnimAsExitAnim = false;
@@ -454,7 +454,7 @@ export class SweetCameraEnforcementService extends ClientListener {
     private lastNotificationMoment: number = 0;
     private readonly tryInvokeAnimCountMax: number = 1000000000;
     private exitAnimEvent: string | undefined = undefined;
-    private optionsCache: AnimOptions | undefined = undefined;
+    private optionsCache: ExitAnimOptions | undefined = undefined;
     private optionCb: (() => void) | undefined = undefined;
     private usePlayerControlsDelayMs: boolean = true;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves exit animation handling in `SweetCameraEnforcementService` by adding `ExitAnimOptions`, modifying `exitAnim()`, and adding `onSendExitAnimationEventLeave()`.
> 
>   - **Behavior**:
>     - Adds `ExitAnimOptions` interface in `sweetCameraEnforcementService.ts` for exit animation handling.
>     - Modifies `exitAnim()` to use `ExitAnimOptions`, caching options and handling player control delays.
>     - Adds `onSendExitAnimationEventLeave()` to track and handle successful exit animation events.
>   - **Functions**:
>     - Updates `onButtonEvent()` to return early if button is pressed.
>     - Refactors `exitAnim()` to manage animation events and player control delays more effectively.
>   - **Misc**:
>     - Adds `exitAnimEvent`, `optionsCache`, `optionCb`, and `usePlayerControlsDelayMs` properties to manage state and callbacks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for c421279e99fea6b7649bf344a82561d7876b0d44. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->