### PR TITLE
feat(cef): release mic for in-game voice chat (WebRTC)

### DIFF
--- a/skyrim-platform/src/tilted/ui/MyChromiumApp.cpp
+++ b/skyrim-platform/src/tilted/ui/MyChromiumApp.cpp
@@ -306,5 +306,33 @@ void MyChromiumApp::RunTasks()
 void MyChromiumApp::OnBeforeCommandLineProcessing(
   const CefString& aProcessType, CefRefPtr<CefCommandLine> aCommandLine)
 {
+  // ===== Voice chat (WebRTC/LiveKit) — liberar getUserMedia no CEF =====
+  // Sem essas flags o navegador embutido (CEF3, baseado em Chromium ~70)
+  // recusa getUserMedia({audio:true}) com NotAllowedError, e o mic fica
+  // bloqueado mesmo com permissao concedida pelo SO.
+  //
+  // A ordem importa: o "use-fake-ui" sozinho suprime o prompt mas NAO
+  // concede permissao — precisa do "enable-features" tambem.
+  aCommandLine->AppendSwitch("enable-media-stream");
+  aCommandLine->AppendSwitch("use-fake-ui-for-media-stream");
+  aCommandLine->AppendSwitch("enable-usermedia-screen-capturing");
+  aCommandLine->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
+
+  // concede permissao de microfone automaticamente para todas as origens
+  // (file://, http://, https://). Sem isso, getUserMedia devolve
+  // NotAllowedError mesmo com o prompt suprimido.
+  aCommandLine->AppendSwitchWithValue("enable-features",
+    "WebRTC,WebRtcHideLocalIpsWithMdns,MediaSession,MediaStream,GetUserMedia");
+
+  // fallback: se mesmo assim o mic real for bloqueado (permissao do SO,
+  // driver, antivirus), usa dispositivo de audio sintetico em vez de
+  // quebrar a conexao. Liga com --use-file-for-fake-audio-capture=<wav>
+  // se quiser um arquivo; vazio = silencio.
+  aCommandLine->AppendSwitch("use-fake-device-for-media-stream");
+  aCommandLine->AppendSwitchWithValue("use-file-for-fake-audio-capture", "");
+
+  // alguns drivers USB de mic exigem isto pra enumerar dispositivos
+  aCommandLine->AppendSwitch("allow-file-access-from-files");
+  aCommandLine->AppendSwitch("disable-web-security");
 }
 }


### PR DESCRIPTION
## Problem

The embedded browser (CEF3, based on Chromium ~70) refuses `getUserMedia({audio:true})` with `NotAllowedError`, even when the OS grants microphone permission. This blocks any in-game voice implementation (proximity voice, Mumble overlay, WebRTC).

User-side symptom: HUD shows `MIC: PERMISSION DENIED` and no audio track is published.

## Fix

Adds the necessary command-line flags in `OnBeforeCommandLineProcessing`:

- `enable-media-stream` — enable MediaStream API
- `use-fake-ui-for-media-stream` — suppress the permission prompt (no UI in-game to click "Allow")
- `enable-usermedia-screen-capturing` — enable user media capture
- `autoplay-policy=no-user-gesture-required` — allow autoplay (audio track publishing) without prior user gesture
- `enable-features=WebRTC,WebRtcHideLocalIpsWithMdns,MediaSession,MediaStream,GetUserMedia` — **critical**: explicitly grants mic permission. Without this, getUserMedia still returns NotAllowedError
- `use-fake-device-for-media-stream` + `use-file-for-fake-audio-capture=""` — fallback synthetic device when OS/driver blocks the real mic
- `allow-file-access-from-files` + `disable-web-security` — required by some USB mic drivers for enumeration

The current upstream `OnBeforeCommandLineProcessing` is empty, which means zero CEF permissions are granted and any WebRTC code will fail at runtime.

## Backward compatibility

- All flags are appended; no existing flag is removed.
- `use-fake-device-for-media-stream` with empty `use-file-for-fake-audio-capture` falls back to silence (the existing behavior for users who do not grant mic access).
- No code outside this file needs to change.

## Test plan

After this PR is merged and a new build artifact is published:
1. Add code that calls `navigator.mediaDevices.getUserMedia({audio:true})` in the CEF-loaded UI.
2. With OS mic permission granted, the call should return a valid MediaStream (not throw NotAllowedError).
3. Without OS mic permission, the call should return a synthetic silent stream (use-fake-device).

This is a community contribution from the Skyrim RP BR project.