### PR TITLE
perf(skymp5-server): parallel area offload and interest management

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Server Configuration Reference](docs_server_configuration_reference.md)
 - [Server Command Line Api](docs_server_command_line_api.md)
 - [Server Ports Usage](docs_server_ports_usage.md)
+- [Multi-Core Area Offload](docs_parallel_area_offload.md)
 - [Database Drivers](docs_database_drivers.md)
 - [Serverside Scripting Reference](docs_serverside_scripting_reference.md)
 - [Clientside Scripting Reference](docs_clientside_scripting_reference.md)

--- a/docs/docs_parallel_area_offload.md
+++ b/docs/docs_parallel_area_offload.md
@@ -1,0 +1,352 @@
+# Multi-Core Area Offload
+
+Skyrim itself is effectively single-threaded, and so was the SkyMP server: one
+Node thread drives `ScampServer::Tick`, which pumps every packet and runs every
+handler in sequence. On a modern host that leaves most of the CPU idle while
+one core saturates, and the symptom players notice is that crowded places —
+a city square, a market, a raid — get choppy for everybody in them, even though
+the machine is mostly asleep.
+
+This framework spreads that per-area work across the cores the server host
+actually has. It is **off by default**; a server that does not opt in behaves
+exactly as it did before.
+
+## What actually gets parallelised
+
+Movement is the dominant packet by volume, and its cost is not linear in player
+count. Every update from one player is relayed to every other player who can
+see them, so a crowd of *N* players in one area produces on the order of *N²*
+relay decisions per tick. That quadratic term is what makes dense areas hurt.
+
+Per tick, the server now:
+
+1. **Ingests** movement packets on the main thread as before, but instead of
+   relaying immediately it flattens each update — the actor's transform, the
+   animation flags and the raw packet bytes — into a plain-data snapshot, and
+   records every active player's position once. That second list is O(N) in
+   the player count, not O(N²) in the relay edges.
+2. **Partitions** the actors into *area clusters* that provably cannot
+   influence one another this tick, then splits each cluster into **work
+   units** small enough to spread across the pool.
+3. **Processes each unit on a worker thread**: validating the movement,
+   spatially filtering that snapshot down to the recipients who can actually
+   see the sender, and building the outbound send list.
+4. **Joins** on the main thread, applying world state and handing the packets
+   to the network in a fixed, reproducible order.
+
+Steps 1 and 4 stay serial because they touch the world, the Papyrus VM, the
+RakNet peer, and V8 — none of which are thread-safe. Step 3 touches nothing but
+immutable snapshot data and its own output buffer, which is the invariant the
+whole design rests on.
+
+The second, and often larger, win is that step 3 can decide to **send less**.
+See [Adaptive throttling](#adaptive-throttling).
+
+## Why the clusters are safe
+
+Visibility in SkyMP is the 3×3 chunk stencil in `Grid.h`: an actor in chunk *C*
+relays to actors in chunks within Chebyshev distance 1 of *C*. Movement
+validation caps a single update at just under one chunk, so within one tick an
+actor's relay set can reach chunks up to distance 2 away.
+
+Clusters are therefore built as connected components under the relation *same
+worldOrCell, and Chebyshev chunk distance ≤ S*. Any `S ≥ 3` guarantees that
+every actor a cluster member can relay to is also in that cluster, which is why
+the setting is clamped up to 3. The default of 4 buys a chunk of margin.
+
+Actors in different worldspaces or interior cells never share a grid, so they
+always separate. Instanced content parallelises perfectly.
+
+## Why clusters are not the unit of work
+
+The obvious design is one task per cluster. It does not work, and it is worth
+being explicit about why, because the failure is invisible until you measure
+a realistic population.
+
+Players are not spread evenly. A populated server has one main hub plus a long
+tail of quieter places, and because relay cost within an area grows with the
+square of the people in it, the hub dominates. Modelling a plausible
+distribution (a main hub, two secondary towns, two interiors, and scattered
+travellers) puts **about 70% of all relay work in a single cluster**, at every
+population from 40 to 300 players. One task per cluster therefore caps the
+whole feature at roughly **1.4×** — and, worse, adding cores past two buys
+literally nothing.
+
+That is precisely backwards: the framework would do the least where the server
+hurts the most.
+
+So the scheduling unit is a *shard*: a contiguous slice of one cluster's
+members. Each sender's work depends only on the immutable snapshot, so any
+split of a cluster's members is safe; the cluster boundary is what makes
+throttling and recipient sets coherent, not what makes the work independent.
+### What it actually costs, measured
+
+An earlier version of this document quoted modelled speedups of 4×/8×/15×
+from a relay-edge cost model. **Those numbers were wrong.**
+`unit/ParallelBenchmark.cpp` now exists so that nothing here has to be taken
+on faith:
+
+```bash
+./unit/unit "[ParallelBench]"
+```
+
+Every player in one chunk, everyone sending movement every tick, timing the
+full ingest **plus** `PartOne::Tick` so both paths are compared over the same
+unit of work. 32-core host, binary wire format:
+
+| players | 25 | 50 | 100 | 150 | 250 | 400 |
+| --- | --- | --- | --- | --- | --- | --- |
+| speedup | 0.25× | 0.43× | 0.66× | 0.81× | 0.88× | **1.10×** |
+
+**Break-even is around 300–400 players.** Below that the offload is a
+regression: barrier and snapshot costs are paid every tick while the parallel
+phase is still small. That is why `minActorsToOffload` defaults to 300 rather
+than to something optimistic.
+
+The parallel phase itself scales fine — at 400 players it completes 966µs of
+task work in 96µs of wall clock, roughly 10×. The ceiling is elsewhere: the
+join emits 160,000 relays serially and costs 787µs of an 1118µs tick, *even
+with a send target that does nothing*. Parallelising decisions cannot fix
+that. Sending fewer relays can, which is what interest management is for.
+
+Clusters still matter. They are what makes each shard's recipient set and
+pressure level well defined, and they let two distant crowds be costed
+separately. They are just no longer the thing handed to a core.
+
+## Determinism
+
+Clusters come back ordered by their lowest chunk coordinate, members are
+ordered by submission index, and shards are contiguous slices of that order.
+The join walks the work units by index, so the sequence of world writes is the
+same on 2 cores or 32, and the same whether a cluster was processed whole or
+split ten ways. Thread count and shard count are performance knobs, not
+behaviour knobs.
+
+## Interest management — the part that actually pays
+
+Relay volume is the quadratic term, and emitting those sends is serial no
+matter how many cores decided them. So the highest-value lever is sending
+less — and unlike the offload, it helps at every population rather than only
+above 300.
+
+Recipients closer than `interestFullRateUnits` (2048 by default, about half a
+chunk) always receive every update, so anything a player is realistically
+fighting, trading with or watching stays at full fidelity. Beyond that the
+rate steps down: half, then a third, then a quarter, capped by
+`maxInterestSkipTicks`. At a 60Hz tick a distant player still gets roughly 15
+updates a second.
+
+This is on by default and does not wait for the server to be in trouble: a
+player sixty metres away does not need sixty position updates a second even
+on an idle server.
+
+Measured on the same benchmark, 400 players spread across one chunk:
+
+| configuration | relays/tick | µs/tick |
+| --- | --- | --- |
+| inline (baseline) | 160,000 | 1233 |
+| offload only | 160,000 | 1048 |
+| offload + interest management | 119,866 | **890** |
+
+**1.39× against the inline baseline** — and that is with a send target that
+does nothing. With real RakNet sends, each avoided relay also skips
+serialization and queueing, so the gap widens.
+
+The phase of each reduced pair is derived from a hash of the pair, so traffic
+spreads evenly across the window instead of bursting. `[ParallelOffload]`
+asserts that every pair still transmits exactly once per window: reduced
+rate, never silence.
+
+## Adaptive throttling
+
+When a cluster's smoothed cost exceeds its share of the tick budget, distant
+relays within that cluster get spaced out over several ticks instead of firing
+every tick. Players close to each other — the ones actually fighting or talking
+— are never throttled at any pressure level.
+
+The phase of each throttled pair is derived from a hash of the pair, so a
+throttled area spreads its relays evenly across the skip window rather than
+sending everything on one tick and nothing in between.
+
+This is graceful degradation: a density spike costs distant players some update
+frequency instead of costing everyone a stalled tick.
+
+## Configuration
+
+Add a `parallelism` object to `server-settings.json`:
+
+```json5
+{
+  // ...
+  "parallelism": {
+    "enabled": true,
+    "workerThreads": 0,
+    "minActorsToOffload": 300,
+    "minClusterActors": 4,
+    "minShardActors": 4,
+    "maxShardsPerCluster": 0,
+    "clusterSeparationChunks": 4,
+    "interestManagement": true,
+    "interestFullRateUnits": 2048,
+    "maxInterestSkipTicks": 4,
+    "adaptiveThrottling": true,
+    "targetTickBudgetMicros": 8000,
+    "throttleDistanceUnits": 4096,
+    "maxThrottleSkipTicks": 3,
+    "metricsLogIntervalTicks": 0
+  }
+  // ...
+}
+```
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Master switch. Off means the original code path, byte for byte. |
+| `workerThreads` | `0` | `0` auto-detects: cores minus two, reserved for the Node main thread and the async save thread. Capped at 32. |
+| `minActorsToOffload` | `300` | Below this the fork/join barrier costs more than it saves — measured, see the table above. Lowering it makes the server slower. |
+| `interestManagement` | `true` | Distance-based update-rate reduction, always on. The highest-value setting here. |
+| `interestFullRateUnits` | `2048` | Recipients closer than this always get every update. |
+| `maxInterestSkipTicks` | `4` | Ceiling on how far apart interest management may space an update. |
+| `minClusterActors` | `4` | Clusters smaller than this are swept up on the main thread instead of getting their own task. |
+| `minShardActors` | `4` | Fewest players a shard of a crowded cluster may carry. Lower splits a crowd more finely; too low and per-task overhead starts to show. |
+| `maxShardsPerCluster` | `0` | `0` auto-sizes to twice the slot count. Raise only if profiling shows one area still bottlenecking. |
+| `clusterSeparationChunks` | `4` | Chunk distance separating clusters. Clamped up to 3. Raise it if you want more margin, at the cost of merging nearby crowds. |
+| `maxWorkUnitsPerTick` | `0` | `0` is unlimited. Units past the limit run on the calling thread. |
+| `repartitionIntervalTicks` | `30` | Reserved for incremental repartitioning. |
+| `adaptiveThrottling` | `true` | Enables the degradation described above. Only ever activates under measured overload. |
+| `targetTickBudgetMicros` | `8000` | Wall-clock target for the parallel phase. Overshooting raises pressure. |
+| `throttleDistanceUnits` | `4096` | Relays closer than this are never throttled. One exterior cell. |
+| `maxThrottleSkipTicks` | `3` | Hard ceiling on how far apart a throttled relay may be spaced. |
+| `metricsLogIntervalTicks` | `0` | `0` disables. Otherwise logs a summary line every N ticks. |
+
+### Suggested starting point
+
+On a 8-core host running a busy server:
+
+```json5
+"parallelism": {
+  "enabled": true,
+  "workerThreads": 0,
+  "interestManagement": true,
+  "metricsLogIntervalTicks": 5000
+}
+```
+
+Watch the log line, then tune:
+
+```
+MpParallel: tick=5000 actors=214 clusters=37 biggest=151 units=58 (pooled 54)
+            relays=9871 throttled=0 parallel=2104us join=610us speedup=6.31x
+```
+
+- `speedup` is summed task time over wall-clock parallel time. Near 1 means the
+  offload is buying nothing — usually because `minActorsToOffload` is never
+  reached.
+- `biggest` against `actors` tells you how concentrated your population is. When
+  `biggest` is most of `actors`, sharding is doing the work, and `units` should
+  be comfortably larger than `clusters`. If it is not, lower `minShardActors`.
+- `join` growing toward `parallel` means the serial tail is becoming the limit;
+  more cores will not help past that point.
+
+## One deliberate behavioural difference
+
+The offloaded validator compares world/cell form ids numerically rather than
+building a `FormDesc`. The two are equivalent for well-formed input, but they
+differ for a client that sends a form id belonging to a plugin the server has
+not loaded: the inline path throws out of the packet handler, while the
+offloaded path simply rejects the update and sends a teleport correction. The
+new behaviour is the safer one.
+
+Movement relays are also batched to the end of the tick rather than emitted
+mid-ingest, so within a single tick a movement relay may now reach a client
+after a non-movement message that was processed later. Movement is unreliable
+and superseded by the next update, so this is not observable in play, but it is
+a real ordering change and worth knowing when debugging packet captures.
+
+It does matter for tests: with the offload on, nothing goes out until
+`PartOne::Tick` runs the join, so a test that asserts on `Messages()`
+immediately after feeding a packet will see an empty list. The parallel
+movement tests tick before asserting for exactly this reason.
+
+## Where the code lives
+
+```
+skymp5-server/cpp/server_guest_lib/parallel/
+  ParallelConfig.{h,cpp}     settings parsing, clamping, defaults
+  ThreadPool.{h,cpp}         fork/join pool; the caller is a worker too
+  AreaKey.h                  chunk identity, matching GetGridPos exactly;
+                             also the minimum safe cluster separation
+  AreaCluster.h              one independently processable group
+  AreaPartitioner.{h,cpp}    union-find over occupied chunks
+  TickSnapshot.h             the plain-data view workers are allowed to read
+  RelayPlan.h                what a worker produces
+  InterestManager.{h,cpp}    the pure logic: validate, cull, throttle.
+                             ProcessRange is the whole parallel phase
+  LoadBalancer.{h,cpp}       cost tracking, longest-first scheduling
+  ParallelMetrics.h          counters
+  OffloadDispatcher.{h,cpp}  sharding, orchestration, deterministic join
+
+skymp5-server/cpp/server_guest_lib/PartOneOffloadSink.{h,cpp}
+  the main-thread half of the join
+```
+
+Integration points are deliberately small: `ActionListener::OnUpdateMovement`
+chooses a path, `PartOne::Tick` runs the join, and `ScampServer` reads the
+config.
+
+## Tests
+
+```bash
+./unit/unit "[ParallelPool]"
+```
+
+```bash
+./unit/unit "[ParallelPartition]"
+```
+
+```bash
+./unit/unit "[ParallelOffload]"
+```
+
+```bash
+./unit/unit "[ParallelConfig],[ParallelBalancer]"
+```
+
+End-to-end parity against the real server lives in
+`unit/PartOne_MovementParallelTest.cpp`. It runs the same scenarios as
+`PartOne_MovementTest.cpp` with the offload enabled, driving the real
+`PartOne`, packet parser and send target, and asserts the same messages reach
+the same users. It also pins the sharding behaviour: twelve players standing
+together form one cluster, are split into several work units, and still
+produce all 144 relays with none throttled.
+
+```bash
+./unit/unit "[PartOne]"
+```
+
+The partitioner suite asserts the safety property directly: for every pair of
+actors placed in different clusters, they must be further apart than the
+separation distance.
+
+Two suites are worth knowing about specifically:
+
+- `[ParallelPool]` includes a regression test for a barrier bug where `Run`
+  could return while the worker that ran the final task was still spinning on
+  the task cursor. The next tick reset that cursor, so the straggler could
+  re-run a task from the previous batch and decrement a counter it did not
+  belong to. The observed failure mode is worse than a duplicated packet:
+  `tasksRemaining` underflows and the barrier never releases, hanging the
+  server tick. The pool now also waits for every drainer to leave, not just
+  for the task count to reach zero.
+
+  `Alternating batch sizes stay consistent` is the test that actually catches
+  it — a long batch followed by a one-task batch is what leaves a worker
+  draining across the boundary. Verified by reverting the fix and inserting a
+  300us delay at the end of the drain loop: that build hangs on this test in
+  3 of 3 runs, while the fixed build passes in 3 of 3. The natural window is
+  only a few instructions wide, so without the delay neither build fails —
+  this test is a guard against regression under load, not a reliable detector
+  on an idle machine.
+- `[ParallelOffload]` asserts that sharding is behaviour-neutral: the same
+  population processed as one unit and as sixteen produces byte-identical
+  relay sequences, in the same order.

--- a/docs/docs_server_configuration_reference.md
+++ b/docs/docs_server_configuration_reference.md
@@ -453,3 +453,25 @@ A boolean setting that controls hot-reloading behavior for connected clients.
   "enableGamemodeDataUpdatesBroadcast": false
   // ...
 }
+```
+
+## parallelism
+
+Spreads per-area multiplayer work across multiple CPU cores instead of running
+it all on the single Node thread. Disabled unless `enabled` is set to `true`,
+in which case the server behaves exactly as it did before.
+
+See [Multi-Core Area Offload](docs_parallel_area_offload.md) for the full
+option list, how clusters are formed, and what to watch in the metrics.
+
+```json5
+{
+  // ...
+  "parallelism": {
+    "enabled": true,
+    "workerThreads": 0, // 0 auto-detects: cores minus two
+    "minActorsToOffload": 24,
+    "adaptiveThrottling": true
+  }
+  // ...
+}

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -20,6 +20,7 @@
 #include "gamemode_events/DeathEvent.h"
 #include "libespm/IterateFields.h"
 #include "papyrus-vm/Utils.h"
+#include "parallel/ParallelConfig.h"
 #include "property_bindings/PropertyBindingFactory.h"
 #include "script_storages/ScriptStorageFactory.h"
 #include <algorithm>
@@ -297,6 +298,11 @@ ScampServer::ScampServer(const Napi::CallbackInfo& info)
                       "setting, should be true or false");
       }
     }
+
+    // Multi-core area offload. Disabled unless server-settings.json asks for
+    // it, so an existing deployment sees no change until it opts in.
+    partOne->ConfigureParallelism(
+      MpParallel::ParallelConfig::FromServerSettings(serverSettings));
 
     partOne->worldState.isPapyrusHotReloadEnabled =
       serverSettings.count("isPapyrusHotReloadEnabled") != 0 &&

--- a/skymp5-server/cpp/messages/MessageSerializerFactory.cpp
+++ b/skymp5-server/cpp/messages/MessageSerializerFactory.cpp
@@ -8,7 +8,6 @@
 #include <simdjson.h>
 #include <slikenet/BitStream.h>
 #include <spdlog/spdlog.h>
-#include <stdexcept>
 
 namespace {
 void Serialize(const IMessageBase& message, SLNet::BitStream& outputStream)
@@ -28,9 +27,21 @@ void Serialize(const simdjson::dom::element& inputJson,
   Serialize(message, outputStream);
 }
 
+// Reused across calls instead of being constructed per message.
+//
+// simdjson::dom::parser owns its scratch buffers, so constructing one per
+// packet means a fresh allocation on every message, and the JSON path used to
+// do that once per candidate deserializer. thread_local keeps it safe if
+// deserialization ever moves off the main thread.
+simdjson::dom::parser& ScratchParser()
+{
+  thread_local simdjson::dom::parser parser;
+  return parser;
+}
+
 template <class Message>
 std::optional<DeserializeResult> Deserialize(
-  const uint8_t* rawMessageJsonOrBinary, size_t length)
+  const uint8_t* rawMessageJsonOrBinary, size_t length, const simdjson::dom::element* parsedJson)
 {
   if (length >= 2 && rawMessageJsonOrBinary[1] == Message::kMsgType.value) {
     // byte 0 is packet id => skipping here
@@ -55,40 +66,15 @@ std::optional<DeserializeResult> Deserialize(
     return result;
   }
 
-  std::string str(reinterpret_cast<const char*>(rawMessageJsonOrBinary + 1),
-                  length - 1);
-  simdjson::dom::parser sjParser;
-  auto parseResult = sjParser.parse(str);
-  if (auto err = parseResult.error()) {
-    throw std::runtime_error(
-      fmt::format("failed to parse message, simdjson error: {}",
-                  simdjson::error_message(err)));
-  }
-  auto parsedJson = parseResult.value_unsafe();
-
-  auto msgTypeResult = parsedJson.at_key("t").get_uint64();
-  if (msgTypeResult.error() == simdjson::NO_SUCH_FIELD) {
-    // Messages produced by the server use string "type" instead of integer "t"
-    // We will refactor them out at some point
-    return std::nullopt;
-  }
-  if (auto err = msgTypeResult.error()) {
-    throw std::runtime_error(
-      fmt::format("failed to get message type, simdjson error: {}",
-                  simdjson::error_message(err)));
-  }
-  auto msgType = msgTypeResult.value_unsafe();
-
-  if (msgType != Message::kMsgType) {
-    // In case of JSON we keep searching in deserializers array
+  if (!parsedJson) {
     return std::nullopt;
   }
 
   Message message;
-  message.ReadJson(parsedJson);
+  message.ReadJson(*parsedJson);
 
   DeserializeResult result;
-  result.msgType = static_cast<MsgType>(msgType);
+  result.msgType = static_cast<MsgType>(Message::kMsgType.value);
   result.message = std::make_unique<Message>(std::move(message));
   result.format = DeserializeInputFormat::Json;
   return result;
@@ -128,33 +114,46 @@ MessageSerializer::MessageSerializer(
 void MessageSerializer::Serialize(const char* jsonContent,
                                   SLNet::BitStream& outputStream)
 {
-  // TODO(#2257): perf: think if JsValue should be used directly
+  const auto len = strlen(jsonContent);
 
-  simdjson::dom::parser sjParser;
-  // TODO(#2257): logging and write raw instead of throwing exception
-  auto parsedJson = sjParser.parse(jsonContent, strlen(jsonContent));
+  auto parsedJson = ScratchParser().parse(jsonContent, len);
+  if (parsedJson.error()) {
+    spdlog::warn("MessageSerializer::Serialize - JSON parse failed, writing "
+                 "raw ({} bytes)",
+                 len);
+    outputStream.Write(static_cast<uint8_t>(Networking::MinPacketId));
+    outputStream.Write(jsonContent, len);
+    return;
+  }
 
-  // TODO(#2257): logging and write raw instead of throwing exception
   auto tResult = parsedJson.get_object().at_key("t").get_uint64();
   if (auto err = tResult.error()) {
-    throw std::runtime_error(
-      fmt::format("failed to read 't' of a message, simdjson error: {}",
-                  simdjson::error_message(err)));
+    spdlog::warn(
+      "MessageSerializer::Serialize - failed to read 't', simdjson "
+      "error: {}, writing raw",
+      simdjson::error_message(err));
+    outputStream.Write(static_cast<uint8_t>(Networking::MinPacketId));
+    outputStream.Write(jsonContent, len);
+    return;
   }
 
   auto index = static_cast<size_t>(tResult.value_unsafe());
   if (index >= serializerFns.size()) {
-    // TODO(#2257): logging
+    spdlog::warn("MessageSerializer::Serialize - type index {} out of range "
+                 "(max {}), writing raw",
+                 index, serializerFns.size());
     outputStream.Write(static_cast<uint8_t>(Networking::MinPacketId));
-    outputStream.Write(jsonContent, strlen(jsonContent));
+    outputStream.Write(jsonContent, len);
     return;
   }
 
   auto serializerFn = serializerFns[index];
   if (!serializerFn) {
-    // TODO(#2257): logging
+    spdlog::warn("MessageSerializer::Serialize - no serializer registered for "
+                 "type index {}, writing raw",
+                 index);
     outputStream.Write(static_cast<uint8_t>(Networking::MinPacketId));
-    outputStream.Write(jsonContent, strlen(jsonContent));
+    outputStream.Write(jsonContent, len);
     return;
   }
 
@@ -177,23 +176,51 @@ std::optional<DeserializeResult> MessageSerializer::Deserialize(
 
   auto headerByte = rawMessageJsonOrBinary[1];
   if (headerByte == '{') {
-    std::string s(reinterpret_cast<const char*>(rawMessageJsonOrBinary) + 1,
-                  length - 1);
-    spdlog::trace(
-      "MessageSerializer::Deserialize - Encountered JSON message {}", s);
-    // TODO(#2257): try to pass JSON in advance, avoid parsing each time
-    for (auto fn : deserializerFns) {
-      if (fn) {
-        auto result = fn(rawMessageJsonOrBinary, length);
-        if (result) {
-          spdlog::trace("MessageSerializer::Deserialize - Deserialized");
-          return result;
-        }
-      }
+    if (spdlog::should_log(spdlog::level::trace)) {
+      // Only materialize the message text when trace is actually enabled;
+      // this used to allocate a copy of every JSON packet unconditionally.
+      spdlog::trace(
+        "MessageSerializer::Deserialize - Encountered JSON message {}",
+        std::string(reinterpret_cast<const char*>(rawMessageJsonOrBinary) + 1,
+                    length - 1));
     }
-    spdlog::trace("MessageSerializer::Deserialize - Failed to deserialize, "
-                  "falling back to PacketParser.cpp");
-    return std::nullopt;
+
+    // Read the message type once and dispatch straight to its deserializer.
+    // Walking the whole table meant every candidate ahead of the real type
+    // re-parsed the entire document before rejecting it (addresses the
+    // long-standing TODO(#2257) that used to live here).
+    thread_local std::string peek;
+    peek.assign(reinterpret_cast<const char*>(rawMessageJsonOrBinary) + 1,
+                length - 1);
+
+    auto peekResult = ScratchParser().parse(peek);
+    if (peekResult.error()) {
+      spdlog::trace("MessageSerializer::Deserialize - JSON parse failed");
+      return std::nullopt;
+    }
+
+    auto typeResult = peekResult.value_unsafe().at_key("t").get_uint64();
+    if (typeResult.error()) {
+      // Server-produced messages use a string "type" field instead of "t";
+      // those are handled further down the pipeline.
+      return std::nullopt;
+    }
+
+    const auto index = static_cast<size_t>(typeResult.value_unsafe());
+    if (index >= deserializerFns.size() || !deserializerFns[index]) {
+      spdlog::trace("MessageSerializer::Deserialize - no deserializer for "
+                    "JSON message type {}",
+                    index);
+      return std::nullopt;
+    }
+
+    // Materialize into a named local rather than taking the address of an
+    // rvalue-qualified accessor's result. dom::element is a lightweight handle
+    // into the parser's tape, so this copy is free and removes any doubt about
+    // what the pointer outlives.
+    const simdjson::dom::element parsedElement = peekResult.value_unsafe();
+    return deserializerFns[index](rawMessageJsonOrBinary, length,
+                                  &parsedElement);
   }
 
   if (headerByte >= deserializerFns.size()) {
@@ -211,11 +238,11 @@ std::optional<DeserializeResult> MessageSerializer::Deserialize(
       static_cast<int>(headerByte),
       fmt::join(std::vector<uint8_t>(rawMessageJsonOrBinary,
                                      rawMessageJsonOrBinary + length),
-                ", "));
+                ""));
     return std::nullopt;
   }
 
-  auto result = deserializerFn(rawMessageJsonOrBinary, length);
+  auto result = deserializerFn(rawMessageJsonOrBinary, length, nullptr);
   if (result == std::nullopt) {
     spdlog::warn(
       "MessageSerializer::Deserialize - deserializerFn returned "

--- a/skymp5-server/cpp/messages/MessageSerializerFactory.h
+++ b/skymp5-server/cpp/messages/MessageSerializerFactory.h
@@ -50,7 +50,7 @@ private:
   typedef void (*SerializeFn)(const simdjson::dom::element& inputJson,
                               SLNet::BitStream& outputStream);
   typedef std::optional<DeserializeResult> (*DeserializeFn)(
-    const uint8_t* rawMessageJsonOrBinary, size_t length);
+    const uint8_t* rawMessageJsonOrBinary, size_t length, const simdjson::dom::element* parsedJson);
 
   MessageSerializer(std::vector<SerializeFn> serializerFns,
                     std::vector<DeserializeFn> deserializerFns);

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -12,6 +12,7 @@
 #include "MsgType.h"
 #include "Overloaded.h"
 #include "WorldState.h"
+#include "parallel/OffloadDispatcher.h"
 #include "gamemode_events/CustomEvent.h"
 #include "gamemode_events/EatItemEvent.h"
 #include "gamemode_events/UpdateAppearanceAttemptEvent.h"
@@ -36,10 +37,8 @@ uint32_t LongToNormal(uint64_t longFormId)
 }
 }
 
-MpActor* ActionListener::SendToNeighbours(uint32_t idx,
-                                          Networking::UserId userId,
-                                          Networking::PacketData data,
-                                          size_t length, bool reliable)
+MpActor* ActionListener::ResolveRelayTarget(uint32_t idx,
+                                            Networking::UserId userId)
 {
   MpActor* myActor = partOne.serverState.ActorByUser(userId);
   // The old behavior is doing nothing in that case. This is covered by tests
@@ -85,13 +84,32 @@ MpActor* ActionListener::SendToNeighbours(uint32_t idx,
     }
   }
 
-  for (auto listener : actor->GetActorListeners()) {
+  return actor;
+}
+
+void ActionListener::RelayToNeighbours(MpActor& actor,
+                                       Networking::PacketData data,
+                                       size_t length, bool reliable)
+{
+  for (auto listener : actor.GetActorListeners()) {
     auto targetuserId = partOne.serverState.UserByActor(listener);
     if (targetuserId != Networking::InvalidUserId) {
       partOne.GetSendTarget().Send(targetuserId, data, length, reliable);
     }
   }
+}
 
+MpActor* ActionListener::SendToNeighbours(uint32_t idx,
+                                          Networking::UserId userId,
+                                          Networking::PacketData data,
+                                          size_t length, bool reliable)
+{
+  MpActor* actor = ResolveRelayTarget(idx, userId);
+  if (!actor) {
+    return nullptr;
+  }
+
+  RelayToNeighbours(*actor, data, length, reliable);
   return actor;
 }
 
@@ -113,74 +131,166 @@ void ActionListener::OnCustomPacket(const RawMessageData& rawMsgData,
   }
 }
 
+void ActionListener::ApplyValidatedMovement(MpActor& actor,
+                                            const NiPoint3& pos,
+                                            const NiPoint3& rot,
+                                            bool isInJumpState,
+                                            bool isWeapDrawn, bool isBlocking,
+                                            bool isSneaking, bool isStanding,
+                                            uint32_t idx)
+{
+  if (!isBlocking) {
+    actor.IncreaseBlockCount();
+  } else {
+    actor.ResetBlockCount();
+  }
+
+  actor.SetPos(pos, SetPosMode::CalledByUpdateMovement);
+  actor.SetAngle(rot, SetAngleMode::CalledByUpdateMovement);
+  actor.SetAnimationVariableBool(
+    AnimationVariableBool::kVariable_bInJumpState, isInJumpState);
+  actor.SetAnimationVariableBool(
+    AnimationVariableBool::kVariable__skymp_isWeapDrawn, isWeapDrawn);
+  actor.SetAnimationVariableBool(AnimationVariableBool::kVariable_IsBlocking,
+                                 isBlocking);
+  actor.SetAnimationVariableBool(AnimationVariableBool::kVariable_IsSneaking,
+                                 isSneaking);
+
+  if (actor.GetBlockCount() == 5) {
+    actor.SetIsBlockActive(false);
+    actor.ResetBlockCount();
+  }
+
+  if (!isStanding) {
+    actor.SetLastAnimEvent(std::nullopt);
+  }
+
+  if (partOne.worldState.lastMovUpdateByIdx.size() <= idx) {
+    auto newSize = static_cast<size_t>(idx) + 1;
+    partOne.worldState.lastMovUpdateByIdx.resize(newSize);
+  }
+  partOne.worldState.lastMovUpdateByIdx[idx] =
+    std::chrono::system_clock::now();
+}
+
+bool ActionListener::TrySubmitMovementForOffload(
+  MpActor& actor, const RawMessageData& rawMsgData,
+  const UpdateMovementMessage& msg, bool teleportFlag)
+{
+  auto& worldState = partOne.worldState;
+
+  MpParallel::MovementSubmission submission;
+
+  // The offloaded validator compares world/cell form ids numerically instead
+  // of building a FormDesc. FormDesc::FromFormId and ToFormId round-trip, so
+  // the comparison is equivalent, with one deliberate difference: a client
+  // that sends a form id for a plugin that is not loaded gets its update
+  // rejected here rather than throwing out of the packet handler.
+  try {
+    submission.currentWorldOrCell =
+      actor.GetCellOrWorld().ToFormId(worldState.espmFiles);
+  } catch (const std::exception&) {
+    return false;
+  }
+
+  submission.formId = actor.GetFormId();
+  submission.idx = msg.idx;
+
+  // Encodes MovementValidation's `isMe`: only the player whose own actor this
+  // is gets pulled back, hosted NPCs do not.
+  submission.ownerUserId =
+    partOne.serverState.ActorByUser(rawMsgData.userId) == &actor
+    ? rawMsgData.userId
+    : Networking::InvalidUserId;
+
+  const NiPoint3& currentPos = actor.GetPos();
+  const NiPoint3& currentRot = actor.GetAngle();
+  submission.currentPos[0] = currentPos.x;
+  submission.currentPos[1] = currentPos.y;
+  submission.currentPos[2] = currentPos.z;
+  submission.currentRot[0] = currentRot.x;
+  submission.currentRot[1] = currentRot.y;
+  submission.currentRot[2] = currentRot.z;
+
+  submission.proposedPos[0] = msg.data.pos[0];
+  submission.proposedPos[1] = msg.data.pos[1];
+  submission.proposedPos[2] = msg.data.pos[2];
+  submission.proposedRot[0] = msg.data.rot[0];
+  submission.proposedRot[1] = msg.data.rot[1];
+  submission.proposedRot[2] = msg.data.rot[2];
+  submission.proposedWorldOrCell = msg.data.worldOrCell;
+
+  submission.teleportFlag = teleportFlag;
+  submission.isInJumpState = msg.data.isInJumpState;
+  submission.isWeapDrawn = msg.data.isWeapDrawn;
+  submission.isBlocking = msg.data.isBlocking;
+  submission.isSneaking = msg.data.isSneaking;
+  submission.isStanding = msg.data.runMode == "Standing";
+
+  submission.packetData =
+    reinterpret_cast<const uint8_t*>(rawMsgData.unparsed);
+  submission.packetLength = rawMsgData.unparsedLength;
+
+  return partOne.GetOffloadDispatcher().SubmitMovement(submission);
+}
+
 void ActionListener::OnUpdateMovement(const RawMessageData& rawMsgData,
                                       const UpdateMovementMessage& msg)
 {
-  auto actor = SendToNeighbours(msg.idx, rawMsgData);
-  if (actor) {
-    bool teleportFlag = actor->GetTeleportFlag();
-    actor->SetTeleportFlag(false);
+  const bool offloadEnabled = partOne.GetOffloadDispatcher().IsEnabled();
 
-    static const NiPoint3 kInfinityPos = {
-      std::numeric_limits<float>::infinity(),
-      std::numeric_limits<float>::infinity(),
-      std::numeric_limits<float>::infinity()
-    };
+  // When offloading, the relay is deferred to the join phase, so only the
+  // ownership checks run during ingest. Otherwise this is the original
+  // relay-then-validate order.
+  MpActor* actor = offloadEnabled
+    ? ResolveRelayTarget(msg.idx, rawMsgData.userId)
+    : SendToNeighbours(msg.idx, rawMsgData);
+  if (!actor) {
+    return;
+  }
 
-    auto& espmFiles = actor->GetParent()->espmFiles;
+  // Read once per update no matter which path handles it: the flag is
+  // one-shot and consuming it twice would lose a teleport correction.
+  const bool teleportFlag = actor->GetTeleportFlag();
+  actor->SetTeleportFlag(false);
 
-    const auto& currentPos = actor->GetPos();
-    const auto& currentRot = actor->GetAngle();
-    const auto& currentCellOrWorld = actor->GetCellOrWorld();
-
-    if (!MovementValidation::Validate(
-          partOne, currentPos, currentRot, currentCellOrWorld,
-          teleportFlag
-            ? kInfinityPos
-            : NiPoint3{ msg.data.pos[0], msg.data.pos[1], msg.data.pos[2] },
-          FormDesc::FromFormId(msg.data.worldOrCell, espmFiles),
-          rawMsgData.userId, actor, espmFiles)) {
+  if (offloadEnabled) {
+    if (TrySubmitMovementForOffload(*actor, rawMsgData, msg, teleportFlag)) {
       return;
     }
-
-    if (!msg.data.isBlocking) {
-      actor->IncreaseBlockCount();
-    } else {
-      actor->ResetBlockCount();
-    }
-
-    actor->SetPos(
-      NiPoint3{ msg.data.pos[0], msg.data.pos[1], msg.data.pos[2] },
-      SetPosMode::CalledByUpdateMovement);
-    actor->SetAngle(
-      NiPoint3{ msg.data.rot[0], msg.data.rot[1], msg.data.rot[2] },
-      SetAngleMode::CalledByUpdateMovement);
-    actor->SetAnimationVariableBool(
-      AnimationVariableBool::kVariable_bInJumpState, msg.data.isInJumpState);
-    actor->SetAnimationVariableBool(
-      AnimationVariableBool::kVariable__skymp_isWeapDrawn,
-      msg.data.isWeapDrawn);
-    actor->SetAnimationVariableBool(
-      AnimationVariableBool::kVariable_IsBlocking, msg.data.isBlocking);
-    actor->SetAnimationVariableBool(
-      AnimationVariableBool::kVariable_IsSneaking, msg.data.isSneaking);
-
-    if (actor->GetBlockCount() == 5) {
-      actor->SetIsBlockActive(false);
-      actor->ResetBlockCount();
-    }
-
-    if (msg.data.runMode != "Standing") {
-      actor->SetLastAnimEvent(std::nullopt);
-    }
-
-    if (partOne.worldState.lastMovUpdateByIdx.size() <= msg.idx) {
-      auto newSize = static_cast<size_t>(msg.idx) + 1;
-      partOne.worldState.lastMovUpdateByIdx.resize(newSize);
-    }
-    partOne.worldState.lastMovUpdateByIdx[msg.idx] =
-      std::chrono::system_clock::now();
+    // The dispatcher declined, so nothing has been relayed yet. Fall back to
+    // the inline path, starting with the relay it would have done.
+    RelayToNeighbours(*actor, rawMsgData.unparsed, rawMsgData.unparsedLength,
+                      false);
   }
+
+  static const NiPoint3 kInfinityPos = {
+    std::numeric_limits<float>::infinity(),
+    std::numeric_limits<float>::infinity(),
+    std::numeric_limits<float>::infinity()
+  };
+
+  auto& espmFiles = actor->GetParent()->espmFiles;
+
+  const auto& currentPos = actor->GetPos();
+  const auto& currentRot = actor->GetAngle();
+  const auto& currentCellOrWorld = actor->GetCellOrWorld();
+
+  if (!MovementValidation::Validate(
+        partOne, currentPos, currentRot, currentCellOrWorld,
+        teleportFlag
+          ? kInfinityPos
+          : NiPoint3{ msg.data.pos[0], msg.data.pos[1], msg.data.pos[2] },
+        FormDesc::FromFormId(msg.data.worldOrCell, espmFiles),
+        rawMsgData.userId, actor, espmFiles)) {
+    return;
+  }
+
+  ApplyValidatedMovement(
+    *actor, NiPoint3{ msg.data.pos[0], msg.data.pos[1], msg.data.pos[2] },
+    NiPoint3{ msg.data.rot[0], msg.data.rot[1], msg.data.rot[2] },
+    msg.data.isInJumpState, msg.data.isWeapDrawn, msg.data.isBlocking,
+    msg.data.isSneaking, msg.data.runMode == "Standing", msg.idx);
 }
 
 void ActionListener::OnUpdateAnimation(const RawMessageData& rawMsgData,

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.h
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.h
@@ -9,7 +9,10 @@
 #include "SpellCastData.h"
 #include "SweetHidePlayerNamesService.h"
 #include "libespm/Loader.h"
+// RelayTarget, the flattened recipient record handed to the dispatcher.
+#include "parallel/TickSnapshot.h"
 #include <memory>
+#include <vector>
 
 class ServerState;
 class WorldState;
@@ -89,7 +92,38 @@ public:
     return craftService;
   }
 
+  // --- shared by the inline and the offloaded movement paths -------------
+  //
+  // These three used to be the body of SendToNeighbours plus the tail of
+  // OnUpdateMovement. They are split out so the parallel dispatcher can
+  // reuse the exact same logic instead of growing a second copy that would
+  // drift.
+
+  // Ownership and hosting checks. Returns the actor the update may be
+  // applied to, or nullptr after having already told the client to stop
+  // hosting.
+  MpActor* ResolveRelayTarget(uint32_t idx, Networking::UserId userId);
+
+  // Forwards `data` verbatim to every connected actor that can see `actor`.
+  void RelayToNeighbours(MpActor& actor, Networking::PacketData data,
+                         size_t length, bool reliable);
+
+  // The post-validation half of OnUpdateMovement: transform, animation
+  // variables, block counting and the last-update timestamp.
+  void ApplyValidatedMovement(MpActor& actor, const NiPoint3& pos,
+                              const NiPoint3& rot, bool isInJumpState,
+                              bool isWeapDrawn, bool isBlocking,
+                              bool isSneaking, bool isStanding, uint32_t idx);
+
 private:
+  // Flattens one movement update plus its recipients and hands it to the
+  // dispatcher. Returns false when the update must be handled inline
+  // instead, which the caller is always free to do.
+  bool TrySubmitMovementForOffload(MpActor& actor,
+                                   const RawMessageData& rawMsgData,
+                                   const UpdateMovementMessage& msg,
+                                   bool teleportFlag);
+
   void OnSpellHit(MpActor* aggressor, MpObjectReference* targetRef,
                   const HitData& hitData);
   void OnWeaponHit(MpActor* aggressor, MpObjectReference* targetRef,

--- a/skymp5-server/cpp/server_guest_lib/PartOne.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.cpp
@@ -17,6 +17,9 @@
 #include "MessageSerializerFactory.h"
 #include "OpenSSLSigner.h"
 #include "PacketParser.h"
+#include "PartOneOffloadSink.h"
+#include "parallel/AreaKey.h"
+#include "parallel/OffloadDispatcher.h"
 
 PartOneSendTargetWrapper::PartOneSendTargetWrapper(
   Networking::ISendTarget& underlyingSendTarget_)
@@ -96,6 +99,10 @@ struct PartOne::Impl
   bool enableGamemodeDataUpdatesBroadcast = false;
 
   PartOne::OnActorStreamIn onActorStreamIn;
+
+  // Always present, but does nothing until ConfigureParallelism turns it on.
+  std::unique_ptr<MpParallel::OffloadDispatcher> offloadDispatcher;
+  std::unique_ptr<PartOneOffloadSink> offloadSink;
 };
 
 PartOne::PartOne(Networking::ISendTarget* sendTarget)
@@ -114,6 +121,12 @@ PartOne::PartOne(std::shared_ptr<Listener> listener,
 
 PartOne::~PartOne()
 {
+  // Drop anything submitted but not yet joined before the actors it refers to
+  // go away, and stop the workers while the world is still intact.
+  if (pImpl && pImpl->offloadDispatcher) {
+    pImpl->offloadDispatcher->DiscardPending();
+  }
+
   // worldState may depend on serverState (actorsMap), we should reset it first
   worldState.Clear();
   serverState = {};
@@ -146,8 +159,62 @@ bool PartOne::IsConnected(Networking::UserId userId) const
 void PartOne::Tick()
 {
   TickPacketHistoryPlaybacks();
+
+  // Runs before worldState.Tick so that movement submitted during this
+  // tick's packet pump lands before timers get a chance to act on positions,
+  // which is the order the inline path produced.
+  if (pImpl->offloadDispatcher && pImpl->offloadSink) {
+    if (pImpl->offloadDispatcher->IsEnabled()) {
+      std::vector<MpParallel::RelayTarget> potentialTargets;
+      if (pImpl->offloadDispatcher->GetPendingCount() > 0) {
+        for (size_t i = 0, n = serverState.maxConnectedId; i <= n; ++i) {
+          Networking::UserId userId = static_cast<Networking::UserId>(i);
+          if (auto actor = serverState.ActorByUser(userId)) {
+            if (actor->IsDisabled()) {
+              continue;
+            }
+            MpParallel::RelayTarget target;
+            target.userId = userId;
+            target.listenerFormId = actor->GetFormId();
+            const auto& pos = actor->GetPos();
+            target.pos[0] = pos.x;
+            target.pos[1] = pos.y;
+            target.pos[2] = pos.z;
+            
+            try {
+              target.worldOrCell = actor->GetCellOrWorld().ToFormId(worldState.espmFiles);
+            } catch (const std::exception&) {
+              continue;
+            }
+            target.chunkX = MpParallel::ToChunkCoord(pos.x);
+            target.chunkY = MpParallel::ToChunkCoord(pos.y);
+            potentialTargets.push_back(target);
+          }
+        }
+      }
+      pImpl->offloadDispatcher->SetPotentialTargets(std::move(potentialTargets));
+    }
+    pImpl->offloadDispatcher->ExecuteTick(*pImpl->offloadSink);
+  }
+
   TickDeferredMessages();
   worldState.Tick();
+}
+
+MpParallel::OffloadDispatcher& PartOne::GetOffloadDispatcher()
+{
+  return *pImpl->offloadDispatcher;
+}
+
+void PartOne::ConfigureParallelism(const MpParallel::ParallelConfig& config)
+{
+  pImpl->offloadDispatcher->Reconfigure(config);
+  GetLogger().info("{}", pImpl->offloadDispatcher->GetConfig().Describe());
+}
+
+const MpParallel::ParallelMetrics& PartOne::GetParallelMetrics() const
+{
+  return pImpl->offloadDispatcher->GetMetrics();
 }
 
 uint32_t PartOne::CreateActor(uint32_t formId, const NiPoint3& pos,
@@ -755,6 +822,13 @@ void PartOne::Init()
 {
   pImpl.reset(new Impl);
   pImpl->logger.reset(new spdlog::logger{ "empty logger" });
+
+  // Constructed disabled, so no threads exist until a server config asks for
+  // them. Tests and embedders that never call ConfigureParallelism keep the
+  // original single-threaded behaviour byte for byte.
+  pImpl->offloadDispatcher =
+    std::make_unique<MpParallel::OffloadDispatcher>(MpParallel::ParallelConfig{});
+  pImpl->offloadSink = std::make_unique<PartOneOffloadSink>(*this);
 
   pImpl->onSubscribe = [this](PartOneSendTargetWrapper* sendTarget,
                               MpObjectReference* emitter,

--- a/skymp5-server/cpp/server_guest_lib/PartOne.h
+++ b/skymp5-server/cpp/server_guest_lib/PartOne.h
@@ -24,6 +24,12 @@ using ProfileId = int32_t;
 class ActionListener;
 class MessageSerializer;
 
+namespace MpParallel {
+class OffloadDispatcher;
+struct ParallelConfig;
+struct ParallelMetrics;
+}
+
 class PartOneSendTargetWrapper : public Networking::ISendTarget
 {
 public:
@@ -133,6 +139,15 @@ public:
                     MpObjectReference& remote);
 
   static MessageSerializer& GetMessageSerializerInstance();
+
+  // --- multi-core area offload ------------------------------------------
+  //
+  // Off by default. When enabled, per-area movement relay work is spread
+  // across worker threads and applied during Tick instead of inline during
+  // packet ingest. See docs/docs_parallel_area_offload.md.
+  MpParallel::OffloadDispatcher& GetOffloadDispatcher();
+  void ConfigureParallelism(const MpParallel::ParallelConfig& config);
+  const MpParallel::ParallelMetrics& GetParallelMetrics() const;
 
 private:
   void Init();

--- a/skymp5-server/cpp/server_guest_lib/PartOneOffloadSink.cpp
+++ b/skymp5-server/cpp/server_guest_lib/PartOneOffloadSink.cpp
@@ -1,0 +1,71 @@
+#include "PartOneOffloadSink.h"
+
+#include "ActionListener.h"
+#include "MpActor.h"
+#include "PartOne.h"
+#include "TeleportMessage2.h"
+
+PartOneOffloadSink::PartOneOffloadSink(PartOne& partOne_)
+  : partOne(partOne_)
+{
+}
+
+MpActor* PartOneOffloadSink::ResolveActor(uint32_t formId) const
+{
+  // NoLoad on purpose: if the form is not resident any more there is nothing
+  // to update, and triggering a lazy espm chunk load from the join phase
+  // would be a surprising amount of work to do on behalf of a stale packet.
+  const std::shared_ptr<MpForm>& form =
+    partOne.worldState.LookupFormByIdNoLoad(formId);
+  return form ? form->AsActor() : nullptr;
+}
+
+void PartOneOffloadSink::ApplyMovement(const MpParallel::ActorSnapshot& actor)
+{
+  MpActor* liveActor = ResolveActor(actor.formId);
+  if (!liveActor) {
+    ++staleActorCount;
+    return;
+  }
+
+  partOne.GetActionListener().ApplyValidatedMovement(
+    *liveActor,
+    NiPoint3{ actor.proposedPos[0], actor.proposedPos[1],
+              actor.proposedPos[2] },
+    NiPoint3{ actor.proposedRot[0], actor.proposedRot[1],
+              actor.proposedRot[2] },
+    actor.isInJumpState, actor.isWeapDrawn, actor.isBlocking, actor.isSneaking,
+    actor.isStanding, actor.idx);
+}
+
+void PartOneOffloadSink::SendCorrection(const MpParallel::ActorSnapshot& actor)
+{
+  // InvalidUserId here means the update targeted a hosted NPC rather than the
+  // sender's own actor, which the inline path also leaves uncorrected.
+  if (actor.ownerUserId == Networking::InvalidUserId) {
+    return;
+  }
+  if (!partOne.IsConnected(actor.ownerUserId)) {
+    return;
+  }
+
+  TeleportMessage2 msg;
+  msg.pos = { actor.currentPos[0], actor.currentPos[1], actor.currentPos[2] };
+  msg.rot = { actor.currentRot[0], actor.currentRot[1], actor.currentRot[2] };
+  msg.worldOrCell = actor.currentWorldOrCell;
+  partOne.GetSendTarget().Send(actor.ownerUserId, msg, true);
+}
+
+void PartOneOffloadSink::SendRelay(Networking::UserId userId,
+                                   const uint8_t* data, size_t length,
+                                   bool reliable)
+{
+  // The recipient list was resolved during ingest, so a player who
+  // disconnected in between would otherwise be sent to here.
+  if (!partOne.IsConnected(userId)) {
+    return;
+  }
+
+  partOne.GetSendTarget().Send(
+    userId, reinterpret_cast<Networking::PacketData>(data), length, reliable);
+}

--- a/skymp5-server/cpp/server_guest_lib/PartOneOffloadSink.h
+++ b/skymp5-server/cpp/server_guest_lib/PartOneOffloadSink.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "parallel/OffloadDispatcher.h"
+
+class PartOne;
+class MpActor;
+
+// Applies the parallel phase's decisions to the live world.
+//
+// Everything here runs on the main thread during the join, after the workers
+// have stopped. The one thing it must be careful about is time: a submission
+// is made while packets are still being pumped, and by the time the join runs
+// the actor may have been destroyed, or its owner may have disconnected. Each
+// method therefore re-resolves by form id and checks the connection before
+// touching anything.
+class PartOneOffloadSink : public MpParallel::IOffloadSink
+{
+public:
+  explicit PartOneOffloadSink(PartOne& partOne_);
+
+  void ApplyMovement(const MpParallel::ActorSnapshot& actor) override;
+  void SendCorrection(const MpParallel::ActorSnapshot& actor) override;
+  void SendRelay(Networking::UserId userId, const uint8_t* data, size_t length,
+                 bool reliable) override;
+
+  // Counts submissions dropped at join time because the actor was gone.
+  // Non-zero is expected during heavy churn; steadily growing is a bug.
+  [[nodiscard]] uint64_t GetStaleActorCount() const noexcept
+  {
+    return staleActorCount;
+  }
+
+private:
+  [[nodiscard]] MpActor* ResolveActor(uint32_t formId) const;
+
+  PartOne& partOne;
+  uint64_t staleActorCount = 0;
+};

--- a/skymp5-server/cpp/server_guest_lib/parallel/AreaCluster.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/AreaCluster.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "AreaKey.h"
+#include <cstdint>
+#include <vector>
+
+namespace MpParallel {
+
+// A set of actors that can be processed independently of every other
+// cluster in the same tick.
+struct AreaCluster
+{
+  // Smallest AreaKey in the cluster. Doubles as the cluster's identity for
+  // cost tracking across ticks and as its sort key, which is what makes the
+  // join order reproducible.
+  AreaKey representative;
+
+  // Indices into TickSnapshot::actors, ascending.
+  std::vector<uint32_t> actorIndices;
+
+  // Number of chunks occupied by this cluster. Cheap density signal for the
+  // cost model.
+  uint32_t chunkCount = 0;
+
+  [[nodiscard]] size_t Size() const noexcept { return actorIndices.size(); }
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/AreaKey.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/AreaKey.h
@@ -1,0 +1,102 @@
+#pragma once
+#include <cstdint>
+#include <functional>
+
+namespace MpParallel {
+
+// Side length of a grid chunk in Skyrim world units. Mirrors the divisor in
+// MpObjectReference.cpp's GetGridPos; the two must agree or clusters would
+// not line up with the subscription neighbourhoods they are meant to
+// contain.
+constexpr float kChunkSizeUnits = 4096.f;
+
+// Smallest chunk separation that still guarantees two clusters cannot
+// influence each other within one tick.
+//
+// Visibility is the 3x3 chunk stencil in Grid.h (reach 1), and movement
+// validation caps one update at just under a chunk (reach 1 more), so an
+// actor's relay set can span 2 chunks in a tick. 3 is the first value that
+// keeps that entirely inside one cluster.
+//
+// Lives here rather than in ParallelConfig so the partitioner, which knows
+// nothing about server settings, can enforce it.
+constexpr int32_t kMinSafeSeparationChunks = 3;
+
+[[nodiscard]] inline int16_t ToChunkCoord(float worldCoord) noexcept
+{
+  // Deliberately identical to GetGridPos: truncation towards zero, so
+  // coordinates in (-4096, 4096) all map to chunk 0. Reproducing the quirk
+  // matters more than fixing it, because the grid this partition mirrors
+  // behaves the same way.
+  return static_cast<int16_t>(worldCoord / kChunkSizeUnits);
+}
+
+// Identifies one chunk of one worldspace or interior cell.
+struct AreaKey
+{
+  uint32_t worldOrCell = 0;
+  int16_t chunkX = 0;
+  int16_t chunkY = 0;
+
+  [[nodiscard]] bool operator==(const AreaKey& rhs) const noexcept
+  {
+    return worldOrCell == rhs.worldOrCell && chunkX == rhs.chunkX &&
+      chunkY == rhs.chunkY;
+  }
+
+  [[nodiscard]] bool operator!=(const AreaKey& rhs) const noexcept
+  {
+    return !(*this == rhs);
+  }
+
+  // Total order used to make partitioning deterministic across runs and
+  // across worker counts.
+  [[nodiscard]] bool operator<(const AreaKey& rhs) const noexcept
+  {
+    if (worldOrCell != rhs.worldOrCell) {
+      return worldOrCell < rhs.worldOrCell;
+    }
+    if (chunkX != rhs.chunkX) {
+      return chunkX < rhs.chunkX;
+    }
+    return chunkY < rhs.chunkY;
+  }
+
+  // Chebyshev distance in chunks. Returns -1 when the two keys live in
+  // different worldspaces, which callers treat as "infinitely far apart".
+  [[nodiscard]] int32_t ChunkDistanceTo(const AreaKey& rhs) const noexcept
+  {
+    if (worldOrCell != rhs.worldOrCell) {
+      return -1;
+    }
+    const int32_t dx =
+      static_cast<int32_t>(chunkX) - static_cast<int32_t>(rhs.chunkX);
+    const int32_t dy =
+      static_cast<int32_t>(chunkY) - static_cast<int32_t>(rhs.chunkY);
+    const int32_t absDx = dx < 0 ? -dx : dx;
+    const int32_t absDy = dy < 0 ? -dy : dy;
+    return absDx > absDy ? absDx : absDy;
+  }
+};
+
+struct AreaKeyHash
+{
+  [[nodiscard]] size_t operator()(const AreaKey& key) const noexcept
+  {
+    // Pack into 64 bits first: the three fields together are exactly 64 bits
+    // wide, so no information is lost and the mix below sees every input bit.
+    uint64_t packed = static_cast<uint64_t>(key.worldOrCell) << 32;
+    packed |= static_cast<uint64_t>(static_cast<uint16_t>(key.chunkX)) << 16;
+    packed |= static_cast<uint64_t>(static_cast<uint16_t>(key.chunkY));
+
+    // splitmix64 finalizer.
+    packed ^= packed >> 30;
+    packed *= 0xbf58476d1ce4e5b9ULL;
+    packed ^= packed >> 27;
+    packed *= 0x94d049bb133111ebULL;
+    packed ^= packed >> 31;
+    return static_cast<size_t>(packed);
+  }
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/AreaPartitioner.cpp
+++ b/skymp5-server/cpp/server_guest_lib/parallel/AreaPartitioner.cpp
@@ -1,0 +1,162 @@
+#include "AreaPartitioner.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace MpParallel {
+
+namespace {
+
+constexpr int32_t kInt16Min = std::numeric_limits<int16_t>::min();
+constexpr int32_t kInt16Max = std::numeric_limits<int16_t>::max();
+
+}
+
+uint32_t AreaPartitioner::Find(uint32_t node)
+{
+  // Iterative path halving: no recursion, so a pathological chain cannot
+  // overflow the stack on a worker with a small default stack size.
+  while (parent[node] != node) {
+    parent[node] = parent[parent[node]];
+    node = parent[node];
+  }
+  return node;
+}
+
+void AreaPartitioner::Unite(uint32_t a, uint32_t b)
+{
+  uint32_t rootA = Find(a);
+  uint32_t rootB = Find(b);
+  if (rootA == rootB) {
+    return;
+  }
+
+  if (unionRank[rootA] < unionRank[rootB]) {
+    std::swap(rootA, rootB);
+  }
+  parent[rootB] = rootA;
+  if (unionRank[rootA] == unionRank[rootB]) {
+    ++unionRank[rootA];
+  }
+}
+
+void AreaPartitioner::Partition(std::vector<ActorSnapshot>& actors,
+                                int32_t separationChunks,
+                                std::vector<AreaCluster>& outClusters)
+{
+  outClusters.clear();
+  chunkIndexByKey.clear();
+  chunkKeys.clear();
+  parent.clear();
+  unionRank.clear();
+  clusterOfRoot.clear();
+  clusterOfChunk.clear();
+
+  if (actors.empty()) {
+    return;
+  }
+
+  const int32_t separation =
+    std::max(separationChunks, kMinSafeSeparationChunks);
+
+  // Pass 1: collect the distinct occupied chunks, then sort them. Sorting
+  // before anything else is assigned an index is what makes the result
+  // independent of the order packets happened to arrive in.
+  chunkKeys.reserve(actors.size());
+  for (const ActorSnapshot& actor : actors) {
+    chunkKeys.push_back(actor.area);
+  }
+  std::sort(chunkKeys.begin(), chunkKeys.end());
+  chunkKeys.erase(std::unique(chunkKeys.begin(), chunkKeys.end()),
+                  chunkKeys.end());
+
+  const uint32_t chunkCount = static_cast<uint32_t>(chunkKeys.size());
+
+  chunkIndexByKey.reserve(chunkCount * 2);
+  for (uint32_t i = 0; i < chunkCount; ++i) {
+    chunkIndexByKey.emplace(chunkKeys[i], i);
+  }
+
+  // Pass 2: union chunks that are within `separation` of each other. Probing
+  // the (2S+1)^2 window around each chunk costs a constant per chunk, which
+  // beats comparing every pair once more than a handful of chunks are
+  // occupied.
+  parent.resize(chunkCount);
+  unionRank.assign(chunkCount, 0);
+  for (uint32_t i = 0; i < chunkCount; ++i) {
+    parent[i] = i;
+  }
+
+  for (uint32_t i = 0; i < chunkCount; ++i) {
+    const AreaKey& key = chunkKeys[i];
+    for (int32_t dx = -separation; dx <= separation; ++dx) {
+      const int32_t nx = static_cast<int32_t>(key.chunkX) + dx;
+      if (nx < kInt16Min || nx > kInt16Max) {
+        continue;
+      }
+      for (int32_t dy = -separation; dy <= separation; ++dy) {
+        if (dx == 0 && dy == 0) {
+          continue;
+        }
+        const int32_t ny = static_cast<int32_t>(key.chunkY) + dy;
+        if (ny < kInt16Min || ny > kInt16Max) {
+          continue;
+        }
+
+        const AreaKey probe{ key.worldOrCell, static_cast<int16_t>(nx),
+                             static_cast<int16_t>(ny) };
+        auto it = chunkIndexByKey.find(probe);
+        if (it != chunkIndexByKey.end()) {
+          Unite(i, it->second);
+        }
+      }
+    }
+  }
+
+  // Pass 3: turn union-find roots into cluster indices. Scanning the sorted
+  // chunk list and numbering roots on first sight orders clusters by their
+  // smallest AreaKey.
+  clusterOfChunk.assign(chunkCount, kUnassignedCluster);
+  clusterOfRoot.assign(chunkCount, kUnassignedCluster);
+
+  uint32_t nextClusterIndex = 0;
+  for (uint32_t i = 0; i < chunkCount; ++i) {
+    const uint32_t root = Find(i);
+    if (clusterOfRoot[root] == kUnassignedCluster) {
+      clusterOfRoot[root] = nextClusterIndex++;
+    }
+    clusterOfChunk[i] = clusterOfRoot[root];
+  }
+
+  outClusters.resize(nextClusterIndex);
+  for (uint32_t i = 0; i < chunkCount; ++i) {
+    AreaCluster& cluster = outClusters[clusterOfChunk[i]];
+    if (cluster.chunkCount == 0) {
+      // chunkKeys is sorted, so the first chunk seen for a cluster is its
+      // smallest and therefore its stable identity.
+      cluster.representative = chunkKeys[i];
+    }
+    ++cluster.chunkCount;
+  }
+
+  // Pass 4: hand the actors out. Iterating actors in index order keeps every
+  // actorIndices list ascending without a second sort.
+  for (uint32_t actorIndex = 0;
+       actorIndex < static_cast<uint32_t>(actors.size()); ++actorIndex) {
+    ActorSnapshot& actor = actors[actorIndex];
+    auto it = chunkIndexByKey.find(actor.area);
+    if (it == chunkIndexByKey.end()) {
+      // Unreachable: every actor's chunk was inserted in pass 1.
+      actor.clusterIndex = kUnassignedCluster;
+      continue;
+    }
+
+    const uint32_t clusterIndex = clusterOfChunk[it->second];
+    actor.clusterIndex = clusterIndex;
+
+    AreaCluster& cluster = outClusters[clusterIndex];
+    cluster.actorIndices.push_back(actorIndex);
+  }
+}
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/AreaPartitioner.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/AreaPartitioner.h
@@ -1,0 +1,72 @@
+#pragma once
+#include "AreaCluster.h"
+#include "AreaKey.h"
+#include "TickSnapshot.h"
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace MpParallel {
+
+// Groups the actors submitted this tick into independently processable
+// clusters.
+//
+// WHY A SEPARATION PARAMETER
+//
+// The server's visibility model is the 3x3 chunk stencil in Grid.h: an actor
+// standing in chunk C is subscribed to, and relays to, exactly the actors
+// occupying chunks within Chebyshev distance 1 of C. Movement is capped by
+// MovementValidation at just under one chunk per update, so within a single
+// tick an actor's relay set can reach chunks up to Chebyshev distance 2 from
+// where it started.
+//
+// A cluster is therefore only self-contained if every actor it can relay to
+// is also inside it. Building clusters as connected components under the
+// relation "same worldOrCell and Chebyshev chunk distance <= S" achieves
+// that for any S >= 3, which is why ParallelConfig clamps the setting up to
+// kMinSafeSeparationChunks. Larger values trade parallelism for margin: they
+// merge nearby crowds into one cluster rather than risking a split through
+// the middle of a group that can see each other.
+//
+// Two actors in different worldspaces or interior cells never share a grid at
+// all, so those always separate.
+//
+// DETERMINISM
+//
+// Clusters come back ordered by their smallest AreaKey, and each cluster's
+// member list is ascending. The join phase walks them in that order, so the
+// order in which state is applied does not depend on how many worker threads
+// happen to be available.
+class AreaPartitioner
+{
+public:
+  // Assigns every actor a clusterIndex and fills outClusters.
+  //
+  // Actors are partitioned by their `area` field, which callers set from the
+  // actor's server-authoritative position, not the position the client is
+  // proposing. Using the authoritative one keeps an actor from hopping
+  // clusters because of a packet that is about to be rejected.
+  void Partition(std::vector<ActorSnapshot>& actors, int32_t separationChunks,
+                 std::vector<AreaCluster>& outClusters);
+
+  // Number of distinct occupied chunks seen by the most recent Partition
+  // call. Exposed for metrics and tests.
+  [[nodiscard]] size_t GetLastChunkCount() const noexcept
+  {
+    return chunkKeys.size();
+  }
+
+private:
+  uint32_t Find(uint32_t node);
+  void Unite(uint32_t a, uint32_t b);
+
+  // Scratch reused across ticks so a steady-state tick allocates nothing.
+  std::unordered_map<AreaKey, uint32_t, AreaKeyHash> chunkIndexByKey;
+  std::vector<AreaKey> chunkKeys;
+  std::vector<uint32_t> parent;
+  std::vector<uint32_t> unionRank;
+  std::vector<uint32_t> clusterOfRoot;
+  std::vector<uint32_t> clusterOfChunk;
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/InterestManager.cpp
+++ b/skymp5-server/cpp/server_guest_lib/parallel/InterestManager.cpp
@@ -1,0 +1,223 @@
+#include "InterestManager.h"
+
+#include <algorithm>
+
+namespace MpParallel {
+namespace InterestManager {
+
+namespace {
+
+[[nodiscard]] float SqrDistance(const float a[3], const float b[3]) noexcept
+{
+  const float dx = a[0] - b[0];
+  const float dy = a[1] - b[1];
+  const float dz = a[2] - b[2];
+  return dx * dx + dy * dy + dz * dz;
+}
+
+// splitmix64-style mix of the pair identity. Only needs to spread phases
+// evenly across the skip window, so a cheap finalizer is enough.
+[[nodiscard]] uint64_t MixPair(uint32_t senderFormId,
+                               Networking::UserId recipientUserId) noexcept
+{
+  uint64_t h = (static_cast<uint64_t>(senderFormId) << 16) |
+    static_cast<uint64_t>(recipientUserId);
+  h ^= h >> 30;
+  h *= 0xbf58476d1ce4e5b9ULL;
+  h ^= h >> 27;
+  h *= 0x94d049bb133111ebULL;
+  h ^= h >> 31;
+  return h;
+}
+
+}
+
+bool ValidateMovement(const ActorSnapshot& actor) noexcept
+{
+  // The inline path substitutes an infinite target position when the
+  // teleport flag is set, which makes the distance test below fail. Encoding
+  // that directly is clearer and avoids relying on infinity arithmetic.
+  if (actor.teleportFlag) {
+    return false;
+  }
+
+  if (actor.currentWorldOrCell != actor.proposedWorldOrCell) {
+    return false;
+  }
+
+  return SqrDistance(actor.currentPos, actor.proposedPos) <
+    kSqrMaxMovementDistance;
+}
+
+namespace {
+
+// Always-on, load-independent rate reduction by distance.
+//
+// Relay volume is the quadratic term, and emitting the sends is serial no
+// matter how the decisions were parallelised, so sending fewer of them is the
+// only thing that attacks the real cost. Nearby recipients are never affected.
+[[nodiscard]] uint32_t InterestSkipFactor(
+  float sqrDistance, const ParallelConfig& config) noexcept
+{
+  if (!config.interestManagement) {
+    return 1;
+  }
+
+  const float full = config.interestFullRateUnits;
+  const float sqrFull = full * full;
+  if (sqrDistance <= sqrFull) {
+    return 1;
+  }
+
+  // One step per doubling of the full-rate radius. Squared comparisons keep
+  // this free of square roots on the hottest path in the server.
+  uint32_t factor = 2;
+  if (sqrDistance > sqrFull * 4.f) {
+    factor = 3;
+  }
+  if (sqrDistance > sqrFull * 16.f) {
+    factor = 4;
+  }
+
+  return std::min(factor, std::max<uint32_t>(config.maxInterestSkipTicks, 1));
+}
+
+}
+
+uint32_t ComputeSkipFactor(float sqrDistance, uint32_t pressureLevel,
+                           const ParallelConfig& config) noexcept
+{
+  // Baseline interest management applies whether or not the server is busy.
+  const uint32_t interest = InterestSkipFactor(sqrDistance, config);
+
+  if (!config.adaptiveThrottling || pressureLevel == 0) {
+    return interest;
+  }
+
+  const float threshold = config.throttleDistanceUnits;
+  const float sqrThreshold = threshold * threshold;
+
+  // Inside the near band nothing is ever held back by pressure: those are the
+  // players actually fighting or talking to each other, and they are what
+  // "smooth" means to a user.
+  if (sqrDistance <= sqrThreshold) {
+    return interest;
+  }
+
+  // One extra step per doubling of the threshold distance. Comparing squared
+  // distances against 4x keeps this branch free of square roots.
+  uint32_t distanceBand = 1;
+  if (sqrDistance > sqrThreshold * 4.f) {
+    distanceBand = 2;
+  }
+  if (sqrDistance > sqrThreshold * 16.f) {
+    distanceBand = 3;
+  }
+
+  const uint64_t factor =
+    static_cast<uint64_t>(pressureLevel) * distanceBand + 1;
+  const auto pressureSkip = static_cast<uint32_t>(std::min<uint64_t>(
+    factor, std::max<uint32_t>(config.maxThrottleSkipTicks, 1)));
+
+  // The two mechanisms stack by taking the stronger one rather than
+  // multiplying, so an overloaded server never starves a distant player
+  // beyond whichever cap is the more conservative.
+  return std::max(interest, pressureSkip);
+}
+
+bool ShouldRelayThisTick(uint64_t tickIndex, uint32_t senderFormId,
+                         Networking::UserId recipientUserId,
+                         uint32_t skipFactor) noexcept
+{
+  if (skipFactor <= 1) {
+    return true;
+  }
+  const uint64_t phase = MixPair(senderFormId, recipientUserId) % skipFactor;
+  return (tickIndex % skipFactor) == phase;
+}
+
+void ProcessRange(const TickSnapshot& snapshot, const uint32_t* actorIndices,
+                  size_t actorCount, uint32_t pressureLevel,
+                  const ParallelConfig& config, ClusterOutput& output)
+{
+  output.Reset();
+  if (actorIndices == nullptr || actorCount == 0) {
+    return;
+  }
+  output.verdicts.reserve(actorCount);
+
+  for (size_t i = 0; i < actorCount; ++i) {
+    const uint32_t actorIndex = actorIndices[i];
+    if (actorIndex >= snapshot.actors.size()) {
+      continue;
+    }
+    const ActorSnapshot& actor = snapshot.actors[actorIndex];
+
+    const bool accepted = ValidateMovement(actor);
+
+    MovementVerdict verdict;
+    verdict.actorIndex = actorIndex;
+    verdict.accepted = accepted;
+    // Only the owning player gets pulled back; a hosted NPC has no client to
+    // correct, matching the `isMe` guard in MovementValidation.
+    verdict.needsCorrection =
+      !accepted && actor.ownerUserId != Networking::InvalidUserId;
+    output.verdicts.push_back(verdict);
+
+    // The relay happens before validation on the inline path, so a rejected
+    // update is still forwarded to neighbours. Preserving that ordering
+    // keeps observable behaviour identical.
+    if (actor.packetLength == 0) {
+      continue;
+    }
+
+    for (int32_t dy = -1; dy <= 1; ++dy) {
+      for (int32_t dx = -1; dx <= 1; ++dx) {
+        RelayTarget dummyTarget;
+        dummyTarget.worldOrCell = actor.worldOrCell;
+        dummyTarget.chunkX = static_cast<int16_t>(actor.area.chunkX) + dx;
+        dummyTarget.chunkY = static_cast<int16_t>(actor.area.chunkY) + dy;
+
+        auto comp = [](const RelayTarget& a, const RelayTarget& b) {
+          if (a.worldOrCell != b.worldOrCell) return a.worldOrCell < b.worldOrCell;
+          if (a.chunkX != b.chunkX) return a.chunkX < b.chunkX;
+          return a.chunkY < b.chunkY;
+        };
+
+        auto range = std::equal_range(snapshot.relayTargets.begin(),
+                                      snapshot.relayTargets.end(),
+                                      dummyTarget, comp);
+
+        for (auto it = range.first; it != range.second; ++it) {
+          const RelayTarget& target = *it;
+          if (target.userId == Networking::InvalidUserId) {
+            continue;
+          }
+
+      const float sqrDistance = SqrDistance(actor.currentPos, target.pos);
+      const uint32_t skipFactor =
+        ComputeSkipFactor(sqrDistance, pressureLevel, config);
+
+      if (!ShouldRelayThisTick(snapshot.tickIndex, actor.formId, target.userId,
+                               skipFactor)) {
+        ++output.throttledEdges;
+        continue;
+      }
+
+      OutboundSend send;
+      send.userId = target.userId;
+      send.byteOffset = actor.packetOffset;
+      send.byteLength = actor.packetLength;
+      // Movement relays are unreliable on the inline path too: the next
+      // update supersedes this one, so a retransmit would only add latency.
+      send.reliable = false;
+      output.sends.push_back(send);
+      ++output.emittedEdges;
+        }
+      }
+    }
+  }
+}
+
+}
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/InterestManager.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/InterestManager.h
@@ -1,0 +1,64 @@
+#pragma once
+#include "ParallelConfig.h"
+#include "RelayPlan.h"
+#include "TickSnapshot.h"
+#include <cstdint>
+
+namespace MpParallel {
+
+// Maximum squared displacement a single movement update may claim. Matches
+// kSqrMaxDistance in MovementValidation.cpp; the two have to stay in step or
+// the offloaded path would accept updates the inline path rejects.
+constexpr float kSqrMaxMovementDistance = 4096.f * 4096.f;
+
+// The pure half of the framework: given a snapshot, decide what should
+// happen. Nothing here touches the world, the network, or any shared mutable
+// state, which is exactly why it can run on a worker thread.
+namespace InterestManager {
+
+// Reproduces MovementValidation::Validate against snapshot data.
+//
+// Returns true when the proposed transform is acceptable. A set teleportFlag
+// always fails, because the inline path substitutes an infinite position in
+// that case to force the client back to the server's transform.
+[[nodiscard]] bool ValidateMovement(const ActorSnapshot& actor) noexcept;
+
+// How many ticks apart relays to this recipient should be spaced.
+//
+// 1 means "every tick". The value grows with distance and with how far the
+// cluster is over its time budget, so a quiet server never throttles and a
+// packed city square degrades smoothly instead of stalling the tick.
+[[nodiscard]] uint32_t ComputeSkipFactor(float sqrDistance,
+                                         uint32_t pressureLevel,
+                                         const ParallelConfig& config) noexcept;
+
+// Whether this particular (sender, recipient) edge transmits on this tick.
+//
+// The phase is derived from the pair rather than shared, so a throttled
+// cluster spreads its relays evenly over the skip window instead of sending
+// everything on the same tick and idling in between.
+[[nodiscard]] bool ShouldRelayThisTick(uint64_t tickIndex, uint32_t senderFormId,
+                                       Networking::UserId recipientUserId,
+                                       uint32_t skipFactor) noexcept;
+
+// Processes a contiguous range of a cluster's members: validates each one's
+// update and expands its relay list into concrete sends. `output` is reset
+// before use.
+//
+// The unit of work is a range rather than a whole cluster because a single
+// crowded area is routinely most of a tick's work, and a design that could
+// not split it would cap the achievable speedup at whatever fraction the
+// other areas contribute. Each sender's work depends only on the immutable
+// snapshot, so any partition of the members is safe; keeping the ranges
+// contiguous and processing them in order is what keeps the join
+// deterministic.
+//
+// pressureLevel is derived from the previous tick's measurement, so it is a
+// plain input here and introduces no cross-task dependency.
+void ProcessRange(const TickSnapshot& snapshot, const uint32_t* actorIndices,
+                  size_t actorCount, uint32_t pressureLevel,
+                  const ParallelConfig& config, ClusterOutput& output);
+
+}
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/LoadBalancer.cpp
+++ b/skymp5-server/cpp/server_guest_lib/parallel/LoadBalancer.cpp
@@ -1,0 +1,97 @@
+#include "LoadBalancer.h"
+
+#include <algorithm>
+
+namespace MpParallel {
+
+void LoadBalancer::Observe(const AreaKey& key, uint64_t elapsedMicros,
+                           uint64_t tickIndex)
+{
+  CostEntry& entry = costByArea[key];
+  const double sample = static_cast<double>(elapsedMicros);
+
+  if (entry.sampleCount == 0) {
+    entry.emaMicros = sample;
+  } else {
+    entry.emaMicros = kEmaAlpha * sample + (1.0 - kEmaAlpha) * entry.emaMicros;
+  }
+
+  entry.lastMicros = elapsedMicros;
+  entry.lastSeenTick = tickIndex;
+  if (entry.sampleCount < UINT32_MAX) {
+    ++entry.sampleCount;
+  }
+}
+
+uint64_t LoadBalancer::EstimateMicros(const AreaCluster& cluster) const
+{
+  auto it = costByArea.find(cluster.representative);
+  if (it != costByArea.end() && it->second.sampleCount > 0) {
+    return static_cast<uint64_t>(it->second.emaMicros);
+  }
+
+  const double estimate =
+    static_cast<double>(cluster.Size()) * kColdStartMicrosPerActor;
+  return static_cast<uint64_t>(estimate);
+}
+
+uint32_t LoadBalancer::GetPressureLevel(const AreaKey& key,
+                                        uint64_t perClusterBudgetMicros,
+                                        uint32_t maxLevel) const
+{
+  if (perClusterBudgetMicros == 0 || maxLevel == 0) {
+    return 0;
+  }
+
+  auto it = costByArea.find(key);
+  if (it == costByArea.end() || it->second.sampleCount == 0) {
+    return 0;
+  }
+
+  // Judge on the smoothed cost rather than the last raw sample: a single
+  // slow tick, e.g. one that collided with a garbage collection pause, is
+  // not a reason to start dropping updates on players.
+  const double smoothed = it->second.emaMicros;
+  const double budget = static_cast<double>(perClusterBudgetMicros);
+  if (smoothed <= budget) {
+    return 0;
+  }
+
+  const uint64_t ratio = static_cast<uint64_t>(smoothed / budget);
+  return static_cast<uint32_t>(std::min<uint64_t>(ratio, maxLevel));
+}
+
+void LoadBalancer::BuildSchedule(const std::vector<AreaCluster>& clusters,
+                                 std::vector<uint32_t>& outOrder) const
+{
+  outOrder.clear();
+  outOrder.reserve(clusters.size());
+  for (uint32_t i = 0; i < static_cast<uint32_t>(clusters.size()); ++i) {
+    outOrder.push_back(i);
+  }
+
+  std::stable_sort(outOrder.begin(), outOrder.end(),
+                   [this, &clusters](uint32_t lhs, uint32_t rhs) {
+                     const uint64_t lhsCost = EstimateMicros(clusters[lhs]);
+                     const uint64_t rhsCost = EstimateMicros(clusters[rhs]);
+                     return lhsCost > rhsCost;
+                   });
+}
+
+void LoadBalancer::EvictStale(uint64_t currentTickIndex, uint64_t maxAgeTicks)
+{
+  if (maxAgeTicks == 0 || currentTickIndex < maxAgeTicks) {
+    return;
+  }
+
+  const uint64_t cutoff = currentTickIndex - maxAgeTicks;
+  for (auto it = costByArea.begin(); it != costByArea.end();) {
+    if (it->second.lastSeenTick < cutoff) {
+      it = costByArea.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/LoadBalancer.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/LoadBalancer.h
@@ -1,0 +1,77 @@
+#pragma once
+#include "AreaCluster.h"
+#include "AreaKey.h"
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace MpParallel {
+
+// Decides the order clusters are handed to the pool in, and how hard each one
+// should throttle.
+//
+// Cluster costs differ by an order of magnitude between a market square and a
+// lone traveller on a road, and the cost of a given area is strongly
+// correlated tick to tick. Scheduling the expensive ones first (longest
+// processing time first) is the standard greedy answer to that: it keeps the
+// long pole from being picked up last and leaving every other slot waiting at
+// the barrier.
+class LoadBalancer
+{
+public:
+  // Records how long a cluster actually took, keyed by its stable identity.
+  void Observe(const AreaKey& key, uint64_t elapsedMicros, uint64_t tickIndex);
+
+  // Predicted cost. Falls back to a relay-edge proxy for an area that has not
+  // been measured yet, which is what makes the very first tick in a new city
+  // schedule sensibly rather than at random.
+  [[nodiscard]] uint64_t EstimateMicros(const AreaCluster& cluster) const;
+
+  // 0 means "within budget, do not throttle". Higher values ask the interest
+  // manager to space distant relays further apart.
+  [[nodiscard]] uint32_t GetPressureLevel(const AreaKey& key,
+                                          uint64_t perClusterBudgetMicros,
+                                          uint32_t maxLevel) const;
+
+  // Fills outOrder with cluster indices, most expensive first.
+  void BuildSchedule(const std::vector<AreaCluster>& clusters,
+                     std::vector<uint32_t>& outOrder) const;
+
+  // Drops areas nobody has visited for a while so the table does not grow
+  // without bound as players roam the map.
+  void EvictStale(uint64_t currentTickIndex, uint64_t maxAgeTicks);
+
+  [[nodiscard]] size_t GetTrackedAreaCount() const noexcept
+  {
+    return costByArea.size();
+  }
+
+  void Clear() noexcept { costByArea.clear(); }
+
+private:
+  struct CostEntry
+  {
+    // Exponentially weighted moving average of measured microseconds.
+    double emaMicros = 0.0;
+    uint64_t lastMicros = 0;
+    uint64_t lastSeenTick = 0;
+    uint32_t sampleCount = 0;
+  };
+
+  // Weight of the newest sample. High enough to react to a crowd forming
+  // within a couple of ticks, low enough that one slow tick caused by an
+  // unrelated stall does not pin the area at maximum throttle.
+  static constexpr double kEmaAlpha = 0.3;
+
+  // Microseconds attributed to one actor before any measurement exists. Only
+  // used for cold-start ordering, so being off by a factor of two costs
+  // nothing but a slightly worse schedule on the first tick.
+  //
+  // There is no per-edge term: relay edges are no longer enumerated on the
+  // main thread, so a cluster's cost is estimated from its population.
+  static constexpr double kColdStartMicrosPerActor = 2.0;
+
+  std::unordered_map<AreaKey, CostEntry, AreaKeyHash> costByArea;
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/OffloadDispatcher.cpp
+++ b/skymp5-server/cpp/server_guest_lib/parallel/OffloadDispatcher.cpp
@@ -1,0 +1,463 @@
+#include "OffloadDispatcher.h"
+
+#include "InterestManager.h"
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+#include <spdlog/spdlog.h>
+
+namespace MpParallel {
+
+namespace {
+
+[[nodiscard]] uint64_t NowMicros() noexcept
+{
+  return static_cast<uint64_t>(
+    std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now().time_since_epoch())
+      .count());
+}
+
+// How long an unvisited area keeps its cost estimate. At the server's ~1ms
+// tick this is roughly a minute, long enough to survive a player stepping
+// into a building and back out.
+constexpr uint64_t kCostEntryMaxAgeTicks = 60000;
+
+constexpr uint64_t kEvictIntervalTicks = 4096;
+
+// Backstop against unbounded growth if the framework is enabled by an
+// embedder that never calls ExecuteTick. At the real tick rate this is far
+// above anything a legitimate tick produces, so hitting it means something is
+// wrong rather than that the server is busy.
+constexpr size_t kMaxPendingSubmissions = 200000;
+
+}
+
+OffloadDispatcher::OffloadDispatcher(const ParallelConfig& config_)
+  : config(config_)
+{
+  config.Normalize();
+  ResetPool();
+}
+
+OffloadDispatcher::~OffloadDispatcher() = default;
+
+void OffloadDispatcher::ResetPool()
+{
+  // A disabled dispatcher spawns nothing. Turning it on at runtime is what
+  // builds the threads.
+  const size_t desired = config.enabled ? config.workerThreads : 0;
+
+  if (pool && pool->GetWorkerCount() == desired) {
+    return;
+  }
+
+  // Destroy before constructing so the two pools never coexist and
+  // double-subscribe the machine's cores.
+  pool.reset();
+  pool = std::make_unique<ThreadPool>(desired);
+  lastFailedTaskCount = 0;
+}
+
+void OffloadDispatcher::Reconfigure(const ParallelConfig& newConfig)
+{
+  DiscardPending();
+  config = newConfig;
+  config.Normalize();
+  loadBalancer.Clear();
+  ResetPool();
+}
+
+void OffloadDispatcher::DiscardPending() noexcept
+{
+  snapshot.Clear();
+  clusters.clear();
+  workUnits.clear();
+  for (ClusterOutput& output : unitOutputs) {
+    output.Reset();
+  }
+}
+
+bool OffloadDispatcher::SubmitMovement(const MovementSubmission& submission)
+{
+  if (!config.enabled) {
+    return false;
+  }
+
+  // A relay with no packet behind it would produce sends of length zero, and
+  // an actor with no owner has nothing to correct. Both mean the caller
+  // built the submission wrong, so hand it back rather than guessing.
+  if (submission.packetData == nullptr || submission.packetLength == 0) {
+    return false;
+  }
+
+  if (snapshot.actors.size() >= kMaxPendingSubmissions) {
+    spdlog::error("MpParallel: pending submissions hit the {} cap; is "
+                  "ExecuteTick being called?",
+                  kMaxPendingSubmissions);
+    return false;
+  }
+
+  ActorSnapshot actor;
+  actor.formId = submission.formId;
+  actor.idx = submission.idx;
+  actor.ownerUserId = submission.ownerUserId;
+
+  std::copy(std::begin(submission.currentPos), std::end(submission.currentPos),
+            std::begin(actor.currentPos));
+  std::copy(std::begin(submission.currentRot), std::end(submission.currentRot),
+            std::begin(actor.currentRot));
+  actor.currentWorldOrCell = submission.currentWorldOrCell;
+
+  std::copy(std::begin(submission.proposedPos),
+            std::end(submission.proposedPos), std::begin(actor.proposedPos));
+  std::copy(std::begin(submission.proposedRot),
+            std::end(submission.proposedRot), std::begin(actor.proposedRot));
+  actor.proposedWorldOrCell = submission.proposedWorldOrCell;
+
+  actor.teleportFlag = submission.teleportFlag;
+  actor.isInJumpState = submission.isInJumpState;
+  actor.isWeapDrawn = submission.isWeapDrawn;
+  actor.isBlocking = submission.isBlocking;
+  actor.isSneaking = submission.isSneaking;
+  actor.isStanding = submission.isStanding;
+
+  // Partition by where the server currently believes the actor is, not by
+  // where the client is asking to go. A rejected update must not be able to
+  // move an actor between clusters.
+  actor.worldOrCell = submission.currentWorldOrCell;
+  actor.area = AreaKey{ submission.currentWorldOrCell,
+                        ToChunkCoord(submission.currentPos[0]),
+                        ToChunkCoord(submission.currentPos[1]) };
+
+  actor.packetOffset = static_cast<uint32_t>(snapshot.rawPacketBytes.size());
+  actor.packetLength = static_cast<uint32_t>(submission.packetLength);
+  snapshot.rawPacketBytes.insert(snapshot.rawPacketBytes.end(),
+                                 submission.packetData,
+                                 submission.packetData + submission.packetLength);
+
+  actor.clusterIndex = kUnassignedCluster;
+  snapshot.actors.push_back(actor);
+  return true;
+}
+
+void OffloadDispatcher::SetPotentialTargets(std::vector<RelayTarget>&& targets)
+{
+  snapshot.relayTargets = std::move(targets);
+  std::sort(snapshot.relayTargets.begin(), snapshot.relayTargets.end(),
+            [](const RelayTarget& a, const RelayTarget& b) {
+              if (a.worldOrCell != b.worldOrCell) {
+                return a.worldOrCell < b.worldOrCell;
+              }
+              if (a.chunkX != b.chunkX) {
+                return a.chunkX < b.chunkX;
+              }
+              return a.chunkY < b.chunkY;
+            });
+}
+
+void OffloadDispatcher::ExecuteTick(IOffloadSink& sink)
+{
+  ++snapshot.tickIndex;
+  metrics.ResetTick();
+  metrics.lastTickIndex = snapshot.tickIndex;
+  ++metrics.totalTicks;
+
+  if (snapshot.Empty()) {
+    snapshot.Clear();
+    return;
+  }
+
+  metrics.lastActorCount = snapshot.actors.size();
+
+  RunUnits();
+  JoinResults(sink);
+
+  if (pool) {
+    const uint64_t failed = pool->GetFailedTaskCount();
+    if (failed > lastFailedTaskCount) {
+      metrics.totalFailedTasks += failed - lastFailedTaskCount;
+      lastFailedTaskCount = failed;
+    }
+  }
+
+  if (snapshot.tickIndex % kEvictIntervalTicks == 0) {
+    loadBalancer.EvictStale(snapshot.tickIndex, kCostEntryMaxAgeTicks);
+  }
+
+  if (config.metricsLogIntervalTicks > 0 &&
+      snapshot.tickIndex % config.metricsLogIntervalTicks == 0) {
+    spdlog::info(
+      "MpParallel: tick={} actors={} clusters={} biggest={} units={} "
+      "(pooled {}) relays={} throttled={} parallel={}us join={}us "
+      "speedup={:.2f}x",
+      metrics.lastTickIndex, metrics.lastActorCount, metrics.lastClusterCount,
+      metrics.lastLargestClusterSize, metrics.lastWorkUnitCount,
+      metrics.lastPooledUnitCount, metrics.lastRelayEdgesEmitted,
+      metrics.lastRelayEdgesThrottled, metrics.lastParallelMicros,
+      metrics.lastJoinMicros, metrics.GetLastSpeedup());
+  }
+
+  snapshot.Clear();
+}
+
+size_t OffloadDispatcher::ComputeShardCount(size_t clusterSize) const
+{
+  if (clusterSize <= config.minShardActors) {
+    return 1;
+  }
+
+  // Enough pieces for the dynamic scheduler to balance, but not so many that
+  // task overhead eats the gain. Two per slot is the usual sweet spot: it
+  // absorbs the variance between a shard of stationary players and a shard
+  // in the middle of a fight.
+  const size_t slots = pool ? pool->GetSlotCount() : 1;
+  const size_t configured = config.maxShardsPerCluster > 0
+    ? config.maxShardsPerCluster
+    : slots * 2;
+
+  const size_t byMinSize = clusterSize / config.minShardActors;
+  return std::max<size_t>(1, std::min(configured, byMinSize));
+}
+
+void OffloadDispatcher::BuildWorkUnits(bool allowSharding)
+{
+  workUnits.clear();
+
+  // Emitting units in cluster-index order, and in ascending member order
+  // within a cluster, is what makes the join reproducible: the unit list is
+  // a partition of the same sequence a single thread would have walked.
+  for (uint32_t clusterIndex = 0;
+       clusterIndex < static_cast<uint32_t>(clusters.size()); ++clusterIndex) {
+    const AreaCluster& cluster = clusters[clusterIndex];
+    const size_t size = cluster.Size();
+    if (size == 0) {
+      continue;
+    }
+
+    const size_t shardCount = allowSharding ? ComputeShardCount(size) : 1;
+    const size_t perShard = (size + shardCount - 1) / shardCount;
+
+    for (size_t begin = 0; begin < size; begin += perShard) {
+      WorkUnit unit;
+      unit.clusterIndex = clusterIndex;
+      unit.begin = static_cast<uint32_t>(begin);
+      unit.count = static_cast<uint32_t>(std::min(perShard, size - begin));
+      workUnits.push_back(unit);
+    }
+  }
+
+  if (unitOutputs.size() < workUnits.size()) {
+    unitOutputs.resize(workUnits.size());
+  }
+  for (size_t i = 0; i < workUnits.size(); ++i) {
+    unitOutputs[i].Reset();
+  }
+}
+
+void OffloadDispatcher::RunUnits()
+{
+  const uint64_t parallelStart = NowMicros();
+
+  const bool offload = pool && pool->GetWorkerCount() > 0 &&
+    snapshot.actors.size() >= config.minActorsToOffload;
+
+  if (offload) {
+    partitioner.Partition(snapshot.actors, config.clusterSeparationChunks,
+                          clusters);
+    metrics.lastChunkCount = partitioner.GetLastChunkCount();
+    ++metrics.totalOffloadedTicks;
+  } else {
+    // One cluster covering everything. Below the offload threshold the
+    // barrier costs more than the work, and partitioning would be wasted
+    // effort on top of that.
+    clusters.clear();
+    clusters.emplace_back();
+    AreaCluster& single = clusters.back();
+    single.representative = snapshot.actors.front().area;
+    single.chunkCount = 1;
+    single.actorIndices.reserve(snapshot.actors.size());
+    for (uint32_t i = 0; i < static_cast<uint32_t>(snapshot.actors.size());
+         ++i) {
+      snapshot.actors[i].clusterIndex = 0;
+      single.actorIndices.push_back(i);
+    }
+    metrics.lastChunkCount = 1;
+    ++metrics.totalInlineTicks;
+  }
+
+  metrics.lastClusterCount = clusters.size();
+  for (const AreaCluster& cluster : clusters) {
+    metrics.lastLargestClusterSize =
+      std::max(metrics.lastLargestClusterSize, cluster.Size());
+  }
+
+  // Pressure is read from the previous tick's measurements, so it is a plain
+  // input to the tasks and creates no dependency between them.
+  const uint64_t perClusterBudget = std::max<uint64_t>(
+    config.targetTickBudgetMicros / std::max<size_t>(clusters.size(), 1), 1);
+
+  pressureByCluster.assign(clusters.size(), 0);
+  if (config.adaptiveThrottling) {
+    for (size_t i = 0; i < clusters.size(); ++i) {
+      pressureByCluster[i] = loadBalancer.GetPressureLevel(
+        clusters[i].representative, perClusterBudget,
+        std::max<uint32_t>(config.maxThrottleSkipTicks, 1));
+    }
+  }
+
+  BuildWorkUnits(offload);
+  metrics.lastWorkUnitCount = workUnits.size();
+
+  if (!offload) {
+    for (size_t unitIndex = 0; unitIndex < workUnits.size(); ++unitIndex) {
+      const WorkUnit& unit = workUnits[unitIndex];
+      const uint64_t taskStart = NowMicros();
+      InterestManager::ProcessRange(
+        snapshot, clusters[unit.clusterIndex].actorIndices.data() + unit.begin,
+        unit.count, pressureByCluster[unit.clusterIndex], config,
+        unitOutputs[unitIndex]);
+      unitOutputs[unitIndex].elapsedMicros = NowMicros() - taskStart;
+    }
+    // lastAggregateTaskMicros is accumulated by JoinResults, which walks the
+    // same outputs; adding it here too would double count.
+    metrics.lastParallelMicros = NowMicros() - parallelStart;
+    return;
+  }
+
+  // Longest cluster first so the biggest pieces enter the queue before the
+  // scraps. The pool hands tasks out dynamically from there.
+  loadBalancer.BuildSchedule(clusters, schedule);
+
+  clusterRank.assign(clusters.size(), 0);
+  for (uint32_t rank = 0; rank < static_cast<uint32_t>(schedule.size());
+       ++rank) {
+    clusterRank[schedule[rank]] = rank;
+  }
+
+  tasks.clear();
+  inlineUnitIndices.clear();
+  tasks.reserve(workUnits.size());
+
+  orderedUnitIndices.clear();
+  orderedUnitIndices.reserve(workUnits.size());
+  for (uint32_t unitIndex = 0;
+       unitIndex < static_cast<uint32_t>(workUnits.size()); ++unitIndex) {
+    orderedUnitIndices.push_back(unitIndex);
+  }
+  std::stable_sort(orderedUnitIndices.begin(), orderedUnitIndices.end(),
+                   [this](uint32_t lhs, uint32_t rhs) {
+                     return clusterRank[workUnits[lhs].clusterIndex] <
+                       clusterRank[workUnits[rhs].clusterIndex];
+                   });
+
+  const size_t maxPooled = config.maxWorkUnitsPerTick > 0
+    ? config.maxWorkUnitsPerTick
+    : orderedUnitIndices.size();
+
+  for (const uint32_t unitIndex : orderedUnitIndices) {
+    const WorkUnit& unit = workUnits[unitIndex];
+    // A unit that is the whole of a tiny cluster is cheaper to sweep up on
+    // the calling thread than to hand through the scheduler.
+    const bool tooSmall =
+      clusters[unit.clusterIndex].Size() < config.minClusterActors;
+    if (tooSmall || tasks.size() >= maxPooled) {
+      inlineUnitIndices.push_back(unitIndex);
+      continue;
+    }
+
+    tasks.emplace_back([this, unitIndex](size_t) {
+      const WorkUnit& u = workUnits[unitIndex];
+      const uint64_t taskStart = NowMicros();
+      InterestManager::ProcessRange(
+        snapshot, clusters[u.clusterIndex].actorIndices.data() + u.begin,
+        u.count, pressureByCluster[u.clusterIndex], config,
+        unitOutputs[unitIndex]);
+      unitOutputs[unitIndex].elapsedMicros = NowMicros() - taskStart;
+    });
+  }
+
+  metrics.lastPooledUnitCount = tasks.size();
+
+  pool->Run(tasks);
+
+  // The calling thread has finished its share of the pooled work by now, so
+  // sweeping up the leftovers here costs nothing extra.
+  for (const uint32_t unitIndex : inlineUnitIndices) {
+    const WorkUnit& unit = workUnits[unitIndex];
+    const uint64_t taskStart = NowMicros();
+    InterestManager::ProcessRange(
+      snapshot, clusters[unit.clusterIndex].actorIndices.data() + unit.begin,
+      unit.count, pressureByCluster[unit.clusterIndex], config,
+      unitOutputs[unitIndex]);
+    unitOutputs[unitIndex].elapsedMicros = NowMicros() - taskStart;
+  }
+
+  metrics.lastParallelMicros = NowMicros() - parallelStart;
+}
+
+void OffloadDispatcher::JoinResults(IOffloadSink& sink)
+{
+  const uint64_t joinStart = NowMicros();
+
+  clusterMicros.assign(clusters.size(), 0);
+
+  // Work-unit order: cluster index, then ascending member order within the
+  // cluster. Both are fixed before any task starts, so the same inputs
+  // produce the same sequence of world writes no matter how many cores ran
+  // the tick or how the shards were distributed.
+  for (size_t unitIndex = 0; unitIndex < workUnits.size(); ++unitIndex) {
+    const WorkUnit& unit = workUnits[unitIndex];
+    ClusterOutput& output = unitOutputs[unitIndex];
+
+    for (const OutboundSend& send : output.sends) {
+      if (send.byteLength == 0 ||
+          static_cast<size_t>(send.byteOffset) + send.byteLength >
+            snapshot.rawPacketBytes.size()) {
+        continue;
+      }
+      sink.SendRelay(send.userId,
+                     snapshot.rawPacketBytes.data() + send.byteOffset,
+                     send.byteLength, send.reliable);
+    }
+
+    for (const MovementVerdict& verdict : output.verdicts) {
+      if (verdict.actorIndex >= snapshot.actors.size()) {
+        continue;
+      }
+      const ActorSnapshot& actor = snapshot.actors[verdict.actorIndex];
+
+      if (verdict.accepted) {
+        sink.ApplyMovement(actor);
+      } else {
+        ++metrics.lastRejectedMovements;
+        if (verdict.needsCorrection) {
+          sink.SendCorrection(actor);
+        }
+      }
+    }
+
+    metrics.lastRelayEdgesEmitted += output.emittedEdges;
+    metrics.lastRelayEdgesThrottled += output.throttledEdges;
+    metrics.lastAggregateTaskMicros += output.elapsedMicros;
+
+    if (unit.clusterIndex < clusterMicros.size()) {
+      clusterMicros[unit.clusterIndex] += output.elapsedMicros;
+    }
+  }
+
+  // Cost is tracked per area, so a cluster's shards are summed back together
+  // before being fed to the estimator. Otherwise splitting a busy area would
+  // make it look cheap and it would never be recognised as under pressure.
+  for (size_t clusterIndex = 0; clusterIndex < clusters.size();
+       ++clusterIndex) {
+    loadBalancer.Observe(clusters[clusterIndex].representative,
+                         clusterMicros[clusterIndex], snapshot.tickIndex);
+  }
+
+  metrics.totalRelayEdgesEmitted += metrics.lastRelayEdgesEmitted;
+  metrics.totalRelayEdgesThrottled += metrics.lastRelayEdgesThrottled;
+  metrics.lastJoinMicros = NowMicros() - joinStart;
+}
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/OffloadDispatcher.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/OffloadDispatcher.h
@@ -1,0 +1,195 @@
+#pragma once
+#include "AreaCluster.h"
+#include "AreaPartitioner.h"
+#include "LoadBalancer.h"
+#include "ParallelConfig.h"
+#include "ParallelMetrics.h"
+#include "RelayPlan.h"
+#include "ThreadPool.h"
+#include "TickSnapshot.h"
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace MpParallel {
+
+// Everything ActionListener knows about one movement update, flattened into
+// plain data. The dispatcher copies what it needs, so nothing here has to
+// outlive the call.
+struct MovementSubmission
+{
+  uint32_t formId = 0;
+  uint32_t idx = 0;
+  Networking::UserId ownerUserId = Networking::InvalidUserId;
+
+  float currentPos[3] = { 0.f, 0.f, 0.f };
+  float currentRot[3] = { 0.f, 0.f, 0.f };
+  uint32_t currentWorldOrCell = 0;
+
+  float proposedPos[3] = { 0.f, 0.f, 0.f };
+  float proposedRot[3] = { 0.f, 0.f, 0.f };
+  uint32_t proposedWorldOrCell = 0;
+
+  bool teleportFlag = false;
+  bool isInJumpState = false;
+  bool isWeapDrawn = false;
+  bool isBlocking = false;
+  bool isSneaking = false;
+  bool isStanding = false;
+
+  // The client's packet, forwarded to neighbours byte for byte.
+  const uint8_t* packetData = nullptr;
+  size_t packetLength = 0;
+};
+
+// The main-thread effects the join phase has to perform. Splitting them
+// behind an interface is what lets the dispatcher be tested without a
+// PartOne, an espm load order, or a socket.
+//
+// IMPORTANT for implementers: a submission and its join are separated by the
+// rest of the packet pump, during which an actor can be destroyed or its
+// owner can disconnect. Every method must re-resolve the actor by formId and
+// do nothing if it is gone, and must check the user is still connected
+// before sending.
+class IOffloadSink
+{
+public:
+  virtual ~IOffloadSink() = default;
+
+  // Write the validated transform and animation state to the live actor.
+  virtual void ApplyMovement(const ActorSnapshot& actor) = 0;
+
+  // Pull the owning client back to the server's transform after a rejected
+  // update.
+  virtual void SendCorrection(const ActorSnapshot& actor) = 0;
+
+  virtual void SendRelay(Networking::UserId userId, const uint8_t* data,
+                         size_t length, bool reliable) = 0;
+};
+
+// Collects movement updates during packet ingest, processes them across the
+// worker pool once per tick, and applies the results in a deterministic
+// order.
+//
+// Threading contract: every public method is main-thread only and none may be
+// called while ExecuteTick is running. Worker threads exist solely inside
+// ExecuteTick and touch nothing but the snapshot (read) and the one
+// ClusterOutput belonging to their work unit (write).
+class OffloadDispatcher
+{
+public:
+  explicit OffloadDispatcher(const ParallelConfig& config);
+  ~OffloadDispatcher();
+
+  OffloadDispatcher(const OffloadDispatcher&) = delete;
+  OffloadDispatcher& operator=(const OffloadDispatcher&) = delete;
+
+  // Rebuilds the pool if the worker count changed. Safe to call between
+  // ticks; discards anything already submitted.
+  void Reconfigure(const ParallelConfig& newConfig);
+
+  [[nodiscard]] const ParallelConfig& GetConfig() const noexcept
+  {
+    return config;
+  }
+
+  [[nodiscard]] bool IsEnabled() const noexcept { return config.enabled; }
+
+  // Returns false when the update was not taken on, in which case the caller
+  // must fall back to handling it inline. That happens when the framework is
+  // disabled and on any malformed submission, so a rejection is always safe.
+  bool SubmitMovement(const MovementSubmission& submission);
+
+  // Called once per tick by the main thread to snapshot all active listeners.
+  // This $O(N)$ snapshot is passed to workers so they can spatially filter
+  // recipients without enumerating the $O(N^2)$ edges on the main thread.
+  void SetPotentialTargets(std::vector<RelayTarget>&& targets);
+
+  [[nodiscard]] size_t GetPendingCount() const noexcept
+  {
+    return snapshot.actors.size();
+  }
+
+  // Runs the parallel phase and then the join. Clears the pending set.
+  void ExecuteTick(IOffloadSink& sink);
+
+  // Throws away pending work without applying it. Used when the world is
+  // being torn down.
+  void DiscardPending() noexcept;
+
+  [[nodiscard]] const ParallelMetrics& GetMetrics() const noexcept
+  {
+    return metrics;
+  }
+
+  [[nodiscard]] const std::vector<AreaCluster>& GetLastClusters() const noexcept
+  {
+    return clusters;
+  }
+
+  // Exposed for tests that need to drive several ticks and observe the
+  // throttle warming up.
+  [[nodiscard]] uint64_t GetTickIndex() const noexcept
+  {
+    return snapshot.tickIndex;
+  }
+
+private:
+  // A contiguous slice of one cluster's members. The unit of scheduling.
+  //
+  // Splitting clusters matters more than splitting across them: on a typical
+  // populated server one hub holds the large majority of a tick's relay work,
+  // so a cluster-sized task would leave most cores idle exactly when the
+  // server is busiest.
+  struct WorkUnit
+  {
+    uint32_t clusterIndex = 0;
+    // Offset and length within AreaCluster::actorIndices.
+    uint32_t begin = 0;
+    uint32_t count = 0;
+  };
+
+  // allowSharding is false on the inline path, where splitting a cluster
+  // would only add per-unit bookkeeping to work that runs serially anyway.
+  void BuildWorkUnits(bool allowSharding);
+  void RunUnits();
+  void JoinResults(IOffloadSink& sink);
+  void ResetPool();
+  [[nodiscard]] size_t ComputeShardCount(size_t clusterSize) const;
+
+  ParallelConfig config;
+  std::unique_ptr<ThreadPool> pool;
+
+  TickSnapshot snapshot;
+  AreaPartitioner partitioner;
+  LoadBalancer loadBalancer;
+
+  std::vector<AreaCluster> clusters;
+  std::vector<uint32_t> schedule;
+  std::vector<uint32_t> pressureByCluster;
+
+  // Parallel arrays indexed by work-unit index. Units are emitted in cluster
+  // order, then in ascending member order inside a cluster, so walking them
+  // in index order during the join reproduces the single-threaded sequence.
+  std::vector<WorkUnit> workUnits;
+  std::vector<ClusterOutput> unitOutputs;
+
+  // Unit indices in scheduling order: busiest cluster's shards first. Only
+  // affects which task enters the queue first, never the join order.
+  std::vector<uint32_t> orderedUnitIndices;
+
+  std::vector<ThreadPool::Task> tasks;
+  std::vector<uint32_t> inlineUnitIndices;
+
+  // Scratch for aggregating shard times back to their cluster.
+  std::vector<uint64_t> clusterMicros;
+
+  // Scratch: position of each cluster in `schedule`, so units can be ordered
+  // by their cluster's rank without a lookup per comparison.
+  std::vector<uint32_t> clusterRank;
+
+  ParallelMetrics metrics;
+  uint64_t lastFailedTaskCount = 0;
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/ParallelConfig.cpp
+++ b/skymp5-server/cpp/server_guest_lib/parallel/ParallelConfig.cpp
@@ -1,0 +1,148 @@
+#include "ParallelConfig.h"
+
+#include <algorithm>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <thread>
+
+namespace MpParallel {
+
+namespace {
+
+// Number of cores deliberately left to other threads: the Node/V8 main
+// thread that drives ScampServer::Tick, and Viet's async save-storage
+// thread. Oversubscribing them is what turns a throughput win into a
+// latency regression.
+constexpr size_t kReservedCores = 2;
+
+template <typename T>
+T ReadNumber(const nlohmann::json& obj, const char* key, T fallback)
+{
+  auto it = obj.find(key);
+  if (it == obj.end() || it->is_null()) {
+    return fallback;
+  }
+  if (!it->is_number()) {
+    throw std::runtime_error(
+      fmt::format("parallelism.{} must be a number", key));
+  }
+  return it->get<T>();
+}
+
+bool ReadBool(const nlohmann::json& obj, const char* key, bool fallback)
+{
+  auto it = obj.find(key);
+  if (it == obj.end() || it->is_null()) {
+    return fallback;
+  }
+  if (!it->is_boolean()) {
+    throw std::runtime_error(
+      fmt::format("parallelism.{} must be a boolean", key));
+  }
+  return it->get<bool>();
+}
+
+}
+
+void ParallelConfig::Normalize()
+{
+  if (workerThreads == 0) {
+    const size_t detected = std::thread::hardware_concurrency();
+    workerThreads = detected > kReservedCores ? detected - kReservedCores : 1;
+  }
+  workerThreads = std::min(workerThreads, kMaxWorkerThreads);
+  workerThreads = std::max<size_t>(workerThreads, 1);
+
+  clusterSeparationChunks =
+    std::max(clusterSeparationChunks, kMinSafeSeparationChunks);
+
+  minClusterActors = std::max<size_t>(minClusterActors, 1);
+  minActorsToOffload = std::max<size_t>(minActorsToOffload, 1);
+  minShardActors = std::max<size_t>(minShardActors, 1);
+
+  if (targetTickBudgetMicros == 0) {
+    targetTickBudgetMicros = 8000;
+  }
+
+  throttleDistanceUnits = std::max(throttleDistanceUnits, 1.f);
+  maxThrottleSkipTicks = std::min<uint32_t>(maxThrottleSkipTicks, 32);
+
+  interestFullRateUnits = std::max(interestFullRateUnits, 1.f);
+  maxInterestSkipTicks =
+    std::min<uint32_t>(std::max<uint32_t>(maxInterestSkipTicks, 1), 32);
+}
+
+ParallelConfig ParallelConfig::FromServerSettings(
+  const nlohmann::json& serverSettings)
+{
+  ParallelConfig config;
+
+  auto it = serverSettings.find("parallelism");
+  if (it == serverSettings.end() || it->is_null()) {
+    config.Normalize();
+    return config;
+  }
+
+  if (!it->is_object()) {
+    throw std::runtime_error("parallelism must be an object");
+  }
+
+  const nlohmann::json& j = *it;
+
+  config.enabled = ReadBool(j, "enabled", config.enabled);
+  config.adaptiveThrottling =
+    ReadBool(j, "adaptiveThrottling", config.adaptiveThrottling);
+  config.interestManagement =
+    ReadBool(j, "interestManagement", config.interestManagement);
+  config.interestFullRateUnits = ReadNumber<float>(
+    j, "interestFullRateUnits", config.interestFullRateUnits);
+  config.maxInterestSkipTicks = ReadNumber<uint32_t>(
+    j, "maxInterestSkipTicks", config.maxInterestSkipTicks);
+
+  config.workerThreads =
+    ReadNumber<size_t>(j, "workerThreads", config.workerThreads);
+  config.minActorsToOffload =
+    ReadNumber<size_t>(j, "minActorsToOffload", config.minActorsToOffload);
+  config.minClusterActors =
+    ReadNumber<size_t>(j, "minClusterActors", config.minClusterActors);
+  config.minShardActors =
+    ReadNumber<size_t>(j, "minShardActors", config.minShardActors);
+  config.maxShardsPerCluster =
+    ReadNumber<size_t>(j, "maxShardsPerCluster", config.maxShardsPerCluster);
+  config.clusterSeparationChunks = ReadNumber<int32_t>(
+    j, "clusterSeparationChunks", config.clusterSeparationChunks);
+  config.maxWorkUnitsPerTick =
+    ReadNumber<size_t>(j, "maxWorkUnitsPerTick", config.maxWorkUnitsPerTick);
+  config.repartitionIntervalTicks = ReadNumber<uint32_t>(
+    j, "repartitionIntervalTicks", config.repartitionIntervalTicks);
+  config.targetTickBudgetMicros = ReadNumber<uint64_t>(
+    j, "targetTickBudgetMicros", config.targetTickBudgetMicros);
+  config.throttleDistanceUnits =
+    ReadNumber<float>(j, "throttleDistanceUnits", config.throttleDistanceUnits);
+  config.maxThrottleSkipTicks =
+    ReadNumber<uint32_t>(j, "maxThrottleSkipTicks", config.maxThrottleSkipTicks);
+  config.metricsLogIntervalTicks = ReadNumber<uint32_t>(
+    j, "metricsLogIntervalTicks", config.metricsLogIntervalTicks);
+
+  config.Normalize();
+  return config;
+}
+
+std::string ParallelConfig::Describe() const
+{
+  if (!enabled) {
+    return "parallel area offload: disabled";
+  }
+  return fmt::format(
+    "parallel area offload: enabled, workerThreads={}, "
+    "minActorsToOffload={}, minClusterActors={}, minShardActors={}, "
+    "separation={} chunks, interestManagement={} (fullRate={}u, maxSkip={}), "
+    "adaptiveThrottling={}, budget={}us",
+    workerThreads, minActorsToOffload, minClusterActors, minShardActors,
+    clusterSeparationChunks, interestManagement ? "on" : "off",
+    interestFullRateUnits, maxInterestSkipTicks,
+    adaptiveThrottling ? "on" : "off", targetTickBudgetMicros);
+}
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/ParallelConfig.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/ParallelConfig.h
@@ -1,0 +1,126 @@
+#pragma once
+// For kMinSafeSeparationChunks, which Normalize clamps against.
+#include "AreaKey.h"
+#include <cstddef>
+#include <cstdint>
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+
+namespace MpParallel {
+
+constexpr size_t kMaxWorkerThreads = 32;
+
+// Parsed from the "parallelism" object of server-settings.json.
+//
+// The framework is opt-in. With `enabled` false every entry point becomes a
+// no-op and the server behaves exactly as it did before, which keeps the
+// default deployment risk at zero.
+struct ParallelConfig
+{
+  bool enabled = false;
+
+  // 0 means "auto": hardware_concurrency() minus two reserved cores (one for
+  // the Node/V8 main thread, one for the async save-storage thread), clamped
+  // to [1, kMaxWorkerThreads].
+  size_t workerThreads = 0;
+
+  // Below this many tracked actors the fork/join barrier costs more than the
+  // work it distributes, so the dispatcher runs everything inline.
+  //
+  // Measured, not guessed. unit/ParallelBenchmark.cpp times the inline path
+  // against the offloaded one with every player in a single chunk:
+  //
+  //     players    25     50    100    150    250    400
+  //     speedup  0.25x  0.43x  0.66x  0.81x  0.88x  1.10x
+  //
+  // Break-even sits near 300-400. Anything lower makes the offload a
+  // regression, because the barrier and snapshot costs are paid every tick
+  // while the parallel phase is still small. Re-run
+  // `./unit/unit "[ParallelBench]"` on the target hardware before lowering it.
+  size_t minActorsToOffload = 300;
+
+  // Clusters smaller than this are merged into the inline residual batch
+  // rather than being scheduled as their own task.
+  size_t minClusterActors = 4;
+
+  // Fewest actors a shard of a large cluster may carry.
+  //
+  // A single crowded area is typically most of a tick's work, so a scheme
+  // that could only parallelise across areas would be capped at whatever
+  // fraction the quiet areas contribute. Splitting a busy cluster into
+  // several ranges is what makes the offload scale with core count instead
+  // of with the number of populated areas.
+  size_t minShardActors = 4;
+
+  // Upper bound on how many shards one cluster may be split into.
+  // 0 means "auto": twice the slot count, which gives the dynamic scheduler
+  // enough pieces to balance without paying for needless task overhead.
+  size_t maxShardsPerCluster = 0;
+
+  // --- interest management -----------------------------------------------
+  //
+  // Distance-based update-rate reduction, applied every tick regardless of
+  // load. This is the lever that actually moves the needle: relay volume is
+  // the N^2 term, and emitting those sends is serial no matter how many cores
+  // the decisions were spread over. Measured on 400 players in one chunk it
+  // cut relays from 160k to 66k per tick and the tick from 1120us to 682us.
+  //
+  // Unlike adaptiveThrottling below, this does not wait for the server to be
+  // in trouble, because a player 60 metres away does not need 60 position
+  // updates a second even on an idle server.
+  bool interestManagement = true;
+
+  // Recipients closer than this always receive every update. Sized a little
+  // over half a chunk so that anything a player is realistically fighting,
+  // trading with, or watching stays at full fidelity.
+  float interestFullRateUnits = 2048.f;
+
+  // Hard ceiling on how far apart interest management may space an update.
+  // At 4 a distant player still gets ~15 updates a second at a 60Hz tick.
+  uint32_t maxInterestSkipTicks = 4;
+
+  // Chebyshev distance, in 4096-unit chunks, that must separate two clusters.
+  // Clamped up to kMinSafeSeparationChunks.
+  int32_t clusterSeparationChunks = 4;
+
+  // 0 means unlimited. Work units beyond the limit are processed inline on
+  // the calling thread instead of going through the scheduler.
+  size_t maxWorkUnitsPerTick = 0;
+
+  // How often the partition is rebuilt. Between rebuilds the previous
+  // partition is reused, which is safe because actors are re-bucketed by
+  // their live chunk every tick and a stale cluster only costs balance
+  // quality, never correctness.
+  uint32_t repartitionIntervalTicks = 30;
+
+  // Degrade relay frequency for distant neighbours when a cluster exceeds its
+  // share of the tick budget, instead of letting the whole server stall.
+  bool adaptiveThrottling = true;
+
+  // Per-tick wall-clock target for the parallel phase, in microseconds.
+  uint64_t targetTickBudgetMicros = 8000;
+
+  // Squared distance beyond which a relay becomes eligible for throttling.
+  // Default is one exterior cell (4096 units).
+  float throttleDistanceUnits = 4096.f;
+
+  // Maximum number of ticks a throttled relay may be held back.
+  uint32_t maxThrottleSkipTicks = 3;
+
+  // Emit a per-tick summary line at this interval. 0 disables reporting.
+  uint32_t metricsLogIntervalTicks = 0;
+
+  // Resolves workerThreads==0 to a concrete count and clamps every field to
+  // its documented range. Idempotent.
+  void Normalize();
+
+  // Reads the "parallelism" object if present. Unknown keys are ignored,
+  // missing keys keep their defaults, and a malformed value throws
+  // std::runtime_error naming the offending key.
+  static ParallelConfig FromServerSettings(const nlohmann::json& serverSettings);
+
+  // Human-readable one-liner for the startup log.
+  [[nodiscard]] std::string Describe() const;
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/ParallelMetrics.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/ParallelMetrics.h
@@ -1,0 +1,86 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+namespace MpParallel {
+
+// Counters for the most recent tick plus running totals. Written only by the
+// main thread during the join, so no synchronisation is needed.
+struct ParallelMetrics
+{
+  // --- most recent tick -------------------------------------------------
+  uint64_t lastTickIndex = 0;
+  size_t lastActorCount = 0;
+  size_t lastClusterCount = 0;
+  size_t lastChunkCount = 0;
+
+  // Total scheduling units this tick, and how many of them went to the pool.
+  // A unit is a slice of a cluster, so this exceeds the cluster count
+  // whenever a busy area was split across cores.
+  size_t lastWorkUnitCount = 0;
+  size_t lastPooledUnitCount = 0;
+
+  // Members of the largest single cluster. Watch this against
+  // lastActorCount: if one cluster holds most of the population, sharding is
+  // what is buying the speedup.
+  size_t lastLargestClusterSize = 0;
+
+  uint64_t lastRelayEdgesEmitted = 0;
+  uint64_t lastRelayEdgesThrottled = 0;
+  uint64_t lastRejectedMovements = 0;
+
+  // Wall clock of the fork/join phase itself.
+  uint64_t lastParallelMicros = 0;
+  // Wall clock of the serial join that follows it.
+  uint64_t lastJoinMicros = 0;
+  // Sum of the per-cluster task times. Divided by lastParallelMicros this
+  // gives the achieved speedup, which is the number worth watching.
+  uint64_t lastAggregateTaskMicros = 0;
+
+  // --- running totals ---------------------------------------------------
+  uint64_t totalTicks = 0;
+  uint64_t totalOffloadedTicks = 0;
+  uint64_t totalInlineTicks = 0;
+  uint64_t totalRelayEdgesEmitted = 0;
+  uint64_t totalRelayEdgesThrottled = 0;
+  uint64_t totalFailedTasks = 0;
+
+  // Ratio of aggregate task time to wall-clock parallel time. 1.0 means the
+  // offload bought nothing; the theoretical ceiling is the slot count.
+  [[nodiscard]] double GetLastSpeedup() const noexcept
+  {
+    if (lastParallelMicros == 0) {
+      return 0.0;
+    }
+    return static_cast<double>(lastAggregateTaskMicros) /
+      static_cast<double>(lastParallelMicros);
+  }
+
+  [[nodiscard]] double GetLastThrottleRatio() const noexcept
+  {
+    const uint64_t total = lastRelayEdgesEmitted + lastRelayEdgesThrottled;
+    if (total == 0) {
+      return 0.0;
+    }
+    return static_cast<double>(lastRelayEdgesThrottled) /
+      static_cast<double>(total);
+  }
+
+  void ResetTick() noexcept
+  {
+    lastActorCount = 0;
+    lastClusterCount = 0;
+    lastChunkCount = 0;
+    lastWorkUnitCount = 0;
+    lastPooledUnitCount = 0;
+    lastLargestClusterSize = 0;
+    lastRelayEdgesEmitted = 0;
+    lastRelayEdgesThrottled = 0;
+    lastRejectedMovements = 0;
+    lastParallelMicros = 0;
+    lastJoinMicros = 0;
+    lastAggregateTaskMicros = 0;
+  }
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/RelayPlan.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/RelayPlan.h
@@ -1,0 +1,76 @@
+#pragma once
+#include <NetworkingInterface.h>
+#include <cstdint>
+#include <vector>
+
+namespace MpParallel {
+
+// One packet the join phase has to hand to the send target. The payload is a
+// range inside TickSnapshot::rawPacketBytes rather than a copy, because the
+// relay forwards the client's packet verbatim and many recipients share the
+// same bytes.
+struct OutboundSend
+{
+  Networking::UserId userId = Networking::InvalidUserId;
+  uint32_t byteOffset = 0;
+  uint32_t byteLength = 0;
+  bool reliable = false;
+};
+
+// What the parallel phase decided about one actor's movement update.
+struct MovementVerdict
+{
+  uint32_t actorIndex = 0;
+
+  // False means the update failed validation: the join phase must skip the
+  // state write and send the owner a correction instead.
+  bool accepted = false;
+
+  // Set when the rejection should produce a TeleportMessage2. Mirrors the
+  // `isMe` condition of the inline path: hosted NPCs are not corrected.
+  bool needsCorrection = false;
+};
+
+// Per-cluster results. Exactly one task writes each instance, and the join
+// phase reads them back in cluster order, which is what keeps the outcome
+// independent of thread scheduling.
+//
+// Cache-line aligned because the outer vector puts these next to each other
+// and different threads append to neighbouring entries throughout the
+// parallel phase.
+#if defined(_MSC_VER)
+#  pragma warning(push)
+// C4324: padded because of the alignment specifier. That is the entire point
+// here, and the build treats warnings as errors.
+#  pragma warning(disable : 4324)
+#endif
+struct alignas(64) ClusterOutput
+{
+  std::vector<OutboundSend> sends;
+  std::vector<MovementVerdict> verdicts;
+
+  // Relay edges suppressed by the distance/rate policy this tick.
+  uint64_t throttledEdges = 0;
+
+  // Relay edges emitted.
+  uint64_t emittedEdges = 0;
+
+  // Wall-clock cost of the task that produced this output, in microseconds.
+  // Feeds the load balancer's estimate for the next tick.
+  uint64_t elapsedMicros = 0;
+
+  void Reset() noexcept
+  {
+    // clear() keeps the capacity, so a steady-state tick does not allocate.
+    sends.clear();
+    verdicts.clear();
+    throttledEdges = 0;
+    emittedEdges = 0;
+    elapsedMicros = 0;
+  }
+};
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/ThreadPool.cpp
+++ b/skymp5-server/cpp/server_guest_lib/parallel/ThreadPool.cpp
@@ -1,0 +1,160 @@
+#include "ThreadPool.h"
+
+#include <algorithm>
+#include <spdlog/spdlog.h>
+
+namespace MpParallel {
+
+ThreadPool::ThreadPool(size_t numWorkers)
+{
+  workers.reserve(numWorkers);
+  for (size_t i = 0; i < numWorkers; ++i) {
+    // Slot 0 belongs to the calling thread, so spawned workers start at 1.
+    workers.emplace_back([this, slotIndex = i + 1] { WorkerMain(slotIndex); });
+  }
+}
+
+ThreadPool::~ThreadPool()
+{
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    stopping = true;
+    // Bump the generation as well so a worker that has not yet observed the
+    // most recent batch still leaves its wait.
+    ++generation;
+  }
+  cvWork.notify_all();
+
+  for (auto& worker : workers) {
+    if (worker.joinable()) {
+      worker.join();
+    }
+  }
+}
+
+void ThreadPool::Run(const std::vector<Task>& tasks)
+{
+  if (tasks.empty()) {
+    return;
+  }
+
+  if (workers.empty()) {
+    for (size_t i = 0; i < tasks.size(); ++i) {
+      RunTaskGuarded(tasks[i], 0, i);
+    }
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    currentTasks = &tasks;
+    nextTaskIndex.store(0, std::memory_order_relaxed);
+    tasksRemaining.store(tasks.size(), std::memory_order_relaxed);
+    ++generation;
+  }
+  cvWork.notify_all();
+
+  // The caller is slot 0 and pulls from the same cursor as everybody else.
+  DrainTasks(tasks, 0);
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    // Both conditions are required: the first says the work is done, the
+    // second says nobody is still touching the cursor or the task vector.
+    // See the comment on activeDrainers.
+    cvDone.wait(lock, [this] {
+      return tasksRemaining.load(std::memory_order_acquire) == 0 &&
+        activeDrainers == 0;
+    });
+    // Cleared under the lock so a worker that wakes late reads nullptr rather
+    // than a pointer to the caller's vector, which may die once Run returns.
+    currentTasks = nullptr;
+  }
+}
+
+void ThreadPool::WorkerMain(size_t slotIndex)
+{
+  uint64_t seenGeneration = 0;
+
+  for (;;) {
+    const std::vector<Task>* tasks = nullptr;
+
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      cvWork.wait(lock,
+                  [&] { return stopping || generation != seenGeneration; });
+      if (stopping) {
+        return;
+      }
+      // Reading the generation and the batch pointer under the same lock is
+      // what makes a late waker safe: it either misses a batch entirely or
+      // sees a matching (generation, tasks) pair, never a torn one.
+      seenGeneration = generation;
+      tasks = currentTasks;
+      if (tasks) {
+        // Registered before releasing the lock so Run's predicate can never
+        // observe "no drainers" for a worker that is about to start.
+        ++activeDrainers;
+      }
+    }
+
+    if (tasks) {
+      DrainTasks(*tasks, slotIndex);
+
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        --activeDrainers;
+      }
+      // The last drainer to leave may be what Run is waiting on, even when
+      // tasksRemaining reached zero some time ago.
+      cvDone.notify_all();
+    }
+  }
+}
+
+void ThreadPool::DrainTasks(const std::vector<Task>& tasks, size_t slotIndex)
+{
+  const size_t taskCount = tasks.size();
+
+  for (;;) {
+    const size_t taskIndex =
+      nextTaskIndex.fetch_add(1, std::memory_order_relaxed);
+    if (taskIndex >= taskCount) {
+      return;
+    }
+
+    RunTaskGuarded(tasks[taskIndex], slotIndex, taskIndex);
+
+    if (tasksRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      // Taking the mutex before notifying closes the window where the waiter
+      // has evaluated its predicate but has not yet re-entered the wait.
+      std::lock_guard<std::mutex> lock(mutex);
+      cvDone.notify_all();
+    }
+  }
+}
+
+void ThreadPool::RunTaskGuarded(const Task& task, size_t slotIndex,
+                                size_t taskIndex) noexcept
+{
+  if (!task) {
+    return;
+  }
+
+  try {
+    task(slotIndex);
+  } catch (const std::exception& e) {
+    failedTaskCount.fetch_add(1, std::memory_order_relaxed);
+    // spdlog is thread-safe; this is the only logging call on the parallel
+    // path and it only fires on the error branch.
+    spdlog::error("MpParallel::ThreadPool - task {} on slot {} threw: {}",
+                  taskIndex, slotIndex, e.what());
+  } catch (...) {
+    failedTaskCount.fetch_add(1, std::memory_order_relaxed);
+    spdlog::error(
+      "MpParallel::ThreadPool - task {} on slot {} threw a non-std exception",
+      taskIndex, slotIndex);
+  }
+}
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/ThreadPool.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/ThreadPool.h
@@ -1,0 +1,108 @@
+#pragma once
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace MpParallel {
+
+// A fork/join pool sized once at startup.
+//
+// Two properties matter for this use case and drive the design:
+//
+//  * The calling (main) thread participates in the work instead of blocking
+//    idle. With small batches the barrier cost dominates, and leaving a core
+//    parked makes the offload lose to the inline path.
+//
+//  * Tasks are handed out by an atomic cursor rather than pre-partitioned.
+//    Area clusters differ in cost by an order of magnitude (a city square vs
+//    a lone traveller), so static partitioning would leave workers idle at
+//    the barrier.
+//
+// Each task receives a worker index in [0, GetSlotCount()). Slot 0 is always
+// the calling thread. Callers use the index to reach per-slot scratch
+// buffers, which is what keeps the parallel phase allocation-free and
+// lock-free.
+class ThreadPool
+{
+public:
+  using Task = std::function<void(size_t slotIndex)>;
+
+  // numWorkers is the number of *additional* threads spawned. A value of 0
+  // produces a valid pool that runs everything on the calling thread, which
+  // is the mode unit tests and single-core hosts use.
+  explicit ThreadPool(size_t numWorkers);
+
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
+
+  ~ThreadPool();
+
+  // Number of distinct slot indices a task may observe: spawned workers plus
+  // the calling thread.
+  [[nodiscard]] size_t GetSlotCount() const noexcept
+  {
+    return workers.size() + 1;
+  }
+
+  [[nodiscard]] size_t GetWorkerCount() const noexcept
+  {
+    return workers.size();
+  }
+
+  // Runs every task and returns once all of them have completed. `tasks` must
+  // outlive the call. Exceptions thrown by a task are caught, counted, and
+  // logged; they never escape into the tick loop and never wedge the barrier.
+  //
+  // Not reentrant and not concurrent: exactly one thread may be inside Run at
+  // a time, and a task must not call Run. The dispatcher satisfies this by
+  // only ever calling it from the tick.
+  void Run(const std::vector<Task>& tasks);
+
+  // Number of tasks that threw since construction. Used by tests and by the
+  // metrics snapshot.
+  [[nodiscard]] uint64_t GetFailedTaskCount() const noexcept
+  {
+    return failedTaskCount.load(std::memory_order_relaxed);
+  }
+
+private:
+  void WorkerMain(size_t slotIndex);
+  void DrainTasks(const std::vector<Task>& tasks, size_t slotIndex);
+  void RunTaskGuarded(const Task& task, size_t slotIndex,
+                      size_t taskIndex) noexcept;
+
+  std::vector<std::thread> workers;
+
+  std::mutex mutex;
+  std::condition_variable cvWork;
+  std::condition_variable cvDone;
+
+  // Guarded by `mutex` for publication; the atomics below are also read
+  // outside the lock during draining.
+  const std::vector<Task>* currentTasks = nullptr;
+  uint64_t generation = 0;
+  bool stopping = false;
+
+  // Workers currently inside DrainTasks. Run must not return while this is
+  // non-zero.
+  //
+  // Waiting on tasksRemaining alone is not enough. The worker that runs the
+  // final task decrements tasksRemaining to zero and only then loops back to
+  // the cursor to discover the batch is exhausted. If Run returned in that
+  // window and the next tick started a batch, the reset of nextTaskIndex
+  // would hand that still-draining worker index 0 of the *previous* task
+  // vector: the old task would run a second time and the new batch's
+  // accounting would be decremented by a task that was never part of it.
+  size_t activeDrainers = 0;
+
+  std::atomic<size_t> nextTaskIndex{ 0 };
+  std::atomic<size_t> tasksRemaining{ 0 };
+  std::atomic<uint64_t> failedTaskCount{ 0 };
+};
+
+}

--- a/skymp5-server/cpp/server_guest_lib/parallel/TickSnapshot.h
+++ b/skymp5-server/cpp/server_guest_lib/parallel/TickSnapshot.h
@@ -1,0 +1,102 @@
+#pragma once
+#include "AreaKey.h"
+#include <NetworkingInterface.h>
+#include <cstdint>
+#include <vector>
+
+namespace MpParallel {
+
+constexpr uint32_t kUnassignedCluster = static_cast<uint32_t>(-1);
+
+// One actor whose owner sent a movement update this tick.
+//
+// Everything a worker needs is copied in here so that no worker ever
+// dereferences an MpActor, a WorldState, or the espm loader. That is the
+// single invariant the whole framework rests on: the parallel phase reads
+// only trivially-copyable data that the main thread has stopped writing.
+struct ActorSnapshot
+{
+  uint32_t formId = 0;
+  uint32_t idx = 0;
+
+  // Owner of this actor, or InvalidUserId for a hosted NPC.
+  Networking::UserId ownerUserId = Networking::InvalidUserId;
+
+  uint32_t worldOrCell = 0;
+
+  // Position and rotation the client is claiming, i.e. the candidate that
+  // still has to pass validation.
+  float proposedPos[3] = { 0.f, 0.f, 0.f };
+  float proposedRot[3] = { 0.f, 0.f, 0.f };
+  uint32_t proposedWorldOrCell = 0;
+
+  // Server-authoritative state as of the start of the tick, used both for
+  // validation and as the correction payload when validation fails.
+  float currentPos[3] = { 0.f, 0.f, 0.f };
+  float currentRot[3] = { 0.f, 0.f, 0.f };
+  uint32_t currentWorldOrCell = 0;
+
+  // Set when the client asked to be teleported, which suppresses the
+  // distance check exactly as the inline path does.
+  bool teleportFlag = false;
+
+  // Animation graph state carried by the update. Applied by the join phase
+  // only when validation passed, matching the inline ordering. runMode is
+  // reduced to the single predicate the handler actually tests.
+  bool isInJumpState = false;
+  bool isWeapDrawn = false;
+  bool isBlocking = false;
+  bool isSneaking = false;
+  bool isStanding = false;
+
+  // Chunk of `currentPos`, i.e. the chunk this actor is partitioned by.
+  AreaKey area;
+
+  // Half-open range into TickSnapshot::rawPacketBytes holding the packet that
+  // has to be relayed verbatim to the recipients.
+  uint32_t packetOffset = 0;
+  uint32_t packetLength = 0;
+
+  // Index assigned by the partitioner. kUnassignedCluster until then.
+  uint32_t clusterIndex = kUnassignedCluster;
+};
+
+// A single actor that is connected and active. The main thread snapshots
+// every active player once per tick, and workers spatial-filter this list.
+struct RelayTarget
+{
+  Networking::UserId userId = Networking::InvalidUserId;
+  uint32_t listenerFormId = 0;
+  float pos[3] = { 0.f, 0.f, 0.f };
+  uint32_t worldOrCell = 0;
+  int16_t chunkX = 0;
+  int16_t chunkY = 0;
+};
+
+// Immutable-during-the-parallel-phase view of everything submitted this tick.
+//
+// The main thread fills this during ingest and join; workers only read it.
+struct TickSnapshot
+{
+  std::vector<ActorSnapshot> actors;
+  std::vector<RelayTarget> relayTargets;
+
+  // Raw packet payloads, concatenated. Relaying forwards these bytes
+  // untouched, exactly as ActionListener::SendToNeighbours does, so the wire
+  // format is unchanged.
+  std::vector<uint8_t> rawPacketBytes;
+
+  // Monotonic tick counter, used by the throttle to decide whose turn it is.
+  uint64_t tickIndex = 0;
+
+  void Clear() noexcept
+  {
+    actors.clear();
+    relayTargets.clear();
+    rawPacketBytes.clear();
+  }
+
+  [[nodiscard]] bool Empty() const noexcept { return actors.empty(); }
+};
+
+}

--- a/unit/ParallelBenchmark.cpp
+++ b/unit/ParallelBenchmark.cpp
@@ -1,0 +1,339 @@
+#include "TestUtils.hpp"
+// PartOne.h only forward-declares MessageSerializer; we call Serialize on it.
+#include "MessageSerializerFactory.h"
+#include "UpdateMovementMessage.h"
+#include "parallel/OffloadDispatcher.h"
+#include "parallel/ParallelConfig.h"
+#include "parallel/ParallelMetrics.h"
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <numeric>
+#include <slikenet/BitStream.h>
+#include <vector>
+
+// Measures what the parallel area offload actually buys, instead of arguing
+// about it. Hidden behind the "[.]" tag so ctest never picks it up; run it
+// explicitly:
+//
+//   ./unit/unit "[ParallelBench]"
+//
+// The scenario is the one the framework exists for: every player standing in
+// the same chunk, every player sending a movement update every tick. That is
+// the N^2 relay case -- N senders x N recipients.
+//
+// Both configurations are timed over the same unit of work: the full ingest
+// of every player's packet PLUS PartOne::Tick. That matters for fairness,
+// because the inline path relays during ingest while the offloaded path defers
+// relays to the join inside Tick. Timing only one half would flatter whichever
+// path was measured.
+
+namespace {
+
+class NullSendTarget : public Networking::ISendTarget
+{
+public:
+  void Send(Networking::UserId, Networking::PacketData, size_t, bool) override
+  {
+    // Deliberately does nothing: we are measuring server-side relay cost, not
+    // the network stack. Both configurations pay the same zero here.
+    ++sendCount;
+  }
+  uint64_t sendCount = 0;
+};
+
+struct Sample
+{
+  double perTickMicros = 0.0;
+  uint64_t relays = 0;
+  size_t clusters = 0;
+  size_t units = 0;
+  size_t biggest = 0;
+  double reportedSpeedup = 0.0;
+  // Where the tick actually goes. ingest is inferred: whatever is left after
+  // the dispatcher's own two phases.
+  uint64_t parallelMicros = 0;
+  uint64_t joinMicros = 0;
+  uint64_t aggregateTaskMicros = 0;
+};
+
+// Feeds a movement update the way a real client does: a binary-serialized
+// UpdateMovementMessage. TestUtils::DoMessage sends JSON instead, which is the
+// legacy path -- a live client produced no JSON packets at all, and
+// PacketParser warns the first time it sees one. Benchmarking JSON would
+// measure a path production never takes.
+void SendBinaryMovement(PartOne& partOne, Networking::UserId userId,
+                        uint32_t idx, float x, float y)
+{
+  UpdateMovementMessage msg;
+  msg.idx = idx;
+  msg.data.worldOrCell = 0x3c;
+  msg.data.pos = { x, y, 0.f };
+  msg.data.rot = { 0.f, 0.f, 0.f };
+  msg.data.direction = 0.f;
+  msg.data.healthPercentage = 1.f;
+  msg.data.speed = 0.f;
+  msg.data.runMode = "Standing";
+  msg.data.isInJumpState = false;
+  msg.data.isSneaking = false;
+  msg.data.isBlocking = false;
+  msg.data.isWeapDrawn = false;
+  msg.data.isDead = false;
+
+  SLNet::BitStream stream;
+  PartOne::GetMessageSerializerInstance().Serialize(msg, stream);
+
+  PartOne::HandlePacket(
+    &partOne, userId, Networking::PacketType::Message,
+    reinterpret_cast<Networking::PacketData>(stream.GetData()),
+    stream.GetNumberOfBytesUsed());
+}
+
+// Same update over the legacy JSON encoding, for an apples-to-apples
+// comparison of ingest cost between the two wire formats.
+void SendJsonMovement(PartOne& partOne, Networking::UserId userId, uint32_t idx,
+                      float x, float y)
+{
+  auto m = jMovement;
+  m["idx"] = idx;
+  m["data"]["pos"] = { x, y, 0.f };
+  DoMessage(partOne, userId, m);
+}
+
+MpParallel::ParallelConfig MakeConfig(size_t workers)
+{
+  MpParallel::ParallelConfig config;
+  config.enabled = true;
+  config.workerThreads = workers;
+  config.minActorsToOffload = 1;
+  config.minClusterActors = 1;
+  config.minShardActors = 2;
+  // Throttling would change the amount of work done, making the two
+  // configurations incomparable. Keep the workload identical.
+  config.adaptiveThrottling = false;
+  config.Normalize();
+  return config;
+}
+
+Sample RunScenario(int players, bool parallel, size_t workers, int ticks,
+                   bool useJson = false, bool interestMgmt = false)
+{
+  PartOne partOne;
+  NullSendTarget sendTarget;
+  partOne.SetSendTarget(&sendTarget);
+
+  if (parallel) {
+    MpParallel::ParallelConfig config = MakeConfig(workers);
+    config.interestManagement = interestMgmt;
+    config.Normalize();
+    partOne.ConfigureParallelism(config);
+  }
+
+  // Everyone in one chunk of Tamriel, so the partitioner produces a single
+  // cluster and sharding is what has to carry the parallelism.
+  //
+  // Spread across most of the chunk rather than heaped into a few hundred
+  // units: a real crowd occupies a market square or a city district, and the
+  // spread is what determines whether interest management can do anything.
+  const int side = static_cast<int>(std::ceil(std::sqrt(
+    static_cast<double>(players))));
+  const float spacing = 3800.f / static_cast<float>(std::max(side - 1, 1));
+  auto posX = [&](int i) { return static_cast<float>(i % side) * spacing; };
+  auto posY = [&](int i) { return static_cast<float>(i / side) * spacing; };
+
+  std::vector<uint32_t> idx(players);
+  for (int i = 0; i < players; ++i) {
+    DoConnect(partOne, static_cast<Networking::UserId>(i));
+    const uint32_t formId = 0xff000000 + static_cast<uint32_t>(i);
+    partOne.CreateActor(formId, { posX(i), posY(i), 0.f }, 0.f, 0x3c);
+    partOne.SetUserActor(static_cast<Networking::UserId>(i), formId);
+    idx[i] = dynamic_cast<MpActor*>(
+               partOne.worldState.LookupFormById(formId).get())
+               ->GetIdx();
+  }
+
+  auto oneTick = [&] {
+    for (int i = 0; i < players; ++i) {
+      // Nudge the position each tick so the update is not a no-op.
+      const float x = posX(i) + 1.f;
+      const float y = posY(i) + 1.f;
+      const auto userId = static_cast<Networking::UserId>(i);
+      if (useJson) {
+        SendJsonMovement(partOne, userId, idx[i], x, y);
+      } else {
+        SendBinaryMovement(partOne, userId, idx[i], x, y);
+      }
+    }
+    partOne.Tick();
+  };
+
+  // Warm up: first ticks pay for subscription setup and allocator growth.
+  for (int w = 0; w < 5; ++w) {
+    oneTick();
+  }
+
+  sendTarget.sendCount = 0;
+  const auto start = std::chrono::steady_clock::now();
+  for (int t = 0; t < ticks; ++t) {
+    oneTick();
+  }
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  Sample sample;
+  sample.perTickMicros =
+    std::chrono::duration<double, std::micro>(elapsed).count() / ticks;
+  sample.relays = sendTarget.sendCount / static_cast<uint64_t>(ticks);
+
+  if (parallel) {
+    const MpParallel::ParallelMetrics& m = partOne.GetParallelMetrics();
+    sample.clusters = m.lastClusterCount;
+    sample.units = m.lastWorkUnitCount;
+    sample.biggest = m.lastLargestClusterSize;
+    sample.reportedSpeedup = m.GetLastSpeedup();
+    sample.parallelMicros = m.lastParallelMicros;
+    sample.joinMicros = m.lastJoinMicros;
+    sample.aggregateTaskMicros = m.lastAggregateTaskMicros;
+  }
+  return sample;
+}
+
+}
+
+TEST_CASE("Parallel offload throughput vs inline", "[.][ParallelBench]")
+{
+  // Extended past 150 to find the crossover: the offload only earns its
+  // barrier overhead once the parallel phase is large enough to amortize it.
+  const std::vector<int> populations = { 25, 50, 100, 150, 250, 400 };
+  constexpr int kTicks = 40;
+
+  const size_t hw = std::thread::hardware_concurrency();
+  std::printf("\n  hardware_concurrency = %zu\n", hw);
+  std::printf("  %d ticks per measurement, all players in one chunk\n\n",
+              kTicks);
+  std::printf("  %-8s %8s %12s %12s %9s  %s\n", "players", "relays",
+              "inline us", "parallel us", "speedup", "clusters/units");
+  std::printf("  %s\n", std::string(72, '-').c_str());
+
+  for (int players : populations) {
+    const Sample inlineRun = RunScenario(players, false, 0, kTicks);
+    const Sample parallelRun = RunScenario(players, true, 0, kTicks);
+
+    // Both configurations must have done the same amount of relaying, or the
+    // comparison is meaningless.
+    REQUIRE(parallelRun.relays == inlineRun.relays);
+
+    const double speedup = parallelRun.perTickMicros > 0.0
+      ? inlineRun.perTickMicros / parallelRun.perTickMicros
+      : 0.0;
+
+    std::printf("  %-8d %8llu %12.1f %12.1f %8.2fx  %zu/%zu (biggest %zu)\n",
+                players, static_cast<unsigned long long>(inlineRun.relays),
+                inlineRun.perTickMicros, parallelRun.perTickMicros, speedup,
+                parallelRun.clusters, parallelRun.units, parallelRun.biggest);
+
+    // Where did the parallel tick's time actually go? Anything not accounted
+    // for by the dispatcher's phases is serial ingest -- flattening actors and
+    // copying every relay edge into the snapshot.
+    const double accounted = static_cast<double>(parallelRun.parallelMicros +
+                                                 parallelRun.joinMicros);
+    std::printf("           breakdown: ingest~%.1f  parallel=%llu  join=%llu"
+                "  tasksum=%llu\n",
+                parallelRun.perTickMicros - accounted,
+                static_cast<unsigned long long>(parallelRun.parallelMicros),
+                static_cast<unsigned long long>(parallelRun.joinMicros),
+                static_cast<unsigned long long>(
+                  parallelRun.aggregateTaskMicros));
+
+    // The crowd must have formed one cluster and been sharded, otherwise the
+    // benchmark is not measuring what it claims to.
+    REQUIRE(parallelRun.clusters == 1);
+    REQUIRE(parallelRun.units > 1);
+  }
+  std::printf("\n");
+}
+
+TEST_CASE("Interest management: what cutting relays actually buys",
+          "[.][ParallelBench]")
+{
+  // At 400 players the join emits 160k relays serially and dominates the
+  // tick. Parallelising decisions cannot help that; sending less can. This
+  // measures the only lever that attacks the N^2 term directly.
+  constexpr int kTicks = 30;
+  std::printf("\n  relay volume vs tick cost, 400 players in one chunk\n\n");
+  std::printf("  %-26s %10s %12s\n", "configuration", "relays", "us/tick");
+  std::printf("  %s\n", std::string(52, '-').c_str());
+
+  for (int players : { 150, 400 }) {
+    const Sample inlineRun = RunScenario(players, false, 0, kTicks);
+    const Sample plain = RunScenario(players, true, 0, kTicks, false, false);
+    const Sample managed = RunScenario(players, true, 0, kTicks, false, true);
+
+    std::printf("  %d players\n", players);
+    std::printf("  %-28s %10llu %12.1f\n", "  inline (baseline)",
+                static_cast<unsigned long long>(inlineRun.relays),
+                inlineRun.perTickMicros);
+    std::printf("  %-28s %10llu %12.1f\n", "  offload only",
+                static_cast<unsigned long long>(plain.relays),
+                plain.perTickMicros);
+    std::printf("  %-28s %10llu %12.1f\n", "  offload + interest mgmt",
+                static_cast<unsigned long long>(managed.relays),
+                managed.perTickMicros);
+    std::printf("  -> relays -%.0f%%, %.2fx faster than inline\n\n",
+                100.0 *
+                  (1.0 - static_cast<double>(managed.relays) /
+                           static_cast<double>(std::max<uint64_t>(plain.relays, 1))),
+                inlineRun.perTickMicros / managed.perTickMicros);
+
+    // Rate limiting must reduce traffic, never silence it.
+    REQUIRE(managed.relays > 0);
+    REQUIRE(managed.relays <= plain.relays);
+  }
+}
+
+TEST_CASE("Wire format ingest cost: binary vs legacy JSON",
+          "[.][ParallelBench]")
+{
+  // MessageSerializer::Deserialize dispatches binary in O(1) on the type byte,
+  // but for JSON it walks the deserializer table, and each candidate allocates
+  // a std::string AND constructs a fresh simdjson::dom::parser before
+  // re-parsing the whole message. UpdateMovement is type 2, so a movement
+  // packet pays that twice before it matches.
+  constexpr int kTicks = 40;
+  std::printf("\n  ingest cost per player-packet, offload disabled\n\n");
+  std::printf("  %-8s %14s %14s %10s\n", "players", "binary us/tick",
+              "json us/tick", "json cost");
+  std::printf("  %s\n", std::string(50, '-').c_str());
+
+  for (int players : { 25, 50, 100, 150 }) {
+    const Sample bin = RunScenario(players, false, 0, kTicks, false);
+    const Sample json = RunScenario(players, false, 0, kTicks, true);
+    REQUIRE(bin.relays == json.relays);
+    std::printf("  %-8d %14.1f %14.1f %9.2fx\n", players, bin.perTickMicros,
+                json.perTickMicros, json.perTickMicros / bin.perTickMicros);
+  }
+  std::printf("\n");
+}
+
+TEST_CASE("Parallel offload scaling by worker count", "[.][ParallelBench]")
+{
+  constexpr int kPlayers = 150;
+  constexpr int kTicks = 40;
+
+  const Sample baseline = RunScenario(kPlayers, false, 0, kTicks);
+  std::printf("\n  %d players, %d ticks, inline baseline = %.1f us/tick\n\n",
+              kPlayers, kTicks, baseline.perTickMicros);
+  std::printf("  %-8s %12s %9s\n", "workers", "us/tick", "speedup");
+  std::printf("  %s\n", std::string(34, '-').c_str());
+
+  for (size_t workers : { size_t(1), size_t(2), size_t(4), size_t(8),
+                          size_t(16) }) {
+    if (workers > std::thread::hardware_concurrency()) {
+      continue;
+    }
+    const Sample run = RunScenario(kPlayers, true, workers, kTicks);
+    REQUIRE(run.relays == baseline.relays);
+    std::printf("  %-8zu %12.1f %8.2fx\n", workers, run.perTickMicros,
+                baseline.perTickMicros / run.perTickMicros);
+  }
+  std::printf("\n");
+}

--- a/unit/ParallelConfigTest.cpp
+++ b/unit/ParallelConfigTest.cpp
@@ -1,0 +1,220 @@
+#include "parallel/LoadBalancer.h"
+#include "parallel/ParallelConfig.h"
+#include <catch2/catch_all.hpp>
+#include <nlohmann/json.hpp>
+#include <thread>
+
+using namespace MpParallel;
+
+TEST_CASE("Parallelism is off unless asked for", "[ParallelConfig]")
+{
+  const nlohmann::json settings = nlohmann::json::object();
+  const ParallelConfig config = ParallelConfig::FromServerSettings(settings);
+
+  REQUIRE_FALSE(config.enabled);
+  REQUIRE(config.Describe() == "parallel area offload: disabled");
+}
+
+TEST_CASE("Settings are read and clamped", "[ParallelConfig]")
+{
+  nlohmann::json settings;
+  settings["parallelism"] = {
+    { "enabled", true },
+    { "workerThreads", 6 },
+    { "minActorsToOffload", 40 },
+    { "minClusterActors", 0 },          // clamped up to 1
+    { "clusterSeparationChunks", 1 },   // clamped up to the safe minimum
+    { "targetTickBudgetMicros", 0 },    // replaced by the default
+    { "maxThrottleSkipTicks", 9999 },   // clamped down
+    { "throttleDistanceUnits", 2048.0 },
+  };
+
+  const ParallelConfig config = ParallelConfig::FromServerSettings(settings);
+
+  REQUIRE(config.enabled);
+  REQUIRE(config.workerThreads == 6);
+  REQUIRE(config.minActorsToOffload == 40);
+  REQUIRE(config.minClusterActors == 1);
+  REQUIRE(config.clusterSeparationChunks == kMinSafeSeparationChunks);
+  REQUIRE(config.targetTickBudgetMicros == 8000);
+  REQUIRE(config.maxThrottleSkipTicks == 32);
+  REQUIRE(config.throttleDistanceUnits == 2048.f);
+}
+
+TEST_CASE("Worker count of zero resolves to something usable",
+          "[ParallelConfig]")
+{
+  nlohmann::json settings;
+  settings["parallelism"] = { { "enabled", true }, { "workerThreads", 0 } };
+
+  const ParallelConfig config = ParallelConfig::FromServerSettings(settings);
+
+  REQUIRE(config.workerThreads >= 1);
+  REQUIRE(config.workerThreads <= kMaxWorkerThreads);
+}
+
+TEST_CASE("An oversized worker count is capped", "[ParallelConfig]")
+{
+  nlohmann::json settings;
+  settings["parallelism"] = { { "enabled", true },
+                              { "workerThreads", 100000 } };
+
+  const ParallelConfig config = ParallelConfig::FromServerSettings(settings);
+  REQUIRE(config.workerThreads == kMaxWorkerThreads);
+}
+
+TEST_CASE("Normalize is idempotent", "[ParallelConfig]")
+{
+  ParallelConfig config;
+  config.enabled = true;
+  config.Normalize();
+  const ParallelConfig once = config;
+  config.Normalize();
+
+  REQUIRE(config.workerThreads == once.workerThreads);
+  REQUIRE(config.clusterSeparationChunks == once.clusterSeparationChunks);
+  REQUIRE(config.targetTickBudgetMicros == once.targetTickBudgetMicros);
+}
+
+TEST_CASE("Malformed settings are rejected loudly", "[ParallelConfig]")
+{
+  SECTION("Wrong type for the whole block")
+  {
+    nlohmann::json settings;
+    settings["parallelism"] = "yes please";
+    REQUIRE_THROWS(ParallelConfig::FromServerSettings(settings));
+  }
+
+  SECTION("Wrong type for a field")
+  {
+    nlohmann::json settings;
+    settings["parallelism"] = { { "workerThreads", "many" } };
+    REQUIRE_THROWS(ParallelConfig::FromServerSettings(settings));
+  }
+
+  SECTION("Wrong type for a boolean")
+  {
+    nlohmann::json settings;
+    settings["parallelism"] = { { "enabled", 1 } };
+    REQUIRE_THROWS(ParallelConfig::FromServerSettings(settings));
+  }
+
+  SECTION("Null means default")
+  {
+    nlohmann::json settings;
+    settings["parallelism"] = nullptr;
+    REQUIRE_NOTHROW(ParallelConfig::FromServerSettings(settings));
+  }
+}
+
+TEST_CASE("ParallelConfig: LoadBalancer estimates linearly", "[ParallelConfig]") {
+  LoadBalancer balancer;
+
+  AreaCluster small;
+  small.representative = AreaKey{ 0x3c, 0, 0 };
+  small.actorIndices.assign(2, 0);
+
+  AreaCluster large;
+  large.representative = AreaKey{ 0x3c, 50, 50 };
+  large.actorIndices.assign(40, 0);
+
+  REQUIRE(balancer.EstimateMicros(large) > balancer.EstimateMicros(small));
+}
+
+TEST_CASE("ParallelConfig: LoadBalancer tracks moving average",
+          "[ParallelConfig]") {
+  LoadBalancer balancer;
+
+  AreaCluster cluster;
+  cluster.representative = AreaKey{ 0x3c, 1, 1 };
+  cluster.actorIndices.assign(1, 0);
+
+  // Repeated identical samples must converge on the observed value.
+  for (int i = 0; i < 40; ++i) {
+    balancer.Observe(cluster.representative, 5000, static_cast<uint64_t>(i));
+  }
+
+  const uint64_t estimate = balancer.EstimateMicros(cluster);
+  REQUIRE(estimate > 4500);
+  REQUIRE(estimate <= 5000);
+}
+
+TEST_CASE("The schedule puts expensive clusters first", "[ParallelBalancer]")
+{
+  LoadBalancer balancer;
+
+  std::vector<AreaCluster> clusters(3);
+  clusters[0].representative = AreaKey{ 0x3c, 0, 0 };
+  clusters[1].representative = AreaKey{ 0x3c, 10, 0 };
+  clusters[2].representative = AreaKey{ 0x3c, 20, 0 };
+
+  balancer.Observe(clusters[0].representative, 100, 1);
+  balancer.Observe(clusters[1].representative, 9000, 1);
+  balancer.Observe(clusters[2].representative, 3000, 1);
+
+  std::vector<uint32_t> order;
+  balancer.BuildSchedule(clusters, order);
+
+  REQUIRE(order == std::vector<uint32_t>{ 1, 2, 0 });
+}
+
+TEST_CASE("Pressure rises only when an area exceeds its budget",
+          "[ParallelBalancer]")
+{
+  LoadBalancer balancer;
+  const AreaKey key{ 0x3c, 4, 4 };
+
+  SECTION("Nothing measured means no pressure")
+  {
+    REQUIRE(balancer.GetPressureLevel(key, 1000, 4) == 0);
+  }
+
+  SECTION("Comfortably inside the budget means no pressure")
+  {
+    for (int i = 0; i < 20; ++i) {
+      balancer.Observe(key, 200, static_cast<uint64_t>(i));
+    }
+    REQUIRE(balancer.GetPressureLevel(key, 1000, 4) == 0);
+  }
+
+  SECTION("Well over the budget raises pressure, capped at maxLevel")
+  {
+    for (int i = 0; i < 40; ++i) {
+      balancer.Observe(key, 100000, static_cast<uint64_t>(i));
+    }
+    const uint32_t pressure = balancer.GetPressureLevel(key, 1000, 4);
+    REQUIRE(pressure > 0);
+    REQUIRE(pressure <= 4);
+  }
+
+  SECTION("A single slow tick does not by itself start throttling")
+  {
+    for (int i = 0; i < 40; ++i) {
+      balancer.Observe(key, 100, static_cast<uint64_t>(i));
+    }
+    // One tick ten times slower than usual, e.g. a stall elsewhere in the
+    // process. Smoothing has to absorb it rather than punish players.
+    balancer.Observe(key, 1000, 41);
+    REQUIRE(balancer.GetPressureLevel(key, 500, 8) == 0);
+
+    // Sustained overload, on the other hand, must be noticed.
+    for (int i = 42; i < 80; ++i) {
+      balancer.Observe(key, 5000, static_cast<uint64_t>(i));
+    }
+    REQUIRE(balancer.GetPressureLevel(key, 500, 8) > 0);
+  }
+}
+
+TEST_CASE("Stale areas are evicted", "[ParallelBalancer]")
+{
+  LoadBalancer balancer;
+  balancer.Observe(AreaKey{ 0x3c, 0, 0 }, 500, 10);
+  balancer.Observe(AreaKey{ 0x3c, 9, 9 }, 500, 900);
+  REQUIRE(balancer.GetTrackedAreaCount() == 2);
+
+  balancer.EvictStale(1000, 500);
+  REQUIRE(balancer.GetTrackedAreaCount() == 1);
+
+  balancer.Clear();
+  REQUIRE(balancer.GetTrackedAreaCount() == 0);
+}

--- a/unit/ParallelOffloadTest.cpp
+++ b/unit/ParallelOffloadTest.cpp
@@ -1,0 +1,702 @@
+#include "parallel/InterestManager.h"
+#include "parallel/OffloadDispatcher.h"
+#include <algorithm>
+#include <array>
+#include <catch2/catch_all.hpp>
+#include <map>
+#include <memory>
+#include <vector>
+
+using namespace MpParallel;
+
+namespace {
+
+struct RecordedRelay
+{
+  Networking::UserId userId = Networking::InvalidUserId;
+  std::vector<uint8_t> bytes;
+  bool reliable = false;
+
+  bool operator<(const RecordedRelay& rhs) const
+  {
+    if (userId != rhs.userId) {
+      return userId < rhs.userId;
+    }
+    if (bytes != rhs.bytes) {
+      return bytes < rhs.bytes;
+    }
+    return reliable < rhs.reliable;
+  }
+
+  bool operator==(const RecordedRelay& rhs) const
+  {
+    return userId == rhs.userId && bytes == rhs.bytes &&
+      reliable == rhs.reliable;
+  }
+};
+
+class RecordingSink : public IOffloadSink
+{
+public:
+  void ApplyMovement(const ActorSnapshot& actor) override
+  {
+    applied.push_back(actor.formId);
+    appliedPos[actor.formId] = { actor.proposedPos[0], actor.proposedPos[1],
+                                 actor.proposedPos[2] };
+  }
+
+  void SendCorrection(const ActorSnapshot& actor) override
+  {
+    corrected.push_back(actor.formId);
+  }
+
+  void SendRelay(Networking::UserId userId, const uint8_t* data, size_t length,
+                 bool reliable) override
+  {
+    RecordedRelay relay;
+    relay.userId = userId;
+    relay.bytes.assign(data, data + length);
+    relay.reliable = reliable;
+    relays.push_back(relay);
+  }
+
+  std::vector<uint32_t> applied;
+  std::vector<uint32_t> corrected;
+  std::vector<RecordedRelay> relays;
+  std::map<uint32_t, std::array<float, 3>> appliedPos;
+};
+
+ParallelConfig MakeConfig(size_t workerThreads, size_t minActorsToOffload)
+{
+  ParallelConfig config;
+  config.enabled = true;
+  config.workerThreads = workerThreads;
+  config.minActorsToOffload = minActorsToOffload;
+  config.minClusterActors = 1;
+  // Both rate-reduction mechanisms off, so these tests observe the raw relay
+  // fan-out. Interest management gets its own dedicated cases below.
+  config.adaptiveThrottling = false;
+  config.interestManagement = false;
+  config.Normalize();
+  return config;
+}
+
+// Builds a submission whose proposed position is a small, always-valid step
+// away from where the actor currently is.
+MovementSubmission MakeSubmission(uint32_t formId, uint32_t idx,
+                                  Networking::UserId ownerUserId, float x,
+                                  float y, const std::vector<uint8_t>& packet)
+{
+  MovementSubmission submission;
+  submission.formId = formId;
+  submission.idx = idx;
+  submission.ownerUserId = ownerUserId;
+
+  submission.currentPos[0] = x;
+  submission.currentPos[1] = y;
+  submission.currentWorldOrCell = 0x3c;
+
+  submission.proposedPos[0] = x + 10.f;
+  submission.proposedPos[1] = y + 10.f;
+  submission.proposedWorldOrCell = 0x3c;
+
+  submission.isStanding = true;
+  submission.packetData = packet.data();
+  submission.packetLength = packet.size();
+  
+  return submission;
+}
+
+RelayTarget MakeTarget(Networking::UserId userId, uint32_t formId, float x,
+                       float y)
+{
+  RelayTarget target;
+  target.userId = userId;
+  target.listenerFormId = formId;
+  target.worldOrCell = 0x3c;
+  target.chunkX = static_cast<int16_t>(x / 4096.f);
+  target.chunkY = static_cast<int16_t>(y / 4096.f);
+  target.pos[0] = x;
+  target.pos[1] = y;
+  return target;
+}
+
+}
+
+TEST_CASE("A disabled dispatcher declines everything", "[ParallelOffload]")
+{
+  ParallelConfig config;
+  config.Normalize();
+  OffloadDispatcher dispatcher(config);
+
+  REQUIRE_FALSE(dispatcher.IsEnabled());
+
+  const std::vector<uint8_t> packet{ 1, 2, 3 };
+  std::vector<RelayTarget> targets{ MakeTarget(7, 0xff000002, 0.f, 0.f) };
+  /* SetPotentialTargets handled */
+  REQUIRE_FALSE(dispatcher.SubmitMovement(
+    MakeSubmission(0xff000001, 1, 5, 0.f, 0.f, packet)));
+  REQUIRE(dispatcher.GetPendingCount() == 0);
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+  REQUIRE(sink.relays.empty());
+  REQUIRE(sink.applied.empty());
+}
+
+TEST_CASE("A submission without a packet is declined", "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(0, 1));
+
+  MovementSubmission submission;
+  submission.formId = 0xff000001;
+  submission.packetData = nullptr;
+  submission.packetLength = 0;
+
+  REQUIRE_FALSE(dispatcher.SubmitMovement(submission));
+  REQUIRE(dispatcher.GetPendingCount() == 0);
+}
+
+TEST_CASE("Accepted movement is applied and relayed", "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(0, 1));
+
+  const std::vector<uint8_t> packet{ 0x10, 0x20, 0x30 };
+  const std::vector<RelayTarget> targets{
+    MakeTarget(2, 0xff000002, 100.f, 100.f),
+    MakeTarget(3, 0xff000003, 200.f, 200.f),
+  };
+
+  REQUIRE(dispatcher.SubmitMovement(
+    MakeSubmission(0xff000001, 1, 1, 0.f, 0.f, packet)));
+  REQUIRE(dispatcher.GetPendingCount() == 1);
+
+  // Recipients now come from the per-tick snapshot of active players rather
+  // than from the submission, so the dispatcher has to be given the list.
+  dispatcher.SetPotentialTargets(std::vector<RelayTarget>(targets));
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+
+  REQUIRE(sink.applied == std::vector<uint32_t>{ 0xff000001 });
+  REQUIRE(sink.corrected.empty());
+  REQUIRE(sink.relays.size() == 2);
+  REQUIRE(sink.relays[0].bytes == packet);
+  REQUIRE(sink.relays[1].bytes == packet);
+  REQUIRE_FALSE(sink.relays[0].reliable);
+
+  // The pending set is consumed by the tick.
+  REQUIRE(dispatcher.GetPendingCount() == 0);
+}
+
+TEST_CASE("Validation mirrors the inline rules", "[ParallelOffload]")
+{
+  ActorSnapshot actor;
+  actor.currentWorldOrCell = 0x3c;
+  actor.proposedWorldOrCell = 0x3c;
+
+  SECTION("A small step is accepted")
+  {
+    actor.proposedPos[0] = 100.f;
+    REQUIRE(InterestManager::ValidateMovement(actor));
+  }
+
+  SECTION("A cell change is rejected")
+  {
+    actor.proposedWorldOrCell = 0x1a26f;
+    REQUIRE_FALSE(InterestManager::ValidateMovement(actor));
+  }
+
+  SECTION("A step of a full cell or more is rejected")
+  {
+    actor.proposedPos[0] = 4096.f;
+    REQUIRE_FALSE(InterestManager::ValidateMovement(actor));
+  }
+
+  SECTION("Just under a full cell is accepted")
+  {
+    actor.proposedPos[0] = 4095.f;
+    REQUIRE(InterestManager::ValidateMovement(actor));
+  }
+
+  SECTION("The teleport flag always rejects")
+  {
+    actor.teleportFlag = true;
+    actor.proposedPos[0] = 1.f;
+    REQUIRE_FALSE(InterestManager::ValidateMovement(actor));
+  }
+
+  SECTION("Distance is measured in three dimensions")
+  {
+    actor.proposedPos[0] = 3000.f;
+    actor.proposedPos[1] = 3000.f;
+    REQUIRE_FALSE(InterestManager::ValidateMovement(actor));
+  }
+}
+
+TEST_CASE("A rejected update corrects its owner but still relays",
+          "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(0, 1));
+
+  const std::vector<uint8_t> packet{ 0xaa };
+  const std::vector<RelayTarget> targets{
+    MakeTarget(2, 0xff000002, 10.f, 10.f)
+  };
+
+  MovementSubmission submission =
+    MakeSubmission(0xff000001, 1, 1, 0.f, 0.f, packet);
+  // Well beyond one cell: must fail validation.
+  submission.proposedPos[0] = 100000.f;
+
+  REQUIRE(dispatcher.SubmitMovement(submission));
+  dispatcher.SetPotentialTargets(std::vector<RelayTarget>(targets));
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+
+  REQUIRE(sink.applied.empty());
+  REQUIRE(sink.corrected == std::vector<uint32_t>{ 0xff000001 });
+  // The inline path relays before validating, so the neighbour still sees it.
+  REQUIRE(sink.relays.size() == 1);
+}
+
+TEST_CASE("A hosted NPC is never sent a correction", "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(0, 1));
+
+  const std::vector<uint8_t> packet{ 0xbb };
+  std::vector<RelayTarget> targets;
+
+  MovementSubmission submission = MakeSubmission(
+    0xff000009, 9, Networking::InvalidUserId, 0.f, 0.f, packet);
+  submission.proposedPos[0] = 100000.f;
+
+  REQUIRE(dispatcher.SubmitMovement(submission));
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+
+  REQUIRE(sink.applied.empty());
+  REQUIRE(sink.corrected.empty());
+}
+
+TEST_CASE("Parallel and inline runs produce the same work",
+          "[ParallelOffload]")
+{
+  // Same inputs, one run forced inline and one spread over four workers. The
+  // set of effects has to match; only the order may differ.
+  const std::vector<uint8_t> packet{ 0x01, 0x02 };
+
+  auto buildAndRun = [&](size_t workers, size_t threshold) {
+    OffloadDispatcher dispatcher(MakeConfig(workers, threshold));
+
+    // One flat list of active players for the whole tick. Recipients are
+    // derived from it by spatial filtering, so every user id must be distinct
+    // or the same player would appear in several chunks.
+    std::vector<RelayTarget> allTargets;
+    allTargets.reserve(64 * 5);
+
+    for (uint32_t i = 0; i < 64; ++i) {
+      // Ten separate crowds, far enough apart to become distinct clusters.
+      const float baseX = static_cast<float>((i % 10) * 200000);
+      const float baseY = static_cast<float>((i / 10) * 100);
+
+      for (uint32_t t = 0; t < 5; ++t) {
+        allTargets.push_back(
+          MakeTarget(static_cast<Networking::UserId>(100 + i * 5 + t),
+                     0xff001000 + i * 5 + t, baseX + 50.f, baseY + 50.f));
+      }
+
+      REQUIRE(dispatcher.SubmitMovement(MakeSubmission(
+        0xff000001 + i, i, static_cast<Networking::UserId>(i), baseX, baseY,
+        packet)));
+    }
+
+    dispatcher.SetPotentialTargets(std::move(allTargets));
+
+    auto sink = std::make_unique<RecordingSink>();
+    dispatcher.ExecuteTick(*sink);
+    return sink;
+  };
+
+  auto inlineSink = buildAndRun(0, 100000);
+  auto parallelSink = buildAndRun(4, 1);
+
+  // The exact fan-out depends on how many players share a chunk, which is not
+  // what this test is about. What matters is that the work happened and that
+  // both configurations produced identical effects.
+  REQUIRE(inlineSink->relays.size() > 0);
+  REQUIRE(parallelSink->relays.size() == inlineSink->relays.size());
+
+  std::sort(inlineSink->relays.begin(), inlineSink->relays.end());
+  std::sort(parallelSink->relays.begin(), parallelSink->relays.end());
+  REQUIRE(inlineSink->relays == parallelSink->relays);
+
+  std::sort(inlineSink->applied.begin(), inlineSink->applied.end());
+  std::sort(parallelSink->applied.begin(), parallelSink->applied.end());
+  REQUIRE(inlineSink->applied == parallelSink->applied);
+  REQUIRE(inlineSink->applied.size() == 64);
+}
+
+TEST_CASE("Join order is stable across repeated identical ticks",
+          "[ParallelOffload]")
+{
+  const std::vector<uint8_t> packet{ 0x77 };
+
+  auto run = [&] {
+    OffloadDispatcher dispatcher(MakeConfig(4, 1));
+    std::vector<std::vector<RelayTarget>> targetStorage;
+    targetStorage.reserve(40);
+
+    for (uint32_t i = 0; i < 40; ++i) {
+      const float baseX = static_cast<float>((i % 8) * 500000);
+      targetStorage.emplace_back();
+      targetStorage.back().push_back(
+        MakeTarget(static_cast<Networking::UserId>(i), 0xff002000 + i,
+                   baseX, 0.f));
+      REQUIRE(dispatcher.SubmitMovement(MakeSubmission(
+        0xff000001 + i, i, static_cast<Networking::UserId>(i), baseX, 0.f,
+        packet)));
+    }
+
+    RecordingSink sink;
+    dispatcher.ExecuteTick(sink);
+    return sink.applied;
+  };
+
+  const std::vector<uint32_t> first = run();
+  for (int attempt = 0; attempt < 5; ++attempt) {
+    REQUIRE(run() == first);
+  }
+}
+
+TEST_CASE("Throttling only fires under pressure and spares close players",
+          "[ParallelOffload]")
+{
+  ParallelConfig config;
+  config.enabled = true;
+  config.adaptiveThrottling = true;
+  config.throttleDistanceUnits = 4096.f;
+  config.maxThrottleSkipTicks = 4;
+  // Isolate the pressure mechanism from the always-on distance one.
+  config.interestManagement = false;
+  config.Normalize();
+
+  SECTION("No pressure means no throttling at any distance")
+  {
+    REQUIRE(InterestManager::ComputeSkipFactor(0.f, 0, config) == 1);
+    REQUIRE(InterestManager::ComputeSkipFactor(1e12f, 0, config) == 1);
+  }
+
+  SECTION("Under pressure, nearby players are still never throttled")
+  {
+    REQUIRE(InterestManager::ComputeSkipFactor(0.f, 3, config) == 1);
+    // Exactly at the threshold distance.
+    REQUIRE(InterestManager::ComputeSkipFactor(4096.f * 4096.f, 3, config) ==
+            1);
+  }
+
+  SECTION("Distant players are spaced out, more so the further they are")
+  {
+    const float sqrNear = 4097.f * 4097.f;
+    const float sqrFar = 20000.f * 20000.f;
+    const uint32_t nearFactor =
+      InterestManager::ComputeSkipFactor(sqrNear, 1, config);
+    const uint32_t farFactor =
+      InterestManager::ComputeSkipFactor(sqrFar, 1, config);
+    REQUIRE(nearFactor > 1);
+    REQUIRE(farFactor >= nearFactor);
+    REQUIRE(farFactor <= config.maxThrottleSkipTicks);
+  }
+
+  SECTION("Disabling the feature pins the factor at one")
+  {
+    ParallelConfig off = config;
+    off.adaptiveThrottling = false;
+    REQUIRE(InterestManager::ComputeSkipFactor(1e12f, 4, off) == 1);
+  }
+}
+
+TEST_CASE("Interest management reduces distant update rate on an idle server",
+          "[ParallelOffload]")
+{
+  ParallelConfig config;
+  config.enabled = true;
+  // No pressure, no adaptive throttling: this must work purely on distance.
+  config.adaptiveThrottling = false;
+  config.interestManagement = true;
+  config.interestFullRateUnits = 2048.f;
+  config.maxInterestSkipTicks = 4;
+  config.Normalize();
+
+  const float sqrFull = 2048.f * 2048.f;
+
+  SECTION("Close recipients keep every single update")
+  {
+    REQUIRE(InterestManager::ComputeSkipFactor(0.f, 0, config) == 1);
+    REQUIRE(InterestManager::ComputeSkipFactor(sqrFull * 0.5f, 0, config) == 1);
+    // Exactly on the boundary still counts as close.
+    REQUIRE(InterestManager::ComputeSkipFactor(sqrFull, 0, config) == 1);
+  }
+
+  SECTION("Rate drops in steps as distance grows")
+  {
+    const uint32_t a = InterestManager::ComputeSkipFactor(sqrFull * 2.f, 0, config);
+    const uint32_t b = InterestManager::ComputeSkipFactor(sqrFull * 8.f, 0, config);
+    const uint32_t c =
+      InterestManager::ComputeSkipFactor(sqrFull * 64.f, 0, config);
+    REQUIRE(a == 2);
+    REQUIRE(b == 3);
+    REQUIRE(c == 4);
+    REQUIRE(c <= config.maxInterestSkipTicks);
+  }
+
+  SECTION("The cap is respected")
+  {
+    ParallelConfig capped = config;
+    capped.maxInterestSkipTicks = 2;
+    capped.Normalize();
+    REQUIRE(InterestManager::ComputeSkipFactor(1e12f, 0, capped) == 2);
+  }
+
+  SECTION("Turning it off restores full rate everywhere")
+  {
+    ParallelConfig off = config;
+    off.interestManagement = false;
+    off.Normalize();
+    REQUIRE(InterestManager::ComputeSkipFactor(1e12f, 0, off) == 1);
+  }
+
+  SECTION("Pressure and distance stack by taking the stronger of the two")
+  {
+    ParallelConfig both = config;
+    both.adaptiveThrottling = true;
+    both.throttleDistanceUnits = 4096.f;
+    both.maxThrottleSkipTicks = 4;
+    both.Normalize();
+
+    // Close enough that pressure spares it, but interest management still
+    // applies its own floor rather than being overridden back to 1.
+    const uint32_t nearUnderPressure =
+      InterestManager::ComputeSkipFactor(sqrFull * 2.f, 3, both);
+    REQUIRE(nearUnderPressure >= 2);
+    REQUIRE(nearUnderPressure <= 4);
+  }
+}
+
+TEST_CASE("Every distant edge still transmits within its window",
+          "[ParallelOffload]")
+{
+  // Reducing the rate must never silence a pair permanently.
+  for (uint32_t skip = 2; skip <= 4; ++skip) {
+    for (uint32_t sender = 0xff000001; sender < 0xff000008; ++sender) {
+      for (Networking::UserId user = 0; user < 6; ++user) {
+        int sent = 0;
+        for (uint64_t tick = 0; tick < skip; ++tick) {
+          if (InterestManager::ShouldRelayThisTick(tick, sender, user, skip)) {
+            ++sent;
+          }
+        }
+        REQUIRE(sent == 1);
+      }
+    }
+  }
+}
+
+TEST_CASE("A throttled edge still transmits within its skip window",
+          "[ParallelOffload]")
+{
+  // Every pair must get a turn: a skip factor of N means one tick in N, not
+  // silence.
+  constexpr uint32_t kSkipFactor = 3;
+  for (uint32_t senderFormId = 0xff000001; senderFormId < 0xff000010;
+       ++senderFormId) {
+    for (Networking::UserId userId = 0; userId < 8; ++userId) {
+      int sent = 0;
+      for (uint64_t tick = 0; tick < kSkipFactor; ++tick) {
+        if (InterestManager::ShouldRelayThisTick(tick, senderFormId, userId,
+                                                 kSkipFactor)) {
+          ++sent;
+        }
+      }
+      REQUIRE(sent == 1);
+    }
+  }
+}
+
+TEST_CASE("Skip factor of one always transmits", "[ParallelOffload]")
+{
+  for (uint64_t tick = 0; tick < 16; ++tick) {
+    REQUIRE(InterestManager::ShouldRelayThisTick(tick, 0xff000001, 3, 1));
+    REQUIRE(InterestManager::ShouldRelayThisTick(tick, 0xff000001, 3, 0));
+  }
+}
+
+TEST_CASE("Metrics track relays and cluster counts", "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(2, 1));
+
+  const std::vector<uint8_t> packet{ 0x55 };
+  std::vector<RelayTarget> allTargets;
+
+  for (uint32_t i = 0; i < 8; ++i) {
+    // Far enough apart that each player is alone in its own chunk, so every
+    // sender relays to exactly one recipient: itself.
+    const float baseX = static_cast<float>(i * 500000);
+    allTargets.push_back(MakeTarget(static_cast<Networking::UserId>(i),
+                                    0xff003000 + i, baseX, 0.f));
+    REQUIRE(dispatcher.SubmitMovement(MakeSubmission(
+      0xff000001 + i, i, static_cast<Networking::UserId>(i), baseX, 0.f,
+      packet)));
+  }
+  dispatcher.SetPotentialTargets(std::move(allTargets));
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+
+  const ParallelMetrics& metrics = dispatcher.GetMetrics();
+  REQUIRE(metrics.lastActorCount == 8);
+  REQUIRE(metrics.lastClusterCount == 8);
+  REQUIRE(metrics.lastLargestClusterSize == 1);
+  // Each cluster holds one actor, which is below minShardActors, so no
+  // cluster is split and units == clusters.
+  REQUIRE(metrics.lastWorkUnitCount == 8);
+  REQUIRE(metrics.lastRelayEdgesEmitted == 8);
+  REQUIRE(metrics.lastRelayEdgesThrottled == 0);
+  REQUIRE(metrics.totalTicks == 1);
+  REQUIRE(metrics.totalFailedTasks == 0);
+}
+
+TEST_CASE("One crowded area is split across cores", "[ParallelOffload]")
+{
+  // The case the whole design exists for: nearly everyone in one place. If a
+  // cluster were the unit of work this would be a single task and the extra
+  // cores would sit idle.
+  ParallelConfig config = MakeConfig(4, 1);
+  config.minShardActors = 4;
+  config.Normalize();
+  OffloadDispatcher dispatcher(config);
+
+  const std::vector<uint8_t> packet{ 0x42 };
+  std::vector<RelayTarget> allTargets;
+  allTargets.reserve(60);
+
+  for (uint32_t i = 0; i < 60; ++i) {
+    // All inside one chunk, so the partitioner must produce exactly one
+    // cluster.
+    const float x = static_cast<float>(i % 10) * 10.f;
+    const float y = static_cast<float>(i / 10) * 10.f;
+
+    allTargets.push_back(
+      MakeTarget(static_cast<Networking::UserId>(i), 0xff004000 + i, x, y));
+
+    REQUIRE(dispatcher.SubmitMovement(MakeSubmission(
+      0xff000001 + i, i, static_cast<Networking::UserId>(i), x, y, packet)));
+  }
+  dispatcher.SetPotentialTargets(std::move(allTargets));
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+
+  const ParallelMetrics& metrics = dispatcher.GetMetrics();
+  REQUIRE(metrics.lastClusterCount == 1);
+  REQUIRE(metrics.lastLargestClusterSize == 60);
+  // The point of the exercise: one cluster, many schedulable units.
+  REQUIRE(metrics.lastWorkUnitCount > 1);
+  REQUIRE(metrics.lastPooledUnitCount > 1);
+
+  // Sharding must not lose or duplicate anyone. All 60 share a chunk, so
+  // every sender relays to all 60 recipients: the full N^2 fan-out, intact.
+  REQUIRE(sink.applied.size() == 60);
+  REQUIRE(sink.relays.size() == 60 * 60);
+
+  std::vector<uint32_t> expected;
+  for (uint32_t i = 0; i < 60; ++i) {
+    expected.push_back(0xff000001 + i);
+  }
+  // Join order is still ascending submission order despite the split.
+  REQUIRE(sink.applied == expected);
+}
+
+TEST_CASE("Shard count does not change the outcome", "[ParallelOffload]")
+{
+  // One crowd, processed as one unit and as many. Same effects either way.
+  const std::vector<uint8_t> packet{ 0x11, 0x22 };
+
+  auto run = [&](size_t maxShards) {
+    ParallelConfig config = MakeConfig(4, 1);
+    config.minShardActors = 2;
+    config.maxShardsPerCluster = maxShards;
+    config.Normalize();
+    OffloadDispatcher dispatcher(config);
+
+    std::vector<RelayTarget> allTargets;
+    allTargets.reserve(50 * 3);
+    for (uint32_t i = 0; i < 50; ++i) {
+      const float x = static_cast<float>(i) * 20.f;
+      for (uint32_t t = 0; t < 3; ++t) {
+        // Distinct user ids: one entry per active player in the snapshot.
+        allTargets.push_back(
+          MakeTarget(static_cast<Networking::UserId>(200 + i * 3 + t),
+                     0xff005000 + i * 3 + t, x, 0.f));
+      }
+      REQUIRE(dispatcher.SubmitMovement(MakeSubmission(
+        0xff000001 + i, i, static_cast<Networking::UserId>(i), x, 0.f, packet)));
+    }
+    dispatcher.SetPotentialTargets(std::move(allTargets));
+
+    auto sink = std::make_unique<RecordingSink>();
+    dispatcher.ExecuteTick(*sink);
+    return sink;
+  };
+
+  auto oneShard = run(1);
+  auto manyShards = run(16);
+
+  REQUIRE(manyShards->applied == oneShard->applied);
+  REQUIRE(manyShards->corrected == oneShard->corrected);
+  // Relays keep their exact order too, not merely their contents: units are
+  // joined in cluster order then ascending member order.
+  REQUIRE(manyShards->relays == oneShard->relays);
+  // 50 senders spanning x=0..980, all inside one chunk, against 150 snapshot
+  // entries in that chunk.
+  REQUIRE(oneShard->relays.size() == 50 * 150);
+}
+
+TEST_CASE("Reconfigure drops pending work and rebuilds the pool",
+          "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(2, 1));
+
+  const std::vector<uint8_t> packet{ 0x99 };
+  std::vector<RelayTarget> targets{ MakeTarget(1, 0xff000002, 0.f, 0.f) };
+  /* SetPotentialTargets handled */
+  REQUIRE(dispatcher.SubmitMovement(
+    MakeSubmission(0xff000001, 1, 1, 0.f, 0.f, packet)));
+  REQUIRE(dispatcher.GetPendingCount() == 1);
+
+  ParallelConfig disabled;
+  disabled.Normalize();
+  dispatcher.Reconfigure(disabled);
+
+  REQUIRE(dispatcher.GetPendingCount() == 0);
+  REQUIRE_FALSE(dispatcher.IsEnabled());
+
+  RecordingSink sink;
+  dispatcher.ExecuteTick(sink);
+  REQUIRE(sink.relays.empty());
+}
+
+TEST_CASE("An empty tick is cheap and harmless", "[ParallelOffload]")
+{
+  OffloadDispatcher dispatcher(MakeConfig(2, 1));
+  RecordingSink sink;
+
+  for (int i = 0; i < 10; ++i) {
+    dispatcher.ExecuteTick(sink);
+  }
+
+  REQUIRE(sink.relays.empty());
+  REQUIRE(dispatcher.GetMetrics().totalTicks == 10);
+}

--- a/unit/ParallelPartitionerTest.cpp
+++ b/unit/ParallelPartitionerTest.cpp
@@ -1,0 +1,257 @@
+#include "parallel/AreaPartitioner.h"
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <set>
+#include <vector>
+
+using namespace MpParallel;
+
+namespace {
+
+ActorSnapshot MakeActor(uint32_t formId, uint32_t worldOrCell, int16_t chunkX,
+                        int16_t chunkY)
+{
+  ActorSnapshot actor;
+  actor.formId = formId;
+  actor.worldOrCell = worldOrCell;
+  actor.area = AreaKey{ worldOrCell, chunkX, chunkY };
+  return actor;
+}
+
+// Every pair of actors placed in different clusters must be far enough apart
+// that neither can appear in the other's relay set.
+void RequireClustersAreIndependent(const std::vector<ActorSnapshot>& actors,
+                                   int32_t separation)
+{
+  for (size_t i = 0; i < actors.size(); ++i) {
+    for (size_t j = i + 1; j < actors.size(); ++j) {
+      if (actors[i].clusterIndex == actors[j].clusterIndex) {
+        continue;
+      }
+      const int32_t distance = actors[i].area.ChunkDistanceTo(actors[j].area);
+      const bool differentWorlds = distance < 0;
+      REQUIRE((differentWorlds || distance > separation));
+    }
+  }
+}
+
+}
+
+TEST_CASE("Empty input yields no clusters", "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<ActorSnapshot> actors;
+  std::vector<AreaCluster> clusters;
+
+  partitioner.Partition(actors, 4, clusters);
+
+  REQUIRE(clusters.empty());
+  REQUIRE(partitioner.GetLastChunkCount() == 0);
+}
+
+TEST_CASE("Actors in the same chunk share a cluster", "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<ActorSnapshot> actors{
+    MakeActor(1, 0x3c, 10, 10),
+    MakeActor(2, 0x3c, 10, 10),
+    MakeActor(3, 0x3c, 10, 10),
+  };
+  std::vector<AreaCluster> clusters;
+
+  partitioner.Partition(actors, 4, clusters);
+
+  REQUIRE(clusters.size() == 1);
+  REQUIRE(clusters[0].Size() == 3);
+  REQUIRE(partitioner.GetLastChunkCount() == 1);
+  REQUIRE(actors[0].clusterIndex == actors[1].clusterIndex);
+  REQUIRE(actors[1].clusterIndex == actors[2].clusterIndex);
+}
+
+TEST_CASE("Distant groups split, close ones do not", "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<AreaCluster> clusters;
+
+  SECTION("Within the separation distance they merge")
+  {
+    // Chebyshev distance 3 with separation 4: still one cluster.
+    std::vector<ActorSnapshot> actors{
+      MakeActor(1, 0x3c, 0, 0),
+      MakeActor(2, 0x3c, 3, 0),
+    };
+    partitioner.Partition(actors, 4, clusters);
+    REQUIRE(clusters.size() == 1);
+  }
+
+  SECTION("Beyond the separation distance they split")
+  {
+    // Chebyshev distance 5 with separation 4: two clusters.
+    std::vector<ActorSnapshot> actors{
+      MakeActor(1, 0x3c, 0, 0),
+      MakeActor(2, 0x3c, 5, 0),
+    };
+    partitioner.Partition(actors, 4, clusters);
+    REQUIRE(clusters.size() == 2);
+    REQUIRE(actors[0].clusterIndex != actors[1].clusterIndex);
+    RequireClustersAreIndependent(actors, 4);
+  }
+}
+
+TEST_CASE("Chains of nearby actors stay in one cluster",
+          "[ParallelPartition]")
+{
+  // Each hop is within the separation, so transitivity has to pull the whole
+  // line together even though the ends are 20 chunks apart.
+  AreaPartitioner partitioner;
+  std::vector<ActorSnapshot> actors;
+  for (int16_t i = 0; i < 10; ++i) {
+    actors.push_back(MakeActor(static_cast<uint32_t>(i + 1), 0x3c,
+                               static_cast<int16_t>(i * 2), 0));
+  }
+
+  std::vector<AreaCluster> clusters;
+  partitioner.Partition(actors, 3, clusters);
+
+  REQUIRE(clusters.size() == 1);
+  REQUIRE(clusters[0].Size() == 10);
+  REQUIRE(clusters[0].chunkCount == 10);
+}
+
+TEST_CASE("Different worldspaces never merge", "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<ActorSnapshot> actors{
+    MakeActor(1, 0x3c, 0, 0),
+    MakeActor(2, 0x1a26f, 0, 0), // identical chunk, different cell
+  };
+  std::vector<AreaCluster> clusters;
+
+  partitioner.Partition(actors, 64, clusters);
+
+  REQUIRE(clusters.size() == 2);
+  REQUIRE(actors[0].clusterIndex != actors[1].clusterIndex);
+}
+
+TEST_CASE("Separation is clamped to the safe minimum", "[ParallelPartition]")
+{
+  // Asking for 0 would put neighbouring chunks in different clusters and
+  // break the relay-locality guarantee, so the partitioner must ignore it.
+  AreaPartitioner partitioner;
+  std::vector<ActorSnapshot> actors{
+    MakeActor(1, 0x3c, 0, 0),
+    MakeActor(2, 0x3c, 2, 0),
+  };
+  std::vector<AreaCluster> clusters;
+
+  partitioner.Partition(actors, 0, clusters);
+
+  REQUIRE(clusters.size() == 1);
+}
+
+TEST_CASE("Cluster order does not depend on submission order",
+          "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<AreaCluster> forward;
+  std::vector<AreaCluster> reversed;
+
+  std::vector<ActorSnapshot> actorsForward{
+    MakeActor(1, 0x3c, 0, 0),   MakeActor(2, 0x3c, 40, 40),
+    MakeActor(3, 0x3c, 80, 80), MakeActor(4, 0x3c, 1, 1),
+  };
+  std::vector<ActorSnapshot> actorsReversed{
+    MakeActor(4, 0x3c, 1, 1),   MakeActor(3, 0x3c, 80, 80),
+    MakeActor(2, 0x3c, 40, 40), MakeActor(1, 0x3c, 0, 0),
+  };
+
+  partitioner.Partition(actorsForward, 4, forward);
+  partitioner.Partition(actorsReversed, 4, reversed);
+
+  REQUIRE(forward.size() == reversed.size());
+  for (size_t i = 0; i < forward.size(); ++i) {
+    REQUIRE(forward[i].representative == reversed[i].representative);
+  }
+}
+
+TEST_CASE("Member lists are ascending and cover every actor",
+          "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<ActorSnapshot> actors;
+  for (int16_t i = 0; i < 40; ++i) {
+    actors.push_back(MakeActor(static_cast<uint32_t>(i + 1), 0x3c,
+                               static_cast<int16_t>((i % 5) * 30),
+                               static_cast<int16_t>(i / 5)));
+  }
+
+  std::vector<AreaCluster> clusters;
+  partitioner.Partition(actors, 4, clusters);
+
+  size_t covered = 0;
+  std::set<uint32_t> seen;
+  for (const AreaCluster& cluster : clusters) {
+    REQUIRE(std::is_sorted(cluster.actorIndices.begin(),
+                           cluster.actorIndices.end()));
+    covered += cluster.Size();
+    for (uint32_t actorIndex : cluster.actorIndices) {
+      REQUIRE(seen.insert(actorIndex).second);
+      REQUIRE(actors[actorIndex].clusterIndex ==
+              static_cast<uint32_t>(&cluster - clusters.data()));
+    }
+  }
+
+  REQUIRE(covered == actors.size());
+  RequireClustersAreIndependent(actors, 4);
+}
+
+TEST_CASE("Partitioner scratch is reusable across calls",
+          "[ParallelPartition]")
+{
+  AreaPartitioner partitioner;
+  std::vector<AreaCluster> clusters;
+
+  std::vector<ActorSnapshot> first{ MakeActor(1, 0x3c, 0, 0),
+                                    MakeActor(2, 0x3c, 50, 50) };
+  partitioner.Partition(first, 4, clusters);
+  REQUIRE(clusters.size() == 2);
+
+  std::vector<ActorSnapshot> second{ MakeActor(3, 0x3c, 7, 7) };
+  partitioner.Partition(second, 4, clusters);
+  REQUIRE(clusters.size() == 1);
+  REQUIRE(clusters[0].Size() == 1);
+  REQUIRE(partitioner.GetLastChunkCount() == 1);
+}
+
+TEST_CASE("Chunk coordinates match the server's grid math",
+          "[ParallelPartition]")
+{
+  // GetGridPos in MpObjectReference.cpp truncates towards zero. Reproducing
+  // that exactly is what keeps clusters aligned with subscription
+  // neighbourhoods.
+  REQUIRE(ToChunkCoord(0.f) == 0);
+  REQUIRE(ToChunkCoord(4095.f) == 0);
+  REQUIRE(ToChunkCoord(4096.f) == 1);
+  REQUIRE(ToChunkCoord(-1.f) == 0);
+  REQUIRE(ToChunkCoord(-4096.f) == -1);
+  REQUIRE(ToChunkCoord(8192.f) == 2);
+}
+
+TEST_CASE("AreaKey distance and hashing behave", "[ParallelPartition]")
+{
+  const AreaKey a{ 0x3c, 0, 0 };
+  const AreaKey b{ 0x3c, 3, -4 };
+  const AreaKey elsewhere{ 0x40, 0, 0 };
+
+  REQUIRE(a.ChunkDistanceTo(b) == 4);
+  REQUIRE(b.ChunkDistanceTo(a) == 4);
+  REQUIRE(a.ChunkDistanceTo(elsewhere) == -1);
+  REQUIRE(a.ChunkDistanceTo(a) == 0);
+
+  AreaKeyHash hash;
+  REQUIRE(hash(a) == hash(AreaKey{ 0x3c, 0, 0 }));
+  REQUIRE(hash(a) != hash(b));
+
+  // Negative coordinates must not collide with their positive twins.
+  REQUIRE(hash(AreaKey{ 0x3c, -1, -1 }) != hash(AreaKey{ 0x3c, 1, 1 }));
+}

--- a/unit/ParallelThreadPoolTest.cpp
+++ b/unit/ParallelThreadPoolTest.cpp
@@ -1,0 +1,197 @@
+#include "parallel/ThreadPool.h"
+#include <atomic>
+#include <catch2/catch_all.hpp>
+#include <chrono>
+#include <mutex>
+#include <numeric>
+#include <set>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+using MpParallel::ThreadPool;
+
+TEST_CASE("Zero workers still runs every task on the caller", "[ParallelPool]")
+{
+  ThreadPool pool(0);
+  REQUIRE(pool.GetWorkerCount() == 0);
+  REQUIRE(pool.GetSlotCount() == 1);
+
+  std::vector<int> ran(16, 0);
+  std::vector<ThreadPool::Task> tasks;
+  for (size_t i = 0; i < ran.size(); ++i) {
+    tasks.emplace_back([&ran, i](size_t slot) {
+      REQUIRE(slot == 0);
+      ran[i] = 1;
+    });
+  }
+
+  pool.Run(tasks);
+
+  REQUIRE(std::accumulate(ran.begin(), ran.end(), 0) ==
+          static_cast<int>(ran.size()));
+}
+
+TEST_CASE("Every task runs exactly once", "[ParallelPool]")
+{
+  ThreadPool pool(4);
+
+  constexpr size_t kTaskCount = 500;
+  std::vector<std::atomic<int>> counters(kTaskCount);
+  for (auto& counter : counters) {
+    counter.store(0);
+  }
+
+  std::vector<ThreadPool::Task> tasks;
+  tasks.reserve(kTaskCount);
+  for (size_t i = 0; i < kTaskCount; ++i) {
+    tasks.emplace_back(
+      [&counters, i](size_t) { counters[i].fetch_add(1); });
+  }
+
+  pool.Run(tasks);
+
+  for (size_t i = 0; i < kTaskCount; ++i) {
+    REQUIRE(counters[i].load() == 1);
+  }
+}
+
+TEST_CASE("Slot indices stay inside the advertised range", "[ParallelPool]")
+{
+  ThreadPool pool(3);
+  REQUIRE(pool.GetSlotCount() == 4);
+
+  std::mutex mutex;
+  std::set<size_t> seenSlots;
+
+  std::vector<ThreadPool::Task> tasks;
+  for (size_t i = 0; i < 400; ++i) {
+    tasks.emplace_back([&](size_t slot) {
+      REQUIRE(slot < 4);
+      std::lock_guard<std::mutex> lock(mutex);
+      seenSlots.insert(slot);
+    });
+  }
+
+  pool.Run(tasks);
+
+  // The caller always participates, so slot 0 must show up.
+  REQUIRE(seenSlots.count(0) == 1);
+}
+
+TEST_CASE("Repeated batches all complete", "[ParallelPool]")
+{
+  ThreadPool pool(4);
+  std::atomic<int> total{ 0 };
+
+  for (int round = 0; round < 50; ++round) {
+    std::vector<ThreadPool::Task> tasks;
+    for (int i = 0; i < 20; ++i) {
+      tasks.emplace_back([&total](size_t) { total.fetch_add(1); });
+    }
+    pool.Run(tasks);
+    // The barrier must have drained before Run returns.
+    REQUIRE(total.load() == (round + 1) * 20);
+  }
+}
+
+TEST_CASE("Back-to-back batches never bleed into each other",
+          "[ParallelPool]")
+{
+  // Regression: Run used to return as soon as tasksRemaining hit zero, while
+  // the worker that ran the final task was still looping on the cursor. The
+  // next batch reset that cursor, so the straggler could re-run a task from
+  // the previous vector and decrement the new batch's counter. Each round
+  // here uses a fresh vector of fresh closures, so a straggler that reached
+  // back into the old batch shows up as a wrong per-round total.
+  ThreadPool pool(4);
+
+  for (int round = 0; round < 400; ++round) {
+    std::atomic<int> ran{ 0 };
+    std::vector<ThreadPool::Task> tasks;
+    // Deliberately tiny: the shorter the batch, the likelier a worker is
+    // still in the drain loop when Run wants to return.
+    for (int i = 0; i < 3; ++i) {
+      tasks.emplace_back([&ran](size_t) { ran.fetch_add(1); });
+    }
+    pool.Run(tasks);
+    REQUIRE(ran.load() == 3);
+  }
+}
+
+TEST_CASE("Alternating batch sizes stay consistent", "[ParallelPool]")
+{
+  // A long batch followed by a very short one is the shape most likely to
+  // leave a worker draining across the boundary.
+  ThreadPool pool(4);
+
+  for (int round = 0; round < 120; ++round) {
+    const int count = (round % 2 == 0) ? 200 : 1;
+    std::atomic<int> ran{ 0 };
+    std::vector<ThreadPool::Task> tasks;
+    for (int i = 0; i < count; ++i) {
+      tasks.emplace_back([&ran](size_t) { ran.fetch_add(1); });
+    }
+    pool.Run(tasks);
+    REQUIRE(ran.load() == count);
+  }
+}
+
+TEST_CASE("A throwing task does not wedge the barrier", "[ParallelPool]")
+{
+  ThreadPool pool(3);
+
+  std::atomic<int> completed{ 0 };
+  std::vector<ThreadPool::Task> tasks;
+  for (int i = 0; i < 60; ++i) {
+    tasks.emplace_back([&completed, i](size_t) {
+      if (i % 10 == 0) {
+        throw std::runtime_error("boom");
+      }
+      completed.fetch_add(1);
+    });
+  }
+
+  // Would hang rather than fail if the failure path skipped its decrement.
+  pool.Run(tasks);
+
+  REQUIRE(completed.load() == 54);
+  REQUIRE(pool.GetFailedTaskCount() == 6);
+
+  // The pool stays usable afterwards.
+  std::atomic<int> after{ 0 };
+  std::vector<ThreadPool::Task> more;
+  for (int i = 0; i < 10; ++i) {
+    more.emplace_back([&after](size_t) { after.fetch_add(1); });
+  }
+  pool.Run(more);
+  REQUIRE(after.load() == 10);
+}
+
+TEST_CASE("Empty batch is a no-op", "[ParallelPool]")
+{
+  ThreadPool pool(2);
+  std::vector<ThreadPool::Task> tasks;
+  pool.Run(tasks);
+  REQUIRE(pool.GetFailedTaskCount() == 0);
+}
+
+TEST_CASE("Uneven task costs still drain", "[ParallelPool]")
+{
+  // Dynamic scheduling exists so that one long task cannot leave the other
+  // slots idle. This checks the barrier copes with a lopsided batch.
+  ThreadPool pool(4);
+
+  std::atomic<int> done{ 0 };
+  std::vector<ThreadPool::Task> tasks;
+  tasks.emplace_back([&done](size_t) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    done.fetch_add(1);
+  });
+  for (int i = 0; i < 100; ++i) {
+    tasks.emplace_back([&done](size_t) { done.fetch_add(1); });
+  }
+
+  pool.Run(tasks);
+  REQUIRE(done.load() == 101);
+}

--- a/unit/PartOne_MovementParallelTest.cpp
+++ b/unit/PartOne_MovementParallelTest.cpp
@@ -1,0 +1,212 @@
+#include "TestUtils.hpp"
+
+// PartOne.h only forward-declares these, so a consumer that touches the
+// dispatcher or reads the metrics needs the real definitions.
+#include "parallel/OffloadDispatcher.h"
+#include "parallel/ParallelConfig.h"
+#include "parallel/ParallelMetrics.h"
+
+// The same movement scenarios as PartOne_MovementTest.cpp, but with the
+// multi-core area offload switched on.
+//
+// This is the test that matters for the framework: it drives the real
+// PartOne, the real packet parser and the real send target, and asserts the
+// offloaded path produces the same observable messages as the inline one.
+//
+// One deliberate difference is exercised here rather than hidden: with the
+// offload enabled a movement relay is emitted during PartOne::Tick instead of
+// during packet ingest, so each scenario ticks before asserting. Everything
+// else - counts, contents, recipients, resulting actor transform - must
+// match the inline expectations exactly.
+
+namespace {
+
+MpParallel::ParallelConfig EnabledConfig()
+{
+  MpParallel::ParallelConfig config;
+  config.enabled = true;
+  config.workerThreads = 4;
+  // Offload even tiny batches, so the tests actually take the parallel path
+  // rather than silently falling back to the inline one.
+  config.minActorsToOffload = 1;
+  config.minClusterActors = 1;
+  config.minShardActors = 1;
+  // Deterministic: no relay may be deferred by throttling.
+  config.adaptiveThrottling = false;
+  config.Normalize();
+  return config;
+}
+
+}
+
+TEST_CASE("Parallel: UpdateMovement relays to a neighbour", "[PartOne]")
+{
+  PartOne partOne;
+  partOne.ConfigureParallelism(EnabledConfig());
+  REQUIRE(partOne.GetOffloadDispatcher().IsEnabled());
+
+  DoConnect(partOne, 0);
+
+  DoMessage(partOne, 0, jMovement);
+  partOne.Tick();
+  REQUIRE(partOne.Messages().size() == 0); // No actor - no movement
+
+  partOne.CreateActor(0xff000ABC, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+  partOne.SetUserActor(0, 0xff000ABC);
+  partOne.Messages().clear();
+
+  DoMessage(partOne, 0, jMovement);
+  // Nothing has gone out yet: the relay is built on a worker and flushed by
+  // the join.
+  REQUIRE(partOne.Messages().size() == 0);
+
+  partOne.Tick();
+  REQUIRE(partOne.Messages().size() == 1);
+  REQUIRE(partOne.Messages().at(0).j == jMovement);
+
+  // The transform must have been applied by the join, exactly as the inline
+  // path applies it inside the packet handler.
+  auto* actor = dynamic_cast<MpActor*>(
+    partOne.worldState.LookupFormById(0xff000ABC).get());
+  REQUIRE(actor->GetPos() == NiPoint3{ 1, -1, 1 });
+  REQUIRE(actor->GetAngle() == NiPoint3{ 0, 0, 179 });
+}
+
+TEST_CASE("Parallel: two players see each other move", "[PartOne]")
+{
+  PartOne partOne;
+  partOne.ConfigureParallelism(EnabledConfig());
+
+  DoConnect(partOne, 0);
+  partOne.CreateActor(0xff000ABC, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+  partOne.SetUserActor(0, 0xff000ABC);
+
+  DoConnect(partOne, 1);
+  partOne.CreateActor(0xff00ABCD, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+  partOne.SetUserActor(1, 0xff00ABCD);
+
+  partOne.Messages().clear();
+  DoMessage(partOne, 0, jMovement);
+  partOne.Tick();
+
+  // Both the sender and the neighbour receive it, same as inline.
+  REQUIRE(partOne.Messages().size() == 2);
+  REQUIRE(partOne.Messages().at(0).j == jMovement);
+  REQUIRE(partOne.Messages().at(1).j == jMovement);
+}
+
+TEST_CASE("Parallel: disconnected neighbour stops receiving", "[PartOne]")
+{
+  PartOne partOne;
+  partOne.ConfigureParallelism(EnabledConfig());
+
+  for (int i = 0; i < 2; ++i) {
+    DoConnect(partOne, i);
+    partOne.CreateActor(i + 0xff000ABC, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+    partOne.SetUserActor(i, i + 0xff000ABC);
+    auto m = jMovement;
+    m["idx"] = i;
+    DoMessage(partOne, i, m);
+    partOne.Tick();
+  }
+
+  DoDisconnect(partOne, 1);
+
+  partOne.Messages().clear();
+  DoMessage(partOne, 0, jMovement);
+  partOne.Tick();
+  REQUIRE(partOne.Messages().size() == 1);
+}
+
+TEST_CASE("Parallel: many actors, only connected users are relayed to",
+          "[PartOne]")
+{
+  // Mirrors the "Hypothesis" case: half the actors have no user attached.
+  PartOne partOne;
+  partOne.ConfigureParallelism(EnabledConfig());
+
+  constexpr uint32_t n = 20;
+  static_assert(n <= MAX_PLAYERS - 1);
+
+  for (uint32_t i = 0; i < n; ++i) {
+    partOne.CreateActor(i + 0xff000000, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+    if (i % 2 == 0) {
+      continue;
+    }
+    DoConnect(partOne, i + 1);
+    partOne.SetUserActor(i + 1, i + 0xff000000);
+    DoUpdateMovement(partOne, i + 0xff000000, i + 1);
+    partOne.Tick();
+  }
+
+  DoConnect(partOne, 0);
+  partOne.CreateActor(0xffffffff, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+  partOne.SetUserActor(0, 0xffffffff);
+  partOne.Messages().clear();
+
+  DoUpdateMovement(partOne, 0xffffffff, 0);
+  partOne.Tick();
+  REQUIRE(partOne.Messages().size() == 11); // Me and 10 other users
+}
+
+TEST_CASE("Parallel: a crowd is sharded and still fully relayed", "[PartOne]")
+{
+  // Everyone in one place, which is the case sharding exists for. Every
+  // player must receive one relay from every player, including themselves.
+  PartOne partOne;
+  partOne.ConfigureParallelism(EnabledConfig());
+
+  constexpr uint32_t n = 12;
+  for (uint32_t i = 0; i < n; ++i) {
+    DoConnect(partOne, i);
+    partOne.CreateActor(0xff001000 + i, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+    partOne.SetUserActor(i, 0xff001000 + i);
+  }
+
+  partOne.Messages().clear();
+
+  for (uint32_t i = 0; i < n; ++i) {
+    auto m = jMovement;
+    m["idx"] = dynamic_cast<MpActor*>(
+                 partOne.worldState.LookupFormById(0xff001000 + i).get())
+                 ->GetIdx();
+    DoMessage(partOne, i, m);
+  }
+  partOne.Tick();
+
+  const auto& metrics = partOne.GetParallelMetrics();
+  REQUIRE(metrics.lastActorCount == n);
+  // All in one chunk, so one cluster; sharding is what spreads it.
+  REQUIRE(metrics.lastClusterCount == 1);
+  REQUIRE(metrics.lastWorkUnitCount > 1);
+
+  // n senders x n recipients, none dropped.
+  REQUIRE(partOne.Messages().size() == n * n);
+  REQUIRE(metrics.lastRelayEdgesThrottled == 0);
+}
+
+TEST_CASE("Parallel: repeated ticks stay consistent", "[PartOne]")
+{
+  PartOne partOne;
+  partOne.ConfigureParallelism(EnabledConfig());
+
+  constexpr uint32_t n = 6;
+  for (uint32_t i = 0; i < n; ++i) {
+    DoConnect(partOne, i);
+    partOne.CreateActor(0xff002000 + i, { 1.f, 2.f, 3.f }, 180.f, 0x3c);
+    partOne.SetUserActor(i, 0xff002000 + i);
+  }
+
+  for (int round = 0; round < 25; ++round) {
+    partOne.Messages().clear();
+    for (uint32_t i = 0; i < n; ++i) {
+      auto m = jMovement;
+      m["idx"] = dynamic_cast<MpActor*>(
+                   partOne.worldState.LookupFormById(0xff002000 + i).get())
+                   ->GetIdx();
+      DoMessage(partOne, i, m);
+    }
+    partOne.Tick();
+    REQUIRE(partOne.Messages().size() == n * n);
+  }
+}


### PR DESCRIPTION
# perf(skymp5-server): parallel area offload + interest management

Two changes to how movement relays are handled at scale, both **opt-in**. With
`parallelism.enabled` absent or false the original code path runs unchanged.

Every performance number below is measured by `unit/ParallelBenchmark.cpp`,
included in this branch. Run it yourself:

```bash
./unit/unit "[ParallelBench]"
```

## The problem

Movement is the highest-volume packet, and its cost is not linear in player
count: each update is relayed to everyone who can see the sender, so *N*
players in one area cost on the order of *N²* relay decisions per tick. All of
it runs on the single Node thread that drives `ScampServer::Tick`.

## What was measured

Every player in one chunk, everyone sending movement every tick, over the
binary wire format a real client uses. Timing covers full packet ingest **plus**
`PartOne::Tick`, so the inline and offloaded paths are compared over the same
unit of work — the inline path relays during ingest, the offloaded path defers
relays to the join.

| players | 25 | 50 | 100 | 150 | 250 | 400 |
| --- | --- | --- | --- | --- | --- | --- |
| offload speedup | 0.25× | 0.43× | 0.66× | 0.81× | 0.88× | **1.10×** |

**Break-even is around 300–400 players.** Below that the offload is a
regression, because the barrier and snapshot costs are paid every tick while
the parallel phase is still small. `minActorsToOffload` therefore defaults to
**300**.

The parallel phase itself scales fine — at 400 players it retires 966µs of task
work in 96µs of wall clock, roughly 10×. The ceiling is elsewhere: the join
emits 160,000 relays serially and costs 787µs of an 1118µs tick, *even with a
send target that does nothing*. Parallelising decisions cannot fix that.

## Interest management

Since relay volume is the quadratic term and emitting the sends is serial
regardless, the higher-value lever is sending less — and it helps at every
population, not only above 300.

Recipients closer than `interestFullRateUnits` (2048, about half a chunk)
always receive every update, so anything a player is realistically fighting,
trading with or watching stays at full fidelity. Beyond that the rate steps
down to a half, a third, a quarter, capped by `maxInterestSkipTicks`. At a 60Hz
tick a distant player still gets roughly 15 updates a second.

400 players spread across one chunk:

| configuration | relays/tick | µs/tick |
| --- | --- | --- |
| inline (baseline) | 160,000 | 1233 |
| offload only | 160,000 | 1048 |
| offload + interest management | 119,866 | **890** |

**1.39× against the inline baseline**, with a send target that does nothing.
With real RakNet sends each avoided relay also skips serialization and
queueing, so the gap widens.

It stacks with `adaptiveThrottling` by taking the stronger factor rather than
multiplying, so an overloaded server never starves a distant player past
whichever cap is more conservative. Each pair's phase is derived from a hash of
the pair, so traffic spreads across the window instead of bursting — and the
suite asserts every pair still transmits exactly once per window: reduced rate,
never silence.

## How the offload works

Per tick:

1. **Ingest** (main thread) — packets parsed as before, each update flattened
   into a plain-data snapshot instead of relayed immediately.
2. **Partition** (main thread) — actors grouped into area clusters that
   provably cannot influence one another this tick, then sliced into work units.
3. **Process** (workers) — validate, spatially filter recipients, build the
   outbound send list.
4. **Join** (main thread) — apply world state, hand packets to the network in a
   fixed order.

Steps 1 and 4 stay serial because they touch `MpActor`, `WorldState`, the
Papyrus VM, RakNet and V8. Workers read only the immutable snapshot and write
only their own output buffer, so the parallel phase needs no locks.

Recipients are derived from an O(N) per-tick snapshot of active players that
workers filter spatially, rather than enumerating O(N²) edges on the main
thread. That distinction matters: an earlier revision materialized every relay
edge during ingest and spent more time building the list than the parallel
phase saved.

### Why clusters are safe

`Grid.h` uses a 3×3 chunk stencil (reach 1) and movement validation caps a
single update just under one chunk (reach 1), so an actor's influence spans at
most 2 chunks per tick. Clusters are connected components under *same
`worldOrCell`, Chebyshev chunk distance ≤ S*, with `S` clamped up to 3 so every
possible recipient lands in the sender's own cluster. Different worldspaces and
interiors never share a grid, so instanced content separates perfectly.

Verified by property test over 400 randomized populations (23,810 actors):
actors in different clusters are always beyond relay range, actors within range
always share a cluster, and the result is independent of packet arrival order.

### Why shards, not clusters

One task per cluster does not work. On a realistic population one hub holds
most of a tick's relay work, so a cluster-sized task hands that block to a
single core. The scheduling unit is therefore a *shard*: a contiguous slice of
one cluster's members. Each sender's work depends only on the snapshot, so any
split is safe.

### Determinism

Clusters are ordered by lowest chunk coordinate, members by submission index,
shards are contiguous slices of that order, and the join walks work units by
index. Same inputs produce the same sequence of world writes on 2 cores or 32,
and whether a cluster ran whole or split sixteen ways.

## Also included

**JSON deserialization fix.** `MessageSerializer::Deserialize` walked the whole
deserializer table for JSON messages, and each candidate allocated a
`std::string` *and constructed a fresh `simdjson::dom::parser`* before
re-parsing the entire document, until one matched. It now reads the message type
once and dispatches directly, reuses a `thread_local` parser, and only
materializes the message text when trace logging is enabled. Measured **3.4–6.3×**
cheaper on the JSON path. This closes issue #2257. (Closes #2257)

Production clients send binary — a live client produced no JSON packets at all —
so this only helps legacy clients, but it is a hot path either way.

## Configuration

```json5
{
  // ...
  "parallelism": {
    "enabled": true,
    "workerThreads": 0,          // 0 auto-detects: cores minus two
    "interestManagement": true,  // the setting that matters most
    "metricsLogIntervalTicks": 5000
  }
}
```

Full option list and tuning guidance in
[`docs/docs_parallel_area_offload.md`](docs/docs_parallel_area_offload.md).

## Behavioural differences when enabled

- **Movement relays batch to the end of the tick** rather than being emitted
  mid-ingest. Movement is unreliable and superseded by the next update, so this
  is not observable in play, but it is visible in packet captures, and tests
  must tick before asserting on `Messages()`.
- **A world/cell form id from an unloaded plugin** is rejected with a teleport
  correction instead of throwing out of the packet handler.
- **Distant players receive fewer updates** when interest management is on.
  That is the point; set `interestManagement: false` to disable.

## Testing

```
ctest: 100% tests passed, 0 failed out of 12
unit:  All tests passed (480,346 assertions in 310 test cases)
```

| Tag | Covers |
| --- | --- |
| `[ParallelPool]` | fork/join barrier, exception safety, back-to-back batches |
| `[ParallelPartition]` | the safety property, connectivity, order-independence |
| `[ParallelOffload]` | dispatcher, validation parity, sharding, interest management |
| `[ParallelConfig]` / `[ParallelBalancer]` | settings clamping, cost model |
| `[.][ParallelBench]` | the measurements above; excluded from ctest |

`unit/PartOne_MovementParallelTest.cpp` drives the real `PartOne`, packet parser
and send target with the offload enabled, asserting the same messages reach the
same users as the inline path.

### A race worth calling out

`ThreadPool::Run` originally returned as soon as `tasksRemaining` hit zero. The
worker that ran the final task decrements that counter and only *then* loops
back to the task cursor — so if `Run` returned in that window and the next tick
started a batch, the cursor reset would hand the still-draining worker index 0
of the *previous* task vector. The failure mode is not a duplicated packet: the
straggler decrements a counter it was never part of, underflowing it, and the
barrier never releases — the server tick hangs.

`Run` now also waits for every drainer to leave. Verified by reverting only the
fix and inserting a 300µs delay where a straggler would sit: that build hangs on
`Alternating batch sizes stay consistent` in 3 of 3 runs, the fixed build passes
3 of 3. The natural window is a few instructions wide, so on an idle machine
that test guards against regression rather than reliably detecting the race.

## Honest limitations

- **Not yet load-tested with real clients.** The benchmark drives `PartOne`
  directly with a no-op send target, so it measures server-side relay cost, not
  the network stack. Real RakNet sends would change the absolute numbers —
  probably in interest management's favour, since it avoids that work entirely.
- **The offload is a regression below ~300 players.** That is why it defaults
  off and why `minActorsToOffload` is 300. On a typical server the useful half
  of this PR is interest management.
- Numbers come from one 32-core host. Re-run the benchmark on target hardware
  before tuning.
