### PR TITLE
internal: set cmake_minimum_required for node-api-headers

### DIFF
--- a/overlay_ports/node-api-headers/CMakeLists.txt
+++ b/overlay_ports/node-api-headers/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.18)
+
 project(nodelib C)
 
 add_custom_target(nodelib ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/node.lib)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `cmake_minimum_required(VERSION 3.18)` in `overlay_ports/node-api-headers/CMakeLists.txt`.
> 
>   - **CMake Configuration**:
>     - Set `cmake_minimum_required(VERSION 3.18)` in `overlay_ports/node-api-headers/CMakeLists.txt` to ensure compatibility with the CMake features used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for df8877ddd2eed9daadc6c731a62623e04f6c5bca. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->