### PR TITLE
feat(skymp5-server): don't skip ACTI and FURN load

### DIFF
--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -364,15 +364,6 @@ void PartOne::AttachSaveStorage(
                             lookupRes.rec->GetType().ToString());
         return;
       }
-      if (lookupRes.rec &&
-          (lookupRes.rec->GetType() == "ACTI" ||
-           lookupRes.rec->GetType() == "FURN")) {
-        pImpl->logger->info("Skipping FF object {} (type is {}), will likely "
-                            "overwrite at some point",
-                            changeForm.formDesc.ToString(),
-                            lookupRes.rec->GetType().ToString());
-        return;
-      }
     }
 
     n++;


### PR DESCRIPTION
ACTI and FURN should not be lost when the server is restarted