### PR TITLE
fix(skyrim-platform): skip DoReset3D when actor 3D is not loaded

### DIFF
--- a/skymp5-client/src/view/formView.ts
+++ b/skymp5-client/src/view/formView.ts
@@ -510,7 +510,7 @@ export class FormView {
           screenPoint[2] < 1;
         if (isOnScreen != this.isOnScreen) {
           this.isOnScreen = isOnScreen;
-          if (isOnScreen) {
+          if (isOnScreen && actor.is3DLoaded()) {
             actor.queueNiNodeUpdate();
             (Game.getPlayer() as Actor).queueNiNodeUpdate();
           }

--- a/skyrim-platform/src/platform_se/skyrim_platform/CallNative.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/CallNative.cpp
@@ -335,6 +335,8 @@ CallNative::AnySafe CallNative::CallNativeSafe(Arguments& args_)
         throw NullPointerException("nativeActorPtr");
       if (nativeActorPtr->formType.get() != RE::FormType::ActorCharacter)
         throw std::runtime_error("QueueNiNodeUpdate must be called on Actor");
+      if (!nativeActorPtr->GetCurrent3D())
+        return;
       // this is called QueueNiNodeUpdate in skse
       nativeActorPtr->DoReset3D(false);
     });


### PR DESCRIPTION
Prevents crash in FaceGen TRI loading when queueNiNodeUpdate is called on actors whose 3D skeleton hasn't fully loaded yet. This caused an access violation at an invalid address when the face gen system tried to operate on not yet loaded character.