### PR TITLE
fix(package.json): correct spelling of "skyrim platform" in keywords

### DIFF
--- a/skymp5-client/package.json
+++ b/skymp5-client/package.json
@@ -18,7 +18,7 @@
   },
   "keywords": [
     "skyrim",
-    "skryim platform"
+    "skyrim platform"
   ],
   "dependencies": {
     "@skyrim-platform/skyrim-platform": "2.8.0",


### PR DESCRIPTION
This pull request includes a minor correction to the `skymp5-client/package.json` file. The change fixes a typo in the keywords list, updating "skryim platform" to "skyrim platform".