### PR TITLE
Add logging for state change notification

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <string>
 #include <vector>
+#include <cpptrace/cpptrace.hpp>
 
 #include "CreateActorMessage.h"
 #include "CustomPacketMessage.h"
@@ -496,6 +497,7 @@ float PartOne::CalculateDamage(const MpActor& aggressor, const MpActor& target,
 void PartOne::NotifyGamemodeApiStateChanged(
   const GamemodeApi::State& newState) noexcept
 {
+  spdlog::warn("!!!!! NotifyGamemodeApiStateChanged called {}", cpptrace::generate_trace().to_string());
   UpdateGameModeDataMessage msg;
 
   for (auto [eventName, eventSourceInfo] : newState.createdEventSources) {


### PR DESCRIPTION
Added logging for NotifyGamemodeApiStateChanged function.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add warning log with stack trace in `NotifyGamemodeApiStateChanged` in `PartOne.cpp`.
> 
>   - **Logging**:
>     - Add warning log with stack trace in `NotifyGamemodeApiStateChanged` in `PartOne.cpp` to log when the function is called.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=skyrim-multiplayer%2Fskymp&utm_source=github&utm_medium=referral)<sup> for 5565673116327daaaaad956fbd82b719133433e1. You can [customize](https://app.ellipsis.dev/skyrim-multiplayer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->