### PR TITLE
internal: add Contributor Assignment Agreement (Harmony CAA)

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # SkyMP Individual / Entity Contributor Assignment Agreement
 
-Thank you for your interest in contributing to SkyMP ("We" or "Us").
+Thank you for your interest in contributing to SkyMP (the "Project"). This Agreement is entered into with Limited Liability Partnership "POSPELOV SOFT", BIN 230440011026, a legal entity organized under the laws of the Republic of Kazakhstan ("We" or "Us"), which manages the Project.
 
 This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign it electronically through the CLA Assistant bot, which will comment on your first pull request to Us with a signing link. This is a legally binding document, so please read it carefully before agreeing to it. The Agreement may cover more than one software project managed by Us.
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,97 @@
+# SkyMP Individual / Entity Contributor Assignment Agreement
+
+Thank you for your interest in contributing to SkyMP ("We" or "Us").
+
+This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign it electronically through the CLA Assistant bot, which will comment on your first pull request to Us with a signing link. This is a legally binding document, so please read it carefully before agreeing to it. The Agreement may cover more than one software project managed by Us.
+
+## 1. Definitions
+
+"You" (Individual) means the individual who Submits a Contribution to Us.
+
+"You" (Entity) means any Legal Entity on behalf of whom a Contribution has been received by Us. "Legal Entity" means an entity which is not a natural person. "Affiliates" means other Legal Entities that control, are controlled by, or under common control with that Legal Entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such Legal Entity, whether by contract or otherwise, (ii) ownership of fifty percent (50%) or more of the outstanding shares or securities which vote to elect the management or other persons who direct such Legal Entity or (iii) beneficial ownership of such entity.
+
+"Contribution" means any work of authorship that is Submitted by You to Us in which You own or assert ownership of the Copyright. If You do not own the Copyright in the entire work of authorship, please contact the maintainers at https://github.com/skyrim-multiplayer/skymp/issues before Submitting.
+
+"Copyright" means all rights protecting works of authorship owned or controlled by You [or Your Affiliates], including copyright, moral and neighboring rights, as appropriate, for the full term of their existence including any extensions by You.
+
+"Material" means the work of authorship which is made available by Us to third parties. When this Agreement covers more than one software project, the Material means the work of authorship to which the Contribution was Submitted. After You Submit the Contribution, it may be included in the Material.
+
+"Submit" means any form of electronic, verbal, or written communication sent to Us or our representatives, including but not limited to electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us for the purpose of discussing and improving the Material, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution to Us.
+
+"Effective Date" means the date You execute this Agreement or the date You first Submit a Contribution to Us, whichever is earlier.
+
+"Media" means any portion of a Contribution which is not software.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright Assignment
+
+(a) At the time the Contribution is Submitted, You assign to Us all right, title, and interest worldwide in all Copyright covering the Contribution; provided that this transfer is conditioned upon compliance with Section 2.3.
+
+(b) To the extent that any of the rights in Section 2.1(a) cannot be assigned by You to Us, You grant to Us a perpetual, worldwide, exclusive, royalty-free, transferable, irrevocable license under such non-assigned rights, with rights to sublicense through multiple tiers of sublicensees, to practice such non-assigned rights, including, but not limited to, the right to reproduce, modify, display, perform and distribute the Contribution; provided that this license is conditioned upon compliance with Section 2.3.
+
+(c) To the extent that any of the rights in Section 2.1(a) can neither be assigned nor licensed by You to Us, You irrevocably waive and agree never to assert such rights against Us, any of our successors in interest, or any of our licensees, either direct or indirect; provided that this agreement not to assert is conditioned upon compliance with Section 2.3.
+
+(d) Upon such transfer of rights to Us, to the maximum extent possible, We immediately grant to You a perpetual, worldwide, non-exclusive, royalty-free, transferable, irrevocable license under such rights covering the Contribution, with rights to sublicense through multiple tiers of sublicensees, to reproduce, modify, display, perform, and distribute the Contribution. The intention of the parties is that this license will be as broad as possible and to provide You with rights as similar as possible to the owner of the rights that You transferred. This license back is limited to the Contribution and does not provide any rights to the Material.
+
+### 2.2 Patent License
+
+For patent claims including, without limitation, method, process, and apparatus claims which You [or Your Affiliates] own, control or have the right to grant, now or in the future, You grant to Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable patent license, with the right to sublicense these rights to multiple tiers of sublicensees, to make, have made, use, sell, offer for sale, import and otherwise transfer the Contribution and the Contribution in combination with the Material (and portions of such combination). This license is granted only to the extent that the exercise of the licensed rights infringes such patent claims; and provided that this license is conditioned upon compliance with Section 2.3.
+
+### 2.3 Outbound License
+
+Based on the grant of rights in Sections 2.1 and 2.2, if We include Your Contribution in a Material, We may license the Contribution under any license, including copyleft, permissive, commercial, or proprietary licenses. As a condition on the exercise of this right, We agree to also license the Contribution under the terms of the license or licenses which We are using for the Material on the Submission Date.
+
+In addition, We may use the following licenses for Media in the Contribution: Creative Commons Attribution 4.0 International (CC-BY 4.0), Creative Commons Attribution-ShareAlike 4.0 International (CC-BY-SA 4.0) (including any right to adopt any future version of a license if permitted).
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by law, You waive and agree not to assert such moral rights against Us or our successors in interest, or any of our licensees, either direct or indirect.
+
+### 2.5 Our Rights
+
+You acknowledge that We are not obligated to use Your Contribution as part of the Material and may decide to include any Contribution We consider appropriate.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly assigned or licensed under this section are expressly reserved by You.
+
+## 3. Agreement
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You [or Your Affiliates] own the Copyright and patent claims covering the Contribution which are required to grant the rights under Section 2.
+
+(c) (Individual) The grant of rights under Section 2 does not violate any grant of rights which You have made to third parties, including Your employer. If You are an employee, You have had Your employer approve this Agreement or sign the Entity version of this document. If You are less than eighteen years old, please have Your parents or guardian sign the Agreement.
+
+(c) (Entity) The grant of rights under Section 2 does not violate any grant of rights which You or Your Affiliates have made to third parties.
+
+(d) You have contacted the maintainers as described in Section 1 above, if You do not own the Copyright in the entire work of authorship Submitted.
+
+## 4. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+## 5. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR US BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+## 6. Miscellaneous
+
+6.1 This Agreement will be governed by and construed in accordance with the laws of the Republic of Kazakhstan excluding its conflicts of law provisions. Under certain circumstances, the governing law in this section might be superseded by the United Nations Convention on Contracts for the International Sale of Goods ("UN Convention") and the parties intend to avoid the application of the UN Convention to this Agreement and, thus, exclude the application of the UN Convention in its entirety to this Agreement.
+
+6.2 This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and overrides all other agreements or understandings.
+
+6.3 If You or We assign the rights or obligations received through this Agreement to a third party, as a condition of the assignment, that third party must agree in writing to abide by all the rights and obligations in the Agreement.
+
+6.4 The failure of either party to require performance by the other party of any provision of this Agreement in one situation shall not affect the right of a party to require such performance at any time in the future. A waiver of performance under a provision in one situation shall not be considered a waiver of the performance of the provision in the future or a waiver of the provision in its entirety.
+
+6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.
+
+---
+
+This Agreement is based on the Harmony Combined Contributor Agreement Template Version 1.0 (Contributor Assignment Agreement variant, Outbound License Option Five), available at https://harmonyagreements.org. The Harmony template is licensed under a [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
## Summary
- Adds `CLA.md` at repo root with a Contributor Assignment Agreement.
- Based on the [Harmony Combined Contributor Agreement Template v1.0](https://harmonyagreements.org):
  - **CAA variant** (Copyright Assignment) — contributors assign copyright to Us.
  - **Outbound License Option Five** — We may relicense under any license (copyleft, permissive, commercial, or proprietary), while also releasing under the project's inbound license(s) on the Submission Date.
  - Combined Individual + Entity form.
  - Governing law: Republic of Kazakhstan.
- A public gist mirror of the same text has been created for CLA Assistant to consume:
  https://gist.github.com/Pospelove/a57b2952d859df104a4ba2d1eaec9df2

## Follow-up (to be done in the GitHub UI, not this PR)
1. Sign in at https://cla-assistant.io with the `skyrim-multiplayer` GitHub account and grant OAuth access.
2. Click **Configure CLA**, select the `skyrim-multiplayer/skymp` repo (or apply org-wide).
3. Paste the gist URL above as the CLA source.
4. Optional: enable "allowlist" for bot accounts (dependabot etc.) to avoid CLA prompts on their PRs.
5. Merging this PR does **not** yet enforce the CLA — enforcement begins once the app is configured in the UI.

## Test plan
- [ ] After the bot is enabled, open a test PR from a second account and verify the bot comments with a signing link.
- [ ] Verify a signed PR shows a green CLA check.
- [ ] Verify an unsigned PR shows a red CLA check that blocks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)