### PR TITLE
perf(skymp5-server): use AsObjectReference() in WorldState::AddForm

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -133,8 +133,7 @@ void WorldState::AddForm(std::unique_ptr<MpForm> form, uint32_t formId,
   auto it = forms.insert({ formId, std::move(form) }).first;
 
   if (optionalChangeFormToApply) {
-    MpObjectReference* refr =
-      it->second ? it->second->AsObjectReference() : nullptr;
+    auto refr = it->second->AsObjectReference();
     if (!refr) {
       forms.erase(it); // Rollback changes due to exception
       throw std::runtime_error(

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -133,7 +133,8 @@ void WorldState::AddForm(std::unique_ptr<MpForm> form, uint32_t formId,
   auto it = forms.insert({ formId, std::move(form) }).first;
 
   if (optionalChangeFormToApply) {
-    auto refr = it->second->AsObjectReference();
+    MpObjectReference* refr =
+      it->second ? it->second->AsObjectReference() : nullptr;
     if (!refr) {
       forms.erase(it); // Rollback changes due to exception
       throw std::runtime_error(

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -133,7 +133,7 @@ void WorldState::AddForm(std::unique_ptr<MpForm> form, uint32_t formId,
   auto it = forms.insert({ formId, std::move(form) }).first;
 
   if (optionalChangeFormToApply) {
-    auto refr = dynamic_cast<MpObjectReference*>(it->second.get());
+    auto refr = it->second->AsObjectReference();
     if (!refr) {
       forms.erase(it); // Rollback changes due to exception
       throw std::runtime_error(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `WorldState::AddForm` to use `AsObjectReference()` instead of `dynamic_cast` for better readability and performance.
> 
>   - **Refactor**:
>     - Replace `dynamic_cast<MpObjectReference*>` with `AsObjectReference()` in `WorldState::AddForm` to improve readability and performance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 77a6c27538aefabe9ecbbfd445cab1b4c751593f. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->