### PR TITLE
fix(skymp5-client): stick to the typescript movement sync for now

### DIFF
--- a/skymp5-client/src/sync/movementApplyAutoSelect.ts
+++ b/skymp5-client/src/sync/movementApplyAutoSelect.ts
@@ -5,7 +5,8 @@ import { applyMovementNg } from "./movementApplyNg";
 
 
 export const applyMovementAutoSelect = (refr: ObjectReference, m: Movement, isMyClone?: boolean): void => {
-    settings["skymp5-client"]["use-old-movement"]
-        ? applyMovement(refr, m, isMyClone)
-        : applyMovementNg(refr, m, isMyClone);
+    applyMovement(refr, m, isMyClone);
+    // settings["skymp5-client"]["use-old-movement"]
+    //     ? applyMovement(refr, m, isMyClone)
+    //     : applyMovementNg(refr, m, isMyClone);
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `applyMovementAutoSelect` in `movementApplyAutoSelect.ts` now always calls `applyMovement`, removing conditional logic.
> 
>   - **Behavior**:
>     - `applyMovementAutoSelect` in `movementApplyAutoSelect.ts` now always calls `applyMovement`.
>     - Removes conditional logic that used `settings["skymp5-client"]["use-old-movement"]` to choose between `applyMovement` and `applyMovementNg`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for c004852b7e452f0d0d3b6a8bf3f6315288c76704. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->