### PR TITLE
fix: add exception logging to RemoveMagicEffect methods in MpActor

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1839,7 +1839,7 @@ void MpActor::RemoveAllMagicEffects()
     EditChangeForm(
       [](MpChangeForm& changeForm) { changeForm.activeMagicEffects.Clear(); });
   } catch (std::exception& e) {
-    spdlog::error("MpActor::RemoveMagicEffect {:x} - {}", GetFormId(),
+    spdlog::error("MpActor::RemoveAllMagicEffects {:x} - {}", GetFormId(),
                   e.what());
   }
 }

--- a/skymp5-server/cpp/server_guest_lib/MpActor.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.cpp
@@ -1814,24 +1814,34 @@ void MpActor::ApplyMagicEffects(std::vector<espm::Effects::Effect>& effects,
   }
 }
 
-void MpActor::RemoveMagicEffect(const espm::ActorValue actorValue) noexcept
+void MpActor::RemoveMagicEffect(const espm::ActorValue actorValue)
 {
-  const ActorValues baseActorValues = GetBaseActorValues(
-    GetParent(), GetBaseId(), GetRaceId(), ChangeForm().templateChain);
-  const float baseActorValue = baseActorValues.GetValue(actorValue);
-  SetActorValue(actorValue, baseActorValue);
-  EditChangeForm([actorValue](MpChangeForm& changeForm) {
-    changeForm.activeMagicEffects.Remove(actorValue);
-  });
+  try {
+    const ActorValues baseActorValues = GetBaseActorValues(
+      GetParent(), GetBaseId(), GetRaceId(), ChangeForm().templateChain);
+    const float baseActorValue = baseActorValues.GetValue(actorValue);
+    SetActorValue(actorValue, baseActorValue);
+    EditChangeForm([actorValue](MpChangeForm& changeForm) {
+      changeForm.activeMagicEffects.Remove(actorValue);
+    });
+  } catch (std::exception& e) {
+    spdlog::error("MpActor::RemoveMagicEffect {:x} - {}", GetFormId(),
+                  e.what());
+  }
 }
 
-void MpActor::RemoveAllMagicEffects() noexcept
+void MpActor::RemoveAllMagicEffects()
 {
-  const ActorValues baseActorValues = GetBaseActorValues(
-    GetParent(), GetBaseId(), GetRaceId(), ChangeForm().templateChain);
-  SetActorValues(baseActorValues);
-  EditChangeForm(
-    [](MpChangeForm& changeForm) { changeForm.activeMagicEffects.Clear(); });
+  try {
+    const ActorValues baseActorValues = GetBaseActorValues(
+      GetParent(), GetBaseId(), GetRaceId(), ChangeForm().templateChain);
+    SetActorValues(baseActorValues);
+    EditChangeForm(
+      [](MpChangeForm& changeForm) { changeForm.activeMagicEffects.Clear(); });
+  } catch (std::exception& e) {
+    spdlog::error("MpActor::RemoveMagicEffect {:x} - {}", GetFormId(),
+                  e.what());
+  }
 }
 
 void MpActor::ReapplyMagicEffects()

--- a/skymp5-server/cpp/server_guest_lib/MpActor.h
+++ b/skymp5-server/cpp/server_guest_lib/MpActor.h
@@ -168,8 +168,8 @@ public:
   void ApplyMagicEffects(std::vector<espm::Effects::Effect>& effects,
                          bool hasSweetpie = false,
                          bool durationOverriden = false);
-  void RemoveMagicEffect(const espm::ActorValue actorValue) noexcept;
-  void RemoveAllMagicEffects() noexcept;
+  void RemoveMagicEffect(const espm::ActorValue actorValue);
+  void RemoveAllMagicEffects();
   void ReapplyMagicEffects();
 
   bool GetConsoleCommandsAllowedFlag() const;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve error handling in `MpActor` by adding exception logging to `RemoveMagicEffect()` and `RemoveAllMagicEffects()`.
> 
>   - **Error Handling**:
>     - Remove `noexcept` from `RemoveMagicEffect()` and `RemoveAllMagicEffects()` in `MpActor.h`.
>     - Add try-catch blocks in `RemoveMagicEffect()` and `RemoveAllMagicEffects()` in `MpActor.cpp` to log exceptions using `spdlog`.
>   - **Logging**:
>     - Log errors in `RemoveMagicEffect()` and `RemoveAllMagicEffects()` with `spdlog::error` in `MpActor.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for f5cad17529e065286625529742503dfd7aa404f3. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->