### PR TITLE
perf(skymp5-server): use string dumps for dynamic fields

### DIFF
--- a/misc/tests/test_crash.js
+++ b/misc/tests/test_crash.js
@@ -1,5 +1,4 @@
 const assert = require("node:assert");
-const fs = require("node:fs");
 
 const main = async () => {
   // instead of [0,0,0] there should be only angleZ

--- a/skymp5-server/cpp/addon/property_bindings/CustomPropertyBinding.cpp
+++ b/skymp5-server/cpp/addon/property_bindings/CustomPropertyBinding.cpp
@@ -43,12 +43,12 @@ Napi::Value CustomPropertyBinding::Get(Napi::Env env, ScampServer& scampServer,
   auto& refr = partOne->worldState.GetFormAt<MpObjectReference>(formId);
 
   if (isPrivate) {
-    return NapiHelper::ParseJson(env,
-                                 refr.GetDynamicFields().Get(propertyName));
+    return NapiHelper::ParseJson(
+      env, refr.GetDynamicFields().GetValueDump(propertyName));
   } else {
     EnsurePropertyExists(scampServer.GetGamemodeApiState(), propertyName);
-    return NapiHelper::ParseJson(env,
-                                 refr.GetDynamicFields().Get(propertyName));
+    return NapiHelper::ParseJson(
+      env, refr.GetDynamicFields().GetValueDump(propertyName));
   }
 }
 
@@ -62,16 +62,16 @@ void CustomPropertyBinding::Set(Napi::Env env, ScampServer& scampServer,
   auto& state = scampServer.GetGamemodeApiState();
 
   auto newValueDump = NapiHelper::Stringify(env, newValue);
-  auto newValueJson = nlohmann::json::parse(newValueDump);
 
   if (isPrivate) {
-    refr.SetProperty(propertyName, newValueJson, false, false);
+    refr.SetPropertyValueDump(propertyName, newValueDump, false, false);
     if (isPrivateIndexed) {
       refr.RegisterPrivateIndexedProperty(propertyName, newValueDump);
     }
     return;
   }
   auto it = EnsurePropertyExists(state, propertyName);
-  refr.SetProperty(propertyName, newValueJson, it->second.isVisibleByOwner,
-                   it->second.isVisibleByNeighbors);
+  refr.SetPropertyValueDump(propertyName, newValueDump,
+                            it->second.isVisibleByOwner,
+                            it->second.isVisibleByNeighbors);
 }

--- a/skymp5-server/cpp/server_guest_lib/DynamicFields.h
+++ b/skymp5-server/cpp/server_guest_lib/DynamicFields.h
@@ -8,17 +8,17 @@
 class DynamicFields
 {
 public:
-  void Set(const std::string& propName, nlohmann::json value);
-  const nlohmann::json& Get(const std::string& propName) const;
+  void SetValueDump(const std::string& propName, const std::string& valueDump);
+  const std::string& GetValueDump(const std::string& propName) const;
 
   const nlohmann::json& GetAsJson() const;
   static DynamicFields FromJson(const nlohmann::json& j);
 
   template <class F>
-  void ForEach(const F& f) const
+  void ForEachValueDump(const F& f) const
   {
-    for (auto [propName, value] : props) {
-      f(propName, value);
+    for (auto [propName, valueDump] : propDumps) {
+      f(propName, valueDump);
     }
   }
 
@@ -27,6 +27,6 @@ public:
   friend bool operator!=(const DynamicFields& r, const DynamicFields& l);
 
 private:
-  std::unordered_map<std::string, nlohmann::json> props;
+  std::unordered_map<std::string, std::string> propDumps;
   mutable std::optional<nlohmann::json> jsonCache;
 };

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -919,7 +919,8 @@ DeathStateContainerMessage MpActor::GetDeathStateMsg(
   const LocationalData& position, bool isDead, bool shouldTeleport)
 {
   DeathStateContainerMessage res;
-  res.tIsDead = PreparePropertyMessage(this, "isDead", isDead);
+  res.tIsDead =
+    PreparePropertyMessage_(this, "isDead", isDead ? "true" : "false");
 
   if (shouldTeleport) {
     res.tTeleport = TeleportMessage();

--- a/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
+++ b/skymp5-server/cpp/server_guest_lib/MpObjectReference.h
@@ -137,8 +137,9 @@ public:
   void ForceSubscriptionsUpdate();
   void SetPrimitive(const NiPoint3& boundsDiv2);
   void UpdateHoster(uint32_t newHosterId);
-  void SetProperty(const std::string& propertyName, nlohmann::json newValue,
-                   bool isVisibleByOwner, bool isVisibleByNeighbor);
+  void SetPropertyValueDump(const std::string& propertyName,
+                            const std::string& valueDump,
+                            bool isVisibleByOwner, bool isVisibleByNeighbor);
   void SetTeleportFlag(bool value);
   void SetPosAndAngleSilent(const NiPoint3& pos, const NiPoint3& rot);
   void Delete();
@@ -262,12 +263,12 @@ private:
 
 protected:
   void BeforeDestroy() override;
-  UpdatePropertyMessage CreatePropertyMessage(MpObjectReference* self,
+  UpdatePropertyMessage CreatePropertyMessage_(MpObjectReference* self,
                                               const char* name,
-                                              const nlohmann::json& value);
-  UpdatePropertyMessage PreparePropertyMessage(MpObjectReference* self,
+                                              const std::string& valueDump);
+  UpdatePropertyMessage PreparePropertyMessage_(MpObjectReference* self,
                                                const char* name,
-                                               const nlohmann::json& value);
+                                               const std::string& valueDump);
 
   const std::shared_ptr<FormCallbacks> callbacks;
 };

--- a/skymp5-server/cpp/server_guest_lib/gamemode_events/RespawnEvent.cpp
+++ b/skymp5-server/cpp/server_guest_lib/gamemode_events/RespawnEvent.cpp
@@ -28,6 +28,5 @@ void RespawnEvent::OnFireSuccess(WorldState*)
 
   // TODO: should probably not sending to ourselves. see also RespawnTest.cpp
   actor->SendMessageToActorListeners(
-    actor->CreatePropertyMessage(actor, "isDead", /*value=*/false),
-    /*reliable=*/true);
+    actor->CreatePropertyMessage_(actor, "isDead", "false"), true);
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `skymp5-server` to use string dumps for dynamic fields, updating relevant classes and functions for improved performance.
> 
>   - **Behavior**:
>     - Refactor `DynamicFields` to use string dumps instead of JSON objects for dynamic fields.
>     - Update `CustomPropertyBinding::Get` and `Set` to use `GetValueDump` and `SetValueDump`.
>     - Modify `MpObjectReference::CreatePropertyMessage_` and `PreparePropertyMessage_` to handle string dumps.
>   - **Functions**:
>     - Rename `Set` to `SetValueDump` and `Get` to `GetValueDump` in `DynamicFields`.
>     - Rename `CreatePropertyMessage` to `CreatePropertyMessage_` and `PreparePropertyMessage` to `PreparePropertyMessage_` in `MpObjectReference`.
>     - Update `MpObjectReference::SetPropertyValueDump` to use string dumps.
>   - **Misc**:
>     - Remove unused `fs` import in `test_crash.js`.
>     - Update `RespawnEvent::OnFireSuccess` to use `CreatePropertyMessage_` with string dumps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for fda24e3eda8bab1d0e1f96362b7b73dcee221f17. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->