### PR TITLE
fix(skyrim-platform): fix noise in isLongSignature (DumpFunctions)

### DIFF
--- a/skyrim-platform/src/platform_se/skyrim_platform/Hooks.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/Hooks.cpp
@@ -93,7 +93,7 @@ void BindNativeMethod(RE::BSScript::Internal::VirtualMachine* thisArg,
   auto skse = (uintptr_t)GetModuleHandleA("skse64_1_6_1170.dll");
 
   uintptr_t isLongSignature =
-    moduleBase == skse ? *reinterpret_cast<uintptr_t*>(raw + 0x58) : 0;
+    moduleBase == skse ? *reinterpret_cast<uint8_t*>(raw + 0x58) : 0;
 
   const char* funcName = func ? func->GetName().data() : "<null func>";
   const char* className =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `isLongSignature` type from `uintptr_t` to `uint8_t` in `BindNativeMethod` in `Hooks.cpp` for correct memory interpretation.
> 
>   - **Type Change**:
>     - In `BindNativeMethod` function in `Hooks.cpp`, change `isLongSignature` type from `uintptr_t` to `uint8_t` to correctly interpret a single byte from memory.
>   - **Behavior**:
>     - This change affects how the `isLongSignature` is read when `moduleBase` equals `skse`, ensuring correct data interpretation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 0e170547f72dcd19ef329e50d90224801a154d9d. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->