### PR TITLE
fix(skymp5-client): defer actor deletion via pending-delete lifecycle

### DIFF
--- a/skymp5-client/src/services/services/gamemodeUpdateService.ts
+++ b/skymp5-client/src/services/services/gamemodeUpdateService.ts
@@ -17,6 +17,7 @@ import * as skyrimPlatform from "skyrimPlatform";
 import { logError, logTrace } from "../../logging";
 import { SettingsService } from "./settingsService";
 import { ServerJsVerificationService } from "./serverJsVerificationService";
+import { WorldCleanerService } from "./worldCleanerService";
 
 export class GamemodeUpdateService extends ClientListener {
     constructor(private sp: Sp, private controller: CombinedController) {
@@ -83,6 +84,13 @@ export class GamemodeUpdateService extends ClientListener {
     }
 
     updateNeighbor(refr: ObjectReference, model: FormModel, state: Record<string, unknown>) {
+        // Pending-delete guard: skip user gameplay callbacks for actors
+        // WorldCleanerService has queued for deletion. Prevents server JS
+        // from touching an actor that is between disable and final delete.
+        if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(refr.getFormID())) {
+            return;
+        }
+
         for (const key of this.updateNeighborFunctionsKeys) {
             const v = (model as Record<string, unknown>)[key];
             // According to docs:

--- a/skymp5-client/src/services/services/hitService.ts
+++ b/skymp5-client/src/services/services/hitService.ts
@@ -5,6 +5,7 @@ import { FormType, HitEvent, storage } from "skyrimPlatform";
 import { ClientListener, CombinedController, Sp } from "./clientListener";
 import { MsgType } from "../../messages";
 import { Hit } from "../messages/hitMessage";
+import { WorldCleanerService } from "./worldCleanerService";
 
 export class HitService extends ClientListener {
     constructor(private sp: Sp, private controller: CombinedController) {
@@ -16,6 +17,16 @@ export class HitService extends ClientListener {
         // TODO: add more logging in case of 'return'
         // TODO: allow non-weapon sources
         const aggressor = e.aggressor.getFormID();
+
+        // Pending-delete guard: skip hit events involving actors already
+        // queued for deletion — both as aggressor and as target. Emitting
+        // OnHit for a pending-delete actor sends a message referencing an
+        // actor the server is about to see disappear.
+        const worldCleaner = this.controller.lookupListener(WorldCleanerService);
+        if (worldCleaner.isPendingDelete(aggressor) || worldCleaner.isPendingDelete(e.target.getFormID())) {
+            return;
+        }
+
         if (aggressor < 0xff000000 && aggressor !== 0x14) return; // all skymp npcs are FF+
 
         if (aggressor >= 0xff000000) {

--- a/skymp5-client/src/services/services/remoteServer.ts
+++ b/skymp5-client/src/services/services/remoteServer.ts
@@ -59,6 +59,7 @@ import {
 } from '../../view/worldViewMisc';
 import { TimeService } from './timeService';
 import { logTrace, logError } from '../../logging';
+import { WorldCleanerService } from './worldCleanerService';
 
 import { SpellCastMessage } from '../messages/spellCastMessage';
 import { UpdateAnimVariablesMessage } from '../messages/updateAnimVariablesMessage';
@@ -129,6 +130,15 @@ export class RemoteServer extends ClientListener {
   private onHostStartMessage(event: ConnectionMessage<HostStartMessage>) {
     const msg = event.message;
     const target = msg.target;
+
+    // Pending-delete guard: refuse to become host of an actor already
+    // queued for deletion. Accepting host would put it into the sendInputs
+    // loop and re-arm the queued-job crash the delete lifecycle avoids.
+    const localId = remoteIdToLocalId(target);
+    if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(localId)) {
+      logTrace(this, 'hostStart ignored, actor pending delete', target.toString(16));
+      return;
+    }
 
     let hosted = storage['hosted'];
     if (typeof hosted !== typeof []) {
@@ -253,6 +263,16 @@ export class RemoteServer extends ClientListener {
         'cell/world is',
         msg.worldOrCell.toString(16),
       );
+
+      // Pending-delete guard: do not teleport an actor queued for
+      // deletion — moveRefrToPosition would kick off cell-load /
+      // pathing work that races the final delete.
+      const refrIdEarly = refr?.getFormID();
+      if (refrIdEarly !== undefined && refrIdEarly !== 0x14 &&
+          this.controller.lookupListener(WorldCleanerService).isPendingDelete(refrIdEarly)) {
+        return;
+      }
+
       const ragdollService = this.controller.lookupListener(RagdollService);
 
       const refrId = refr?.getFormID();
@@ -793,6 +813,13 @@ export class RemoteServer extends ClientListener {
           ? Game.getPlayer()!
           : Actor.from(Game.getFormEx(remoteIdToLocalId(form.refrId ?? 0)));
       if (actor) {
+        // Pending-delete guard: skip death-state application AND the
+        // RespawnNeededError disableNoWait+delete fallback on an actor
+        // already in the delete pipeline — the fallback would double-
+        // delete via a path that bypasses WorldCleanerService.
+        if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(actor.getFormID())) {
+          return;
+        }
         try {
           this.controller.emitter.emit("applyDeathStateEvent", {
             actor: actor,
@@ -826,6 +853,13 @@ export class RemoteServer extends ClientListener {
       const refr = id === this.getMyActorIndex() ? Game.getPlayer() : getObjectReference(id);
       const ac = Actor.from(refr);
       if (!ac) {
+        return;
+      }
+
+      // Pending-delete guard: do not mutate actor values on an actor
+      // queued for deletion (would trigger AV recomputation right before
+      // the delete).
+      if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(ac.getFormID())) {
         return;
       }
 
@@ -947,6 +981,12 @@ export class RemoteServer extends ClientListener {
         return;
       }
 
+      // Pending-delete guard: skip cast/interrupt for a caster queued
+      // for deletion.
+      if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(ac.getFormID())) {
+        return;
+      }
+
       const actorAnimationVariables: ActorAnimationVariables = {
         booleans: new Uint8Array(msg.data.actorAnimationVariables.booleans),
         floats: new Uint8Array(msg.data.actorAnimationVariables.floats),
@@ -972,6 +1012,12 @@ export class RemoteServer extends ClientListener {
     once('update', () => {
       const ac = Actor.from(Game.getFormEx(remoteIdToLocalId(msg.data.actorRemoteId)));
       if (!ac) {
+        return;
+      }
+
+      // Pending-delete guard: skip animation-variable application on an
+      // actor queued for deletion.
+      if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(ac.getFormID())) {
         return;
       }
 

--- a/skymp5-client/src/services/services/sendInputsService.ts
+++ b/skymp5-client/src/services/services/sendInputsService.ts
@@ -22,6 +22,7 @@ import { UpdateEquipmentMessage } from "../messages/updateEquipmentMessage";
 import { UpdateAppearanceMessage } from "../messages/updateAppearanceMessage";
 import { RemoteServer } from "./remoteServer";
 import { DeathService } from "./deathService";
+import { WorldCleanerService } from "./worldCleanerService";
 import { logTrace } from "../../logging";
 
 const playerFormId = 0x14;
@@ -99,7 +100,19 @@ export class SendInputsService extends ClientListener {
 
         const world = modelSource.getWorldModel();
 
+        const worldCleaner = this.controller.lookupListener(WorldCleanerService);
+
         targets.forEach((target) => {
+            // Pending-delete guard: skip hosted actors that WorldCleanerService
+            // has queued for deletion. 'target' is undefined for the local
+            // player (never pending). For hosted actors we resolve the local
+            // Actor via getInputOwner and check its local FormID.
+            if (typeof target === "number") {
+                const owner = this.getInputOwner(target);
+                if (owner && worldCleaner.isPendingDelete(owner.getFormID())) {
+                    return;
+                }
+            }
             const targetFormModel = target ? this.getForm(target, world) : this.getForm(undefined, world);
             this.sendMovement(target, targetFormModel);
             this.sendAnimation(target);

--- a/skymp5-client/src/services/services/spSnippetService.ts
+++ b/skymp5-client/src/services/services/spSnippetService.ts
@@ -8,6 +8,7 @@ import { ClientListener, CombinedController, Sp } from "./clientListener";
 import { remoteIdToLocalId } from '../../view/worldViewMisc';
 import { logError, logTrace } from "../../logging";
 import { WorldView } from "../../view/worldView";
+import { WorldCleanerService } from "./worldCleanerService";
 
 export class SpSnippetService extends ClientListener {
   constructor(private sp: Sp, private controller: CombinedController) {
@@ -170,6 +171,16 @@ export class SpSnippetService extends ClientListener {
 
   private async runMethod(snippet: SpSnippetMessage): Promise<unknown> {
     const selfId = remoteIdToLocalId(snippet.selfId);
+
+    // Pending-delete guard: server snippets can invoke arbitrary Papyrus
+    // methods on any form via selfId. Skipping snippets whose target is
+    // queued for deletion prevents late per-actor calls from racing the
+    // final delete.
+    if (this.controller.lookupListener(WorldCleanerService).isPendingDelete(selfId)) {
+      logTrace(this, 'runMethod skipped, target pending delete', selfId.toString(16), snippet.class, snippet.function);
+      return;
+    }
+
     const self = this.sp.Game.getFormEx(selfId);
     if (!self)
       throw new Error(

--- a/skymp5-client/src/services/services/worldCleanerService.ts
+++ b/skymp5-client/src/services/services/worldCleanerService.ts
@@ -4,6 +4,18 @@ import { ObjectReferenceEx } from "../../extensions/objectReferenceEx";
 import { Actor } from "skyrimPlatform";
 import { logTrace } from "../../logging";
 
+const DELETE_DELAY_TICKS = 15;
+// Upper bound on update ticks we will wait for the `disable(false)` promise
+// to resolve before dropping the pending entry. Prevents a permanent state
+// leak (and permanently-suppressed processing) if the promise never fires.
+const MAX_DISABLE_WAIT_TICKS = 300;
+
+interface PendingDeleteState {
+  disabled: boolean;
+  ticksRemaining: number;
+  ticksWaitingForDisable: number;
+}
+
 export class WorldCleanerService extends ClientListener {
   constructor(private sp: Sp, private controller: CombinedController) {
     super();
@@ -20,7 +32,13 @@ export class WorldCleanerService extends ClientListener {
     return this.protection.get(actorId) || 0;
   }
 
+  isPendingDelete(actorId: number): boolean {
+    return this.pendingDelete.has(actorId);
+  }
+
   private onGameLoad() {
+    this.pendingDelete.clear();
+
     let player = this.sp.Game.getPlayer();
     if (!player) {
       return;
@@ -31,7 +49,51 @@ export class WorldCleanerService extends ClientListener {
   }
 
   private onUpdate() {
+    this.processPendingDeletions();
     this.processOneActor();
+  }
+
+  private processPendingDeletions() {
+    if (this.pendingDelete.size === 0) {
+      return;
+    }
+
+    const readyForDelete: number[] = [];
+    const abandoned: number[] = [];
+    this.pendingDelete.forEach((state, actorId) => {
+      if (!state.disabled) {
+        state.ticksWaitingForDisable++;
+        if (state.ticksWaitingForDisable > MAX_DISABLE_WAIT_TICKS) {
+          abandoned.push(actorId);
+        }
+        return;
+      }
+      if (state.ticksRemaining > 0) {
+        state.ticksRemaining--;
+        return;
+      }
+      readyForDelete.push(actorId);
+    });
+
+    for (const actorId of abandoned) {
+      this.pendingDelete.delete(actorId);
+      logTrace(this, "Pending delete: disable never resolved, dropping", actorId.toString(16));
+    }
+
+    for (const actorId of readyForDelete) {
+      this.pendingDelete.delete(actorId);
+      const ac = this.sp.Actor.from(this.sp.Game.getFormEx(actorId));
+      if (!ac) {
+        logTrace(this, "Pending delete: form gone, dropping", actorId.toString(16));
+        continue;
+      }
+      if (this.isActorInDialogue(ac)) {
+        logTrace(this, "Pending delete: actor entered dialogue, aborting delete", actorId.toString(16));
+        continue;
+      }
+      logTrace(this, "Pending delete: final delete", actorId.toString(16));
+      ac.delete();
+    }
   }
 
   private processOneActor() {
@@ -51,6 +113,10 @@ export class WorldCleanerService extends ClientListener {
     }
 
     const actorId = actor.getFormID();
+
+    if (this.pendingDelete.has(actorId)) {
+      return;
+    }
 
     const currentProtection = this.protection.get(actorId) || 0;
     if (currentProtection > 0) {
@@ -98,12 +164,18 @@ export class WorldCleanerService extends ClientListener {
       }
     }
 
+    // Deferred delete: mark pending, disable, then delete N ticks after disable resolves.
+    const state: PendingDeleteState = { disabled: false, ticksRemaining: DELETE_DELAY_TICKS, ticksWaitingForDisable: 0 };
+    this.pendingDelete.set(actorId, state);
+    logTrace(this, "Pending delete: scheduling disable", actorId.toString(16));
+
     actor.disable(false).then(() => {
-      const ac = this.sp.Actor.from(this.sp.Game.getFormEx(actorId));
-      if (!ac || this.isActorInDialogue(ac)) {
+      const currentState = this.pendingDelete.get(actorId);
+      if (!currentState) {
         return;
       }
-      ac.delete();
+      currentState.disabled = true;
+      logTrace(this, "Pending delete: disable resolved", actorId.toString(16));
     });
   }
 
@@ -112,6 +184,7 @@ export class WorldCleanerService extends ClientListener {
   }
 
   private protection = new Map<number, number>();
+  private pendingDelete = new Map<number, PendingDeleteState>();
   private initialPos?: NiPoint3;
   private initialCellOrWorld?: number;
 }

--- a/skymp5-client/src/view/formView.ts
+++ b/skymp5-client/src/view/formView.ts
@@ -36,6 +36,18 @@ export class FormView {
   constructor(private remoteRefrId?: number) { }
 
   update(model: FormModel): void {
+    // Pending-delete guard: skip the whole update pass for actors queued
+    // for deletion. Without this, the pre-applyAll portion of update()
+    // can still respawn the actor via placeAtMe, rewrite setDisplayName
+    // in-place, or force appearance/base rebuilds while the delete
+    // countdown is running.
+    if (this.refrId !== 0) {
+      const worldCleanerService = SpApiInteractor.getControllerInstance().lookupListener(WorldCleanerService);
+      if (worldCleanerService.isPendingDelete(this.refrId)) {
+        return;
+      }
+    }
+
     // Other players mutate into PC clones when moving to another location
     if (model.movement) {
       if (!this.lastWorldOrCell)
@@ -338,6 +350,16 @@ export class FormView {
   private isSetNodeScaleApplied = false;
 
   private applyAll(refr: ObjectReference, model: FormModel) {
+    // Pending-delete guard: skip all remote-actor state application if
+    // WorldCleanerService has queued this actor for deletion. Continuing
+    // to push movement / animation / appearance / equipment through here
+    // during the pending window re-arms the queued-job crash the delete
+    // lifecycle is meant to avoid.
+    const worldCleanerService = SpApiInteractor.getControllerInstance().lookupListener(WorldCleanerService);
+    if (worldCleanerService.isPendingDelete(refr.getFormID())) {
+      return;
+    }
+
     let forcedWeapDrawn: boolean | null = null;
 
     if (PlayerCharacterDataHolder.getCrosshairRefId() === this.refrId) {
@@ -646,6 +668,12 @@ export class FormView {
   };
 
   private tryHostIfNeed(ac: Actor, remoteId: number) {
+    // Do not attempt to become host of an actor already queued for delete.
+    const worldCleanerService = SpApiInteractor.getControllerInstance().lookupListener(WorldCleanerService);
+    if (worldCleanerService.isPendingDelete(ac.getFormID())) {
+      return false;
+    }
+
     const last = lastTryHost[remoteId];
     if (!last || Date.now() - last >= 1000) {
       lastTryHost[remoteId] = Date.now();


### PR DESCRIPTION
Marks actors as pending-delete, disables them, and deletes them N update ticks later instead of doing an immediate disable→delete. Every remote-actor path (movement, animation, gameplay, hosting, hits) now checks isPendingDelete() and skips actors in the pipeline, so queued engine jobs can't fire against a freed actor and crash the game.