### PR TITLE
fix(skyrim-platform): JS hook deadlock and DirectoryMonitor leak fix

### DIFF
--- a/skyrim-platform/src/platform_lib/ThreadPoolWrapper.h
+++ b/skyrim-platform/src/platform_lib/ThreadPoolWrapper.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <BS_thread_pool.hpp>
+#include <chrono>
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <mutex>
 
@@ -24,6 +26,22 @@ public:
   }
 
   void PushAndWait(const std::function<void()>& task) { Push(task).wait(); }
+
+  // Same as PushAndWait, but gives up after 'timeout' and returns false.
+  // Use this from the main game thread so a slow or stuck task on the
+  // pool can't freeze the whole game -- the caller can decide to just
+  // move on when this returns false.
+  //
+  // Note: on timeout the task is NOT cancelled, it stays queued and may
+  // still run later. Any state it captures must therefore stay valid for
+  // the whole lifetime of the pool (typical solution: capture by value
+  // into a shared_ptr).
+  bool PushAndWaitFor(const std::function<void()>& task,
+                      std::chrono::milliseconds timeout)
+  {
+    auto future = Push(task);
+    return future.wait_for(timeout) == std::future_status::ready;
+  }
 
 private:
   std::unique_ptr<BS::light_thread_pool> pool;

--- a/skyrim-platform/src/platform_se/skyrim_platform/DirectoryMonitor.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/DirectoryMonitor.cpp
@@ -1,16 +1,26 @@
 #include "DirectoryMonitor.h"
 
 namespace {
+// How long to sleep before retrying when the watched directory is missing
+// or the file-system watcher failed. Without this the watch thread burns
+// 100% of a CPU core calling FindFirstChangeNotificationW in a tight loop.
+constexpr DWORD kBackoffOnErrorMs = 1000;
+
 bool WaitForNextUpdate(DWORD* outErrorCode, std::filesystem::path dir)
 {
-  HANDLE hDir;
-  hDir = FindFirstChangeNotificationW(dir.c_str(), TRUE,
-                                      FILE_NOTIFY_CHANGE_LAST_WRITE);
+  HANDLE hDir = FindFirstChangeNotificationW(dir.c_str(), TRUE,
+                                             FILE_NOTIFY_CHANGE_LAST_WRITE);
   if (hDir == INVALID_HANDLE_VALUE) {
     *outErrorCode = GetLastError();
     return false;
   }
+
   WaitForSingleObject(hDir, INFINITE);
+
+  // Always release the notification handle. The old code never closed it,
+  // which slowly leaked handles and could push the watch thread into a
+  // high-CPU loop once the process-wide handle table filled up.
+  FindCloseChangeNotification(hDir);
   return true;
 }
 }
@@ -75,6 +85,10 @@ void DirectoryMonitor::Watch()
         ++pImpl_->numUpdates;
       } else {
         pImpl_->errorCode = err;
+        // Back off before retrying so we don't burn a whole CPU core
+        // hammering FindFirstChangeNotificationW when the folder is
+        // missing or the OS returns an error.
+        Sleep(kBackoffOnErrorMs);
       }
     }
   }).detach();

--- a/skyrim-platform/src/platform_se/skyrim_platform/Hook.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/Hook.cpp
@@ -2,6 +2,15 @@
 #include "Handler.h"
 #include "SkyrimPlatform.h"
 
+namespace {
+// How long a game-thread hook is allowed to wait for its JS handler.
+// If a JS handler runs longer than this (or the JS thread is busy),
+// we give up, skip the handler, and let the game keep running instead
+// of freezing. This is the SkyrimPlatform-level guard against hook
+// deadlocks caused by slow / buggy JS code.
+constexpr auto kHookDispatchTimeout = std::chrono::seconds(5);
+}
+
 Hook::Hook(std::string hookName_, std::string eventNameVariableName_,
            std::optional<std::string> succeededVariableName_)
   : hookName(hookName_)
@@ -58,12 +67,17 @@ void Hook::Enter(uint32_t selfId, std::string& eventName)
       });
   }
 
-  auto f = [&](Napi::Env env) {
+  // Copy the event name into a shared string so the queued task can safely
+  // touch it even if we bail out on timeout (the game thread's local
+  // string may be gone by then).
+  auto sharedEventName = std::make_shared<std::string>(eventName);
+
+  auto f = [this, owningThread, selfId, sharedEventName](Napi::Env env) {
     try {
       if (inProgressThreads.count(owningThread))
         throw std::runtime_error("'" + hookName + "' is already processing");
       inProgressThreads.insert(owningThread);
-      HandleEnter(owningThread, selfId, eventName, env);
+      HandleEnter(owningThread, selfId, *sharedEventName, env);
     } catch (std::exception& e) {
       auto err = std::string(e.what()) + " (while performing enter on '" +
         hookName + "')";
@@ -71,7 +85,22 @@ void Hook::Enter(uint32_t selfId, std::string& eventName)
         [err](Napi::Env) { throw std::runtime_error(err); });
     }
   };
-  SkyrimPlatform::GetSingleton()->PushAndWait(f);
+
+  bool ok =
+    SkyrimPlatform::GetSingleton()->PushAndWaitFor(f, kHookDispatchTimeout);
+  if (ok) {
+    // JS handler finished in time -- propagate any renamed event back to
+    // the game so hooks that rewrite event names still work.
+    eventName = *sharedEventName;
+  } else {
+    // JS handler is taking too long. Rather than freeze the game, skip
+    // this hook fire. The queued task may still run later (it's safe --
+    // it only touches the shared string, not game stack memory).
+    spdlog::warn("Hook '{}' handler timed out after {} ms; skipping to keep "
+                 "the game responsive.",
+                 hookName,
+                 static_cast<long long>(kHookDispatchTimeout.count()));
+  }
   addRemoveBlocker--;
 }
 
@@ -84,12 +113,15 @@ void Hook::Leave(bool succeeded)
     return;
   }
 
-  auto f = [&](Napi::Env env) {
+  auto self = this;
+  auto capturedHookName = hookName;
+  auto f = [self, owningThread, succeeded, capturedHookName](Napi::Env env) {
     try {
-      if (!inProgressThreads.count(owningThread))
-        throw std::runtime_error("'" + hookName + "' is not processing");
-      inProgressThreads.erase(owningThread);
-      HandleLeave(owningThread, succeeded, env);
+      if (!self->inProgressThreads.count(owningThread))
+        throw std::runtime_error("'" + capturedHookName +
+                                 "' is not processing");
+      self->inProgressThreads.erase(owningThread);
+      self->HandleLeave(owningThread, succeeded, env);
 
     } catch (std::exception& e) {
       std::string what = e.what();
@@ -98,7 +130,15 @@ void Hook::Leave(bool succeeded)
       });
     }
   };
-  SkyrimPlatform::GetSingleton()->PushAndWait(f);
+
+  bool ok =
+    SkyrimPlatform::GetSingleton()->PushAndWaitFor(f, kHookDispatchTimeout);
+  if (!ok) {
+    spdlog::warn("Hook '{}' leave handler timed out after {} ms; skipping to "
+                 "keep the game responsive.",
+                 hookName,
+                 static_cast<long long>(kHookDispatchTimeout.count()));
+  }
   addRemoveBlocker--;
 }
 

--- a/skyrim-platform/src/platform_se/skyrim_platform/SkyrimPlatform.cpp
+++ b/skyrim-platform/src/platform_se/skyrim_platform/SkyrimPlatform.cpp
@@ -441,6 +441,17 @@ void SkyrimPlatform::PushAndWait(const std::function<void(Napi::Env)>& f)
   });
 }
 
+bool SkyrimPlatform::PushAndWaitFor(
+  const std::function<void(Napi::Env)>& f, std::chrono::milliseconds timeout)
+{
+  return pImpl->pool.PushAndWaitFor(
+    [this, f] {
+      auto engine = pImpl->commonExecutionListener->GetJsEngine();
+      engine->AcquireEnvAndCall(f);
+    },
+    timeout);
+}
+
 void SkyrimPlatform::Push(const std::function<void(Napi::Env)>& f)
 {
   pImpl->pool.Push([this, f] {

--- a/skyrim-platform/src/platform_se/skyrim_platform/SkyrimPlatform.h
+++ b/skyrim-platform/src/platform_se/skyrim_platform/SkyrimPlatform.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "TPOverlayService.h"
+#include <chrono>
 
 class SkyrimPlatform
 {
@@ -10,6 +11,11 @@ public:
   void AddTickTask(const std::function<void(Napi::Env env)>& f);
   void AddUpdateTask(const std::function<void(Napi::Env env)>& f);
   void PushAndWait(const std::function<void(Napi::Env env)>& task);
+  // Same as PushAndWait, but gives up after 'timeout' and returns false.
+  // Use this when the calling thread must not block the game forever
+  // (e.g. game-side hooks running on the main thread).
+  bool PushAndWaitFor(const std::function<void(Napi::Env env)>& task,
+                      std::chrono::milliseconds timeout);
   void Push(const std::function<void(Napi::Env env)>& task);
   void PushToWorkerAndWait(
     RE::BSTSmartPointer<RE::BSScript::IFunction> fPtr,


### PR DESCRIPTION
The JS deadlock usually happens at very heavy areas, at Keizaal it happens often when getting close to Whiterun.
The DirectoryMonitor is a leak I found while investigating the last.