### PR TITLE
internal: disable dependabot updates for skymp5-front

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/skymp5-front"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` that suppresses Dependabot version and security PRs for `/skymp5-front` via `open-pull-requests-limit: 0` + `ignore: "*"`.
- Existing open Dependabot PRs against `/skymp5-front` were closed: #2781, #2775, #2772, #2771, #2768, #2763.

## Test plan
- [ ] Confirm no new Dependabot PRs open for `/skymp5-front` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)