### PR TITLE
ESL Form ID Fix (Includes black screen fix when load order changes)

### DIFF
--- a/libespm/include/libespm/CombineBrowser.h
+++ b/libespm/include/libespm/CombineBrowser.h
@@ -36,6 +36,9 @@ public:
   const IdMapping* GetCombMapping(size_t fileIndex) const noexcept;
   const IdMapping* GetRawMapping(size_t fileIndex) const noexcept;
 
+  // The plugin's slot in the combined form-id space (full index or light slot)
+  PluginSlot GetPluginSlot(size_t fileIndex) const noexcept;
+
   // CompressedFieldsCache is not logically related to Combiner, this method is
   // added for usability
   espm::CompressedFieldsCache& GetCache() const noexcept;
@@ -50,6 +53,7 @@ private:
     Browser* br = nullptr;
     std::string fileName;
     std::unique_ptr<espm::IdMapping> toComb, toRaw;
+    PluginSlot slot;
   };
 
   struct Impl

--- a/libespm/include/libespm/IdMapping.h
+++ b/libespm/include/libespm/IdMapping.h
@@ -1,9 +1,73 @@
 #pragma once
 #include <array>
 #include <cstdint>
+#include <unordered_map>
 
 namespace espm {
 
-using IdMapping = std::array<uint8_t, 256>;
+// Where a plugin sits in a form-id space. Skyrim has two: full plugins get a
+// byte-wide index plus 24 bits of local id, light plugins (ESL / ESPFE) live
+// under the 0xFE prefix with a 12-bit slot and 12 bits of local id.
+// Runtime formula (CommonLibSSE TESDataHandler::LookupFormID):
+//   compileIndex << 24 | smallFileCompileIndex << 12 | localFormId
+struct PluginSlot
+{
+  bool light = false;
+  uint32_t index = 0; // 0..0xFD when full, 0..0xFFF when light
+
+  uint32_t Base() const noexcept
+  {
+    return light ? (0xFE000000u | ((index & 0xFFFu) << 12))
+                 : ((index & 0xFFu) << 24);
+  }
+
+  uint32_t LocalMask() const noexcept { return light ? 0xFFFu : 0xFFFFFFu; }
+};
+
+// Translates form ids between spaces (raw per-file space <-> combined space).
+// Full source indices use the array fast path; light sources are keyed by their
+// 12-bit slot because they all share the 0xFE high byte.
+class IdMapping
+{
+public:
+  // Out of the valid id range, so callers keep using the existing
+  // ">= 0xff000000 means skip this source" contract.
+  static constexpr uint32_t kInvalid = 0xFFFFFFFFu;
+
+  IdMapping() { mapped.fill(false); }
+
+  void Set(const PluginSlot& from, const PluginSlot& to) noexcept
+  {
+    if (from.light) {
+      light[static_cast<uint16_t>(from.index & 0xFFFu)] = to;
+      return;
+    }
+    const uint32_t i = from.index & 0xFFu;
+    full[i] = to;
+    mapped[i] = true;
+  }
+
+  uint32_t Map(uint32_t id) const noexcept
+  {
+    const uint32_t high = id >> 24;
+    if (high == 0xFEu) {
+      const auto it = light.find(static_cast<uint16_t>((id >> 12) & 0xFFFu));
+      if (it == light.end()) {
+        return kInvalid;
+      }
+      return it->second.Base() | (id & 0xFFFu);
+    }
+    if (!mapped[high]) {
+      return kInvalid;
+    }
+    const PluginSlot& to = full[high];
+    return to.Base() | (id & to.LocalMask());
+  }
+
+private:
+  std::array<PluginSlot, 256> full{};
+  std::array<bool, 256> mapped{};
+  std::unordered_map<uint16_t, PluginSlot> light;
+};
 
 }

--- a/libespm/src/CombineBrowser.cpp
+++ b/libespm/src/CombineBrowser.cpp
@@ -138,6 +138,14 @@ const IdMapping* CombineBrowser::GetCombMapping(
   return pImpl->sources[fileIndex].toComb.get();
 }
 
+PluginSlot CombineBrowser::GetPluginSlot(size_t fileIndex) const noexcept
+{
+  if (fileIndex >= pImpl->numSources) {
+    return PluginSlot{};
+  }
+  return pImpl->sources[fileIndex].slot;
+}
+
 const IdMapping* CombineBrowser::GetRawMapping(size_t fileIndex) const noexcept
 {
   if (fileIndex >= pImpl->numSources) {

--- a/libespm/src/Combiner.cpp
+++ b/libespm/src/Combiner.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <fmt/format.h>
 #include <string>
+#include <vector>
 
 namespace espm {
 
@@ -25,29 +26,60 @@ void espm::Combiner::AddSource(Browser* src, const char* fileName) noexcept
   pImpl->sources[pImpl->numSources++] = { src, fileName, nullptr };
 }
 
+namespace {
+// TES4 header flag 0x200 (CommonLibSSE RecordFlag::kSmallFile) marks a light
+// plugin. Light plugins are indexed in the 0xFE space by the runtime, so the
+// server has to match or every form id past the first ESL resolves wrong.
+constexpr uint32_t kSmallFileFlag = 0x200;
+}
+
 std::unique_ptr<espm::CombineBrowser> Combiner::Combine()
 {
   if (pImpl->numSources > std::size(pImpl->sources)) {
     throw CombineError("too many sources");
   }
 
+  // Pass 1: classify every source and assign its slot in the combined space.
+  // Full and light plugins are counted separately, exactly like the game does.
+  std::vector<PluginSlot> slots(pImpl->numSources);
+  uint32_t nextFull = 0, nextLight = 0;
   for (size_t i = 0; i < pImpl->numSources; ++i) {
     auto& src = pImpl->sources[i];
     if (!src.br) {
       throw CombineError("nullptr source with index " + std::to_string(i));
     }
-
-    const auto tes4 = Convert<TES4>(src.br->LookupById(0));
-    if (!tes4) {
+    const auto tes4Rec = src.br->LookupById(0);
+    if (!Convert<TES4>(tes4Rec)) {
       throw CombineError(src.fileName + " doesn't have TES4 record");
     }
+    const bool light = (tes4Rec->GetFlags() & kSmallFileFlag) != 0;
+    if (light) {
+      if (nextLight > 0xFFF) {
+        throw CombineError("too many light plugins (max 4096)");
+      }
+      slots[i] = PluginSlot{ true, nextLight++ };
+    } else {
+      if (nextFull > 0xFD) {
+        throw CombineError("too many full plugins (max 254)");
+      }
+      slots[i] = PluginSlot{ false, nextFull++ };
+    }
+  }
+
+  // Pass 2: build the per-source mappings using those slots.
+  for (size_t i = 0; i < pImpl->numSources; ++i) {
+    auto& src = pImpl->sources[i];
+
+    const auto tes4 = Convert<TES4>(src.br->LookupById(0));
     espm::CompressedFieldsCache dummyCache;
     const auto masters = tes4->GetData(dummyCache).masters;
 
     auto toComb = std::make_unique<IdMapping>();
-    toComb->fill(0xff);
     auto toRaw = std::make_unique<IdMapping>();
-    toRaw->fill(0xff);
+
+    // Inside a plugin file, a reference's high byte is always an index into
+    // that file's own master list, even when the master is light. Only the
+    // combined side uses the 0xFE space.
     size_t m = 0;
     for (m = 0; m < masters.size(); ++m) {
       const int globalIdx = pImpl->GetFileIndex(masters[m]);
@@ -55,11 +87,15 @@ std::unique_ptr<espm::CombineBrowser> Combiner::Combine()
         throw CombineError(src.fileName + " has unresolved dependency (" +
                            masters[m] + ")");
       }
-      (*toComb)[m] = static_cast<uint8_t>(globalIdx);
-      (*toRaw)[globalIdx] = static_cast<uint8_t>(m);
+      const PluginSlot rawSlot{ false, static_cast<uint32_t>(m) };
+      toComb->Set(rawSlot, slots[globalIdx]);
+      toRaw->Set(slots[globalIdx], rawSlot);
     }
-    (*toComb)[m] = static_cast<uint8_t>(i);
-    (*toRaw)[i] = static_cast<uint8_t>(m);
+    // The file's own records use the slot right after its masters.
+    const PluginSlot ownRaw{ false, static_cast<uint32_t>(m) };
+    toComb->Set(ownRaw, slots[i]);
+    toRaw->Set(slots[i], ownRaw);
+
     src.toComb = std::move(toComb);
     src.toRaw = std::move(toRaw);
   }

--- a/libespm/src/Combiner.cpp
+++ b/libespm/src/Combiner.cpp
@@ -98,6 +98,7 @@ std::unique_ptr<espm::CombineBrowser> Combiner::Combine()
 
     src.toComb = std::move(toComb);
     src.toRaw = std::move(toRaw);
+    src.slot = slots[i];
   }
 
   std::unique_ptr<espm::CombineBrowser> res(new CombineBrowser);

--- a/libespm/src/Utils.cpp
+++ b/libespm/src/Utils.cpp
@@ -68,9 +68,7 @@ uint32_t GetCorrectHashcode(const std::string& fileName)
 
 uint32_t GetMappedId(uint32_t id, const IdMapping& mapping) noexcept
 {
-  const uint32_t shortId = id % 0x01000000;
-  const uint8_t index = id / 0x01000000;
-  return shortId + (mapping[index] * 0x01000000);
+  return mapping.Map(id);
 }
 
 std::wstring ReadWstring(const uint8_t* ptr)

--- a/misc/migrate-formid-space.js
+++ b/misc/migrate-formid-space.js
@@ -1,0 +1,209 @@
+// Rewrites raw numeric form ids in MongoDB after the server learned to index
+// ESL / light plugins the way the game runtime does.
+//
+// Before: every plugin got a flat byte index (0,1,2,...) regardless of ESL.
+// After:  full plugins are numbered among themselves; light plugins move to
+//         0xFE | slot<<12 | localId.
+// FormDesc strings ("1a26f:Skyrim.esm") are filename-keyed and need no change.
+//
+// Run with the GAME SERVER STOPPED. Dry run by default.
+//   node misc/migrate-formid-space.js
+//   node misc/migrate-formid-space.js --apply
+//
+// Needs the mongodb driver: it resolves from server-manager/node_modules.
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const REPO = path.dirname(__dirname)
+const SETTINGS = path.join(REPO, 'build', 'dist', 'server', 'server-settings.json')
+const SCHEMA_VERSION = 1
+const APPLY = process.argv.includes('--apply')
+
+function loadMongo() {
+  for (const dir of ['server-manager', 'skymp5-backend']) {
+    try { return require(path.join(REPO, dir, 'node_modules', 'mongodb')) } catch {}
+  }
+  try { return require('mongodb') } catch {}
+  throw new Error('mongodb driver not found - run "npm install" in server-manager')
+}
+
+// TES4 header: type(4) dataSize(4) flags(4). Light plugin = flags & 0x200.
+function isLightPlugin(file) {
+  const fd = fs.openSync(file, 'r')
+  try {
+    const buf = Buffer.alloc(12)
+    if (fs.readSync(fd, buf, 0, 12, 0) < 12) return false
+    if (buf.toString('latin1', 0, 4) !== 'TES4') {
+      throw new Error(`${file} is not a plugin (no TES4 header)`)
+    }
+    return (buf.readUInt32LE(8) & 0x200) !== 0
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
+// old flat index -> new slot, for every plugin in loadOrder
+function buildMap(loadOrder) {
+  const map = []
+  let nextFull = 0, nextLight = 0
+  loadOrder.forEach((p, flatIdx) => {
+    const light = isLightPlugin(p)
+    map[flatIdx] = light
+      ? { light: true, index: nextLight++, name: path.basename(p) }
+      : { light: false, index: nextFull++, name: path.basename(p) }
+  })
+  return map
+}
+
+const hex = v => '0x' + (v >>> 0).toString(16).padStart(8, '0')
+
+function remap(v, map) {
+  if (!Number.isInteger(v) || v < 0) return v
+  const hb = v >>> 24
+  if (hb === 0xfe || hb === 0xff) return v // already light-encoded, or dynamic
+  const slot = map[hb]
+  if (!slot) throw new Error(`no plugin at old flat index ${hex(v)} (high byte 0x${hb.toString(16)})`)
+  if (!slot.light) return (((slot.index << 24) >>> 0) | (v & 0x00ffffff)) >>> 0
+  const short = v & 0x00ffffff
+  if (short > 0xfff) {
+    throw new Error(`${hex(v)} targets light plugin ${slot.name} but its local id exceeds 12 bits`)
+  }
+  return (0xfe000000 | (slot.index << 12) | short) >>> 0
+}
+
+// Every raw-numeric form id field written by MpChangeForm::ToJson
+function walkDoc(doc, map, hits) {
+  const num = (obj, key, where) => {
+    const before = obj[key]
+    if (!Number.isInteger(before)) return
+    const after = remap(before, map)
+    if (after !== before) {
+      obj[key] = after
+      hits.push({ where, before, after })
+    }
+  }
+  const entries = (inv, where) => {
+    if (!inv || !Array.isArray(inv.entries)) return
+    inv.entries.forEach((e, i) => {
+      num(e, 'baseId', `${where}[${i}].baseId`)
+      num(e, 'enchantmentId', `${where}[${i}].enchantmentId`)
+      num(e, 'poisonId', `${where}[${i}].poisonId`)
+    })
+  }
+  entries(doc.inv, 'inv.entries')
+  if (doc.equipmentDump) {
+    entries(doc.equipmentDump.inv, 'equipmentDump.inv.entries')
+    for (const k of ['leftSpell', 'rightSpell', 'voiceSpell', 'instantSpell']) {
+      num(doc.equipmentDump, k, `equipmentDump.${k}`)
+    }
+  }
+  if (Array.isArray(doc.learnedSpells)) {
+    doc.learnedSpells.forEach((v, i) => {
+      const after = remap(v, map)
+      if (after !== v) { doc.learnedSpells[i] = after; hits.push({ where: `learnedSpells[${i}]`, before: v, after }) }
+    })
+  }
+  // appearanceDump.tints[].argb are colors, not form ids - deliberately skipped
+  if (doc.appearanceDump) {
+    num(doc.appearanceDump, 'raceId', 'appearanceDump.raceId')
+    num(doc.appearanceDump, 'headTextureSetId', 'appearanceDump.headTextureSetId')
+    if (Array.isArray(doc.appearanceDump.headpartIds)) {
+      doc.appearanceDump.headpartIds.forEach((v, i) => {
+        const after = remap(v, map)
+        if (after !== v) {
+          doc.appearanceDump.headpartIds[i] = after
+          hits.push({ where: `appearanceDump.headpartIds[${i}]`, before: v, after })
+        }
+      })
+    }
+  }
+  return hits
+}
+
+async function main() {
+  const settings = JSON.parse(fs.readFileSync(SETTINGS, 'utf8'))
+  if (!Array.isArray(settings.loadOrder) || !settings.loadOrder.length) {
+    throw new Error('server-settings.json has no loadOrder')
+  }
+  const uri = settings.databaseUri
+  const dbName = settings.databaseName || 'skymp'
+  if (settings.databaseDriver !== 'mongodb' || !uri) {
+    throw new Error('server-settings.json is not on the mongodb driver')
+  }
+
+  const map = buildMap(settings.loadOrder)
+  console.log(`load order: ${map.length} plugins, ${map.filter(m => m.light).length} light\n`)
+  map.forEach((m, i) => {
+    const before = hex(i << 24)
+    const after = m.light ? `0xFE${m.index.toString(16).padStart(3, '0')}xxx` : hex(m.index << 24)
+    if (before !== after.replace('xxx', '000')) {
+      console.log(`  ${String(i).padStart(2)} ${m.name.padEnd(46)} ${before} -> ${after}`)
+    }
+  })
+
+  const { MongoClient } = loadMongo()
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 5000 })
+  await client.connect()
+  try {
+    const db = client.db(dbName)
+    const meta = db.collection('schemaMeta')
+    const existing = await meta.findOne({ _id: 'formIdSpace' })
+    if (existing && existing.version >= SCHEMA_VERSION) {
+      console.log(`\nAlready migrated (version ${existing.version}, ${existing.appliedAt}). Nothing to do.`)
+      return
+    }
+
+    const coll = db.collection('changeForms')
+    const docs = await coll.find({ _fidv: { $ne: SCHEMA_VERSION } }).toArray()
+    console.log(`\nscanning ${docs.length} changeForms...\n`)
+
+    let changedDocs = 0, changedValues = 0
+    const ops = []
+    for (const doc of docs) {
+      const hits = walkDoc(doc, map, [])
+      if (hits.length) {
+        changedDocs++
+        changedValues += hits.length
+        for (const h of hits) {
+          console.log(`  ${String(doc.formDesc).padEnd(22)} ${h.where.padEnd(40)} ${hex(h.before)} -> ${hex(h.after)}`)
+        }
+      }
+      if (APPLY) {
+        const set = { _fidv: SCHEMA_VERSION }
+        if (doc.inv) set.inv = doc.inv
+        if (doc.equipmentDump) set.equipmentDump = doc.equipmentDump
+        if (doc.learnedSpells) set.learnedSpells = doc.learnedSpells
+        if (doc.appearanceDump) set.appearanceDump = doc.appearanceDump
+        ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: set } } })
+      }
+    }
+
+    console.log(`\n${changedValues} value(s) in ${changedDocs} document(s) would change.`)
+
+    if (!APPLY) {
+      console.log('\nDRY RUN - nothing written. Re-run with --apply once the numbers look right.')
+      return
+    }
+    // Back up before writing so a rollback is one rename
+    const backup = `changeForms_bak_${Date.now()}`
+    await coll.aggregate([{ $match: {} }, { $out: backup }]).toArray()
+    console.log(`backed up to ${backup}`)
+
+    for (let i = 0; i < ops.length; i += 500) {
+      await coll.bulkWrite(ops.slice(i, i + 500), { ordered: false })
+    }
+    await meta.updateOne(
+      { _id: 'formIdSpace' },
+      { $set: { version: SCHEMA_VERSION, appliedAt: new Date().toISOString(), plugins: map.length } },
+      { upsert: true }
+    )
+    console.log(`\napplied to ${ops.length} document(s).`)
+  } finally {
+    await client.close()
+  }
+}
+
+main().catch(err => { console.error('\nFAILED:', err.message); process.exit(1) })

--- a/misc/migrate-formid-space.js
+++ b/misc/migrate-formid-space.js
@@ -106,6 +106,11 @@ function walkDoc(doc, map, hits) {
       if (after !== v) { doc.learnedSpells[i] = after; hits.push({ where: `learnedSpells[${i}]`, before: v, after }) }
     })
   }
+  if (Array.isArray(doc.effects)) {
+    doc.effects.forEach((e, i) => {
+      if (e) num(e, 'effectId', `effects[${i}].effectId`)
+    })
+  }
   // appearanceDump.tints[].argb are colors, not form ids - deliberately skipped
   if (doc.appearanceDump) {
     num(doc.appearanceDump, 'raceId', 'appearanceDump.raceId')
@@ -171,12 +176,15 @@ async function main() {
           console.log(`  ${String(doc.formDesc).padEnd(22)} ${h.where.padEnd(40)} ${hex(h.before)} -> ${hex(h.after)}`)
         }
       }
-      if (APPLY) {
+      // Only rewrite documents that actually changed. Writing back untouched
+      // subtrees would revert any save the server made after we read them.
+      if (APPLY && hits.length) {
         const set = { _fidv: SCHEMA_VERSION }
         if (doc.inv) set.inv = doc.inv
         if (doc.equipmentDump) set.equipmentDump = doc.equipmentDump
         if (doc.learnedSpells) set.learnedSpells = doc.learnedSpells
         if (doc.appearanceDump) set.appearanceDump = doc.appearanceDump
+        if (doc.effects) set.effects = doc.effects
         ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: set } } })
       }
     }
@@ -195,6 +203,9 @@ async function main() {
     for (let i = 0; i < ops.length; i += 500) {
       await coll.bulkWrite(ops.slice(i, i + 500), { ordered: false })
     }
+    // Mark the untouched documents too, so a re-run does not rescan them
+    await coll.updateMany({ _fidv: { $ne: SCHEMA_VERSION } },
+                          { $set: { _fidv: SCHEMA_VERSION } })
     await meta.updateOne(
       { _id: 'formIdSpace' },
       { $set: { version: SCHEMA_VERSION, appliedAt: new Date().toISOString(), plugins: map.length } },

--- a/skymp5-server/cpp/addon/PapyrusUtils.h
+++ b/skymp5-server/cpp/addon/PapyrusUtils.h
@@ -13,7 +13,7 @@ class PapyrusUtils
 public:
   static Napi::Value GetJsObjectFromPapyrusObject(
     Napi::Env env, const VarValue& value,
-    const std::vector<std::string>& espmFilenames)
+    const EspmFileTable& espmFilenames)
   {
     auto ptr = static_cast<IGameObject*>(value);
     if (!ptr) {
@@ -50,7 +50,7 @@ public:
 
   static Napi::Value GetJsValueFromPapyrusValue(
     Napi::Env env, const VarValue& value,
-    const std::vector<std::string>& espmFilenames)
+    const EspmFileTable& espmFilenames)
   {
     if (value.promise) {
       Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
@@ -188,8 +188,7 @@ public:
           auto desc = NapiHelper::ExtractString(obj.Get("desc"), "desc");
           auto type = NapiHelper::ExtractString(obj.Get("type"), "type");
 
-          const auto espmFileNames = wst.GetEspm().GetFileNames();
-          uint32_t id = FormDesc::FromString(desc).ToFormId(espmFileNames);
+          uint32_t id = FormDesc::FromString(desc).ToFormId(wst.espmFiles);
 
           if (type == "form") {
             MpObjectReference& refr = wst.GetFormAt<MpObjectReference>(id);

--- a/skymp5-server/cpp/addon/ScampServer.cpp
+++ b/skymp5-server/cpp/addon/ScampServer.cpp
@@ -1250,8 +1250,8 @@ Napi::Value ScampServer::GetDescFromId(const Napi::CallbackInfo& info)
 {
   try {
     auto formId = NapiHelper::ExtractUInt32(info[0], "formId");
-    auto espmFileNames = partOne->GetEspm().GetFileNames();
-    auto formDesc = FormDesc::FromFormId(formId, espmFileNames);
+    // Must be worldState.espmFiles: it is the only table carrying plugin slots
+    auto formDesc = FormDesc::FromFormId(formId, partOne->worldState.espmFiles);
 
     return Napi::String::New(info.Env(), formDesc.ToString());
   } catch (std::exception& e) {
@@ -1264,9 +1264,9 @@ Napi::Value ScampServer::GetIdFromDesc(const Napi::CallbackInfo& info)
   try {
     auto formDescStr = NapiHelper::ExtractString(info[0], "formDesc");
     auto formDesc = FormDesc::FromString(formDescStr);
-    auto espmFileNames = partOne->GetEspm().GetFileNames();
 
-    return Napi::Number::New(info.Env(), formDesc.ToFormId(espmFileNames));
+    return Napi::Number::New(
+      info.Env(), formDesc.ToFormId(partOne->worldState.espmFiles));
   } catch (std::exception& e) {
     throw Napi::Error::New(info.Env(), std::string(e.what()));
   }

--- a/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
+++ b/skymp5-server/cpp/server_guest_lib/ActionListener.cpp
@@ -1050,7 +1050,7 @@ void ActionListener::OnHit(const RawMessageData& rawMsgData,
   const FormDesc& targetCellOrWorld = targetRef->GetCellOrWorld();
 
   if (aggressorCellOrWorld != targetCellOrWorld) {
-    const std::vector<std::string>& files = partOne.worldState.espmFiles;
+    const EspmFileTable& files = partOne.worldState.espmFiles;
     spdlog::error(
       "ActionListener::OnHit - aggressor and targetRef are in different cells "
       "or world. Aggressor: {:x}, targetRef: {:x}, cellOrWorld of aggressor: "

--- a/skymp5-server/cpp/server_guest_lib/EspmFileTable.h
+++ b/skymp5-server/cpp/server_guest_lib/EspmFileTable.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "libespm/IdMapping.h"
+#include <string>
+#include <vector>
+
+// The loaded plugin list plus each plugin's slot in the form-id space.
+// Derives from vector<string> so the many places that only need the names keep
+// working unchanged; FormDesc uses the slots to encode light (ESL) plugins into
+// the 0xFE space the game runtime uses.
+class EspmFileTable : public std::vector<std::string>
+{
+public:
+  using std::vector<std::string>::vector;
+
+  // Without explicit slots every file is treated as a full plugin indexed by
+  // position, which is exactly the pre-ESL behaviour (used by tests).
+  espm::PluginSlot SlotAt(size_t i) const
+  {
+    if (i < slots.size()) {
+      return slots[i];
+    }
+    return espm::PluginSlot{ false, static_cast<uint32_t>(i) };
+  }
+
+  void SetSlots(std::vector<espm::PluginSlot> slots_)
+  {
+    slots = std::move(slots_);
+  }
+
+  // Index of the file owning this form id, or -1. Handles both spaces.
+  int FileIndexOf(uint32_t formId) const
+  {
+    const bool light = (formId >> 24) == 0xFEu;
+    const uint32_t idx =
+      light ? ((formId >> 12) & 0xFFFu) : ((formId >> 24) & 0xFFu);
+    const int n = static_cast<int>(size());
+    for (int i = 0; i < n; ++i) {
+      const espm::PluginSlot slot = SlotAt(i);
+      if (slot.light == light && slot.index == idx) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+private:
+  std::vector<espm::PluginSlot> slots;
+};

--- a/skymp5-server/cpp/server_guest_lib/EspmFileTable.h
+++ b/skymp5-server/cpp/server_guest_lib/EspmFileTable.h
@@ -12,6 +12,22 @@ class EspmFileTable : public std::vector<std::string>
 public:
   using std::vector<std::string>::vector;
 
+  EspmFileTable() = default;
+
+  // Inherited constructors do not include the base copy/move ones, so allow
+  // assigning a plain name list (espm::Loader::GetFileNames) directly.
+  EspmFileTable(std::vector<std::string> names)
+    : std::vector<std::string>(std::move(names))
+  {
+  }
+
+  EspmFileTable& operator=(std::vector<std::string> names)
+  {
+    std::vector<std::string>::operator=(std::move(names));
+    slots.clear();
+    return *this;
+  }
+
   // Without explicit slots every file is treated as a full plugin indexed by
   // position, which is exactly the pre-ESL behaviour (used by tests).
   espm::PluginSlot SlotAt(size_t i) const

--- a/skymp5-server/cpp/server_guest_lib/FormDesc.cpp
+++ b/skymp5-server/cpp/server_guest_lib/FormDesc.cpp
@@ -43,7 +43,7 @@ FormDesc FormDesc::FromString(const std::string& str, char delimiter)
   return res;
 }
 
-uint32_t FormDesc::ToFormId(const std::vector<std::string>& files) const
+uint32_t FormDesc::ToFormId(const EspmFileTable& files) const
 {
   // Workaround legacy tests throwing exceptions (drop support for PartOne
   // instances without espm to remove this)
@@ -68,13 +68,14 @@ uint32_t FormDesc::ToFormId(const std::vector<std::string>& files) const
       throw std::runtime_error(file + " not found in loaded files");
     }
 
-    realFormId = fileIdx * 0x01000000 + shortFormId;
+    // Light (ESL) plugins live in the 0xFE space with a 12-bit local id
+    const espm::PluginSlot slot = files.SlotAt(fileIdx);
+    realFormId = slot.Base() | (shortFormId & slot.LocalMask());
   }
   return realFormId;
 }
 
-FormDesc FormDesc::FromFormId(uint32_t formId,
-                              const std::vector<std::string>& files)
+FormDesc FormDesc::FromFormId(uint32_t formId, const EspmFileTable& files)
 {
   // Workaround legacy tests throwing exceptions (drop support for PartOne
   // instances without espm to remove this)
@@ -83,17 +84,20 @@ FormDesc FormDesc::FromFormId(uint32_t formId,
   }
 
   FormDesc res;
-  if (formId < 0xff000000) {
-    int fileIdx = formId / 0x01000000;
-    if (fileIdx >= static_cast<int>(files.size())) {
-      throw std::runtime_error("FromFormId failed due to invalid file index " +
-                               std::to_string(fileIdx));
-    }
-    res.file = files[fileIdx];
-    res.shortFormId = formId % 0x01000000;
-  } else {
+  if (formId >= 0xff000000) {
     res.shortFormId = formId - 0xff000000;
+    return res;
   }
+
+  // Light plugins share the 0xFE high byte, so resolve them by slot. This must
+  // run before the byte-index path below, which would read 254 as a file index.
+  const int fileIdx = files.FileIndexOf(formId);
+  if (fileIdx < 0) {
+    throw std::runtime_error("FromFormId failed due to invalid file index " +
+                             std::to_string(formId >> 24));
+  }
+  res.file = files[fileIdx];
+  res.shortFormId = formId & files.SlotAt(fileIdx).LocalMask();
   return res;
 }
 

--- a/skymp5-server/cpp/server_guest_lib/FormDesc.cpp
+++ b/skymp5-server/cpp/server_guest_lib/FormDesc.cpp
@@ -70,6 +70,12 @@ uint32_t FormDesc::ToFormId(const EspmFileTable& files) const
 
     // Light (ESL) plugins live in the 0xFE space with a 12-bit local id
     const espm::PluginSlot slot = files.SlotAt(fileIdx);
+    if (slot.light && shortFormId > slot.LocalMask()) {
+      // Truncating would silently resolve to an unrelated record
+      throw std::runtime_error(
+        file + " is a light plugin but form id " + std::to_string(shortFormId) +
+        " does not fit its 12-bit local id space");
+    }
     realFormId = slot.Base() | (shortFormId & slot.LocalMask());
   }
   return realFormId;

--- a/skymp5-server/cpp/server_guest_lib/FormDesc.h
+++ b/skymp5-server/cpp/server_guest_lib/FormDesc.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "EspmFileTable.h"
 #include <cstdint>
 #include <filesystem>
 #include <string>
@@ -18,9 +19,8 @@ public:
   std::string ToString(char delimiter = ':') const;
   static FormDesc FromString(const std::string& str, char delimiter = ':');
 
-  uint32_t ToFormId(const std::vector<std::string>& files) const;
-  static FormDesc FromFormId(uint32_t formId,
-                             const std::vector<std::string>& files);
+  uint32_t ToFormId(const EspmFileTable& files) const;
+  static FormDesc FromFormId(uint32_t formId, const EspmFileTable& files);
 
   friend bool operator==(const FormDesc& left, const FormDesc& right)
   {

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.cpp
@@ -12,7 +12,7 @@ bool Validate(PartOne& partOne, const NiPoint3& currentPos,
               const NiPoint3& currentRot, const FormDesc& currentCellOrWorld,
               const NiPoint3& newPos, const FormDesc& newCellOrWorld,
               Networking::UserId userId, MpActor* actor,
-              const std::vector<std::string>& espmFiles)
+              const EspmFileTable& espmFiles)
 {
   constexpr float kSqrMaxDistance = 4096.f * 4096.f;
 

--- a/skymp5-server/cpp/server_guest_lib/MovementValidation.h
+++ b/skymp5-server/cpp/server_guest_lib/MovementValidation.h
@@ -13,5 +13,5 @@ bool Validate(PartOne& partOne, const NiPoint3& currentPos,
               const NiPoint3& currentRot, const FormDesc& currentCellOrWorld,
               const NiPoint3& newPos, const FormDesc& newCellOrWorld,
               Networking::UserId userId, MpActor* actor,
-              const std::vector<std::string>& espmFiles);
+              const EspmFileTable& espmFiles);
 }

--- a/skymp5-server/cpp/server_guest_lib/WorldState.cpp
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.cpp
@@ -88,6 +88,15 @@ void WorldState::AttachEspm(espm::Loader* espm_,
   formCallbacksFactory = formCallbacksFactory_;
   espmCache.reset(new espm::CompressedFieldsCache);
   espmFiles = espm->GetFileNames();
+
+  // Reuse the combiner's full/light slot assignment (single source of truth)
+  // so FormDesc encodes the same form ids the game runtime does.
+  std::vector<espm::PluginSlot> slots;
+  slots.reserve(espmFiles.size());
+  for (size_t i = 0; i < espmFiles.size(); ++i) {
+    slots.push_back(espm->GetBrowser().GetPluginSlot(i));
+  }
+  espmFiles.SetSlots(std::move(slots));
 }
 
 void WorldState::AttachSaveStorage(
@@ -892,12 +901,14 @@ std::shared_ptr<std::vector<uint32_t>> WorldState::GetAllForms(
     // so we don't need de-duplicate in runtime
     std::unordered_set<uint32_t> formIds;
     for (const auto& p : forms) {
-      if ((p.first >> 24) == modIndex) {
+      // Match by file index, not high byte: all light plugins share 0xFE
+      if (GetFileIdx(p.first) == modIndex) {
         formIds.insert(p.first);
       }
     }
     for (const auto& p : pImpl->changeFormsForDeferredLoad) {
-      if ((p.first >> 24) == modIndex) {
+      // Match by file index, not high byte: all light plugins share 0xFE
+      if (GetFileIdx(p.first) == modIndex) {
         formIds.insert(p.first);
       }
     }
@@ -1160,7 +1171,9 @@ bool WorldState::IsNpcAllowed(uint32_t refrId) const noexcept
 
 uint32_t WorldState::GetFileIdx(uint32_t formId) const noexcept
 {
-  return formId >> 24;
+  // Every light plugin shares the 0xFE high byte, so resolve by slot instead
+  const int idx = espmFiles.FileIndexOf(formId);
+  return idx < 0 ? (formId >> 24) : static_cast<uint32_t>(idx);
 }
 
 void WorldState::SetNpcSettings(

--- a/skymp5-server/cpp/server_guest_lib/WorldState.h
+++ b/skymp5-server/cpp/server_guest_lib/WorldState.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ConditionsEvaluator.h" // ConditionsEvaluatorSettings
+#include "EspmFileTable.h"
 #include "FormIndex.h"
 #include "Grid.h"
 #include "GridElement.h"
@@ -232,7 +233,7 @@ public:
   void SetEnableConsoleCommandsForAllSetting(bool enable);
 
 public:
-  std::vector<std::string> espmFiles;
+  EspmFileTable espmFiles;
   std::unordered_map<int32_t, std::set<uint32_t>> actorIdByProfileId;
   std::unordered_map<std::string, std::set<uint32_t>>
     actorIdByPrivateIndexedProperty;

--- a/skymp5-server/tools/remap-changeforms.js
+++ b/skymp5-server/tools/remap-changeforms.js
@@ -1,0 +1,118 @@
+'use strict'
+
+// Remap load-order-dependent form IDs in the game server's changeForms store after the plugin load order changed.
+
+const fs = require('fs')
+const path = require('path')
+
+function parseArgs(argv) {
+  const a = { apply: false }
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i]
+    if      (k === '--dir')   a.dir = argv[++i]
+    else if (k === '--old')   a.old = argv[++i]
+    else if (k === '--new')   a.new = argv[++i]
+    else if (k === '--apply') a.apply = true
+  }
+  return a
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.dir || !args.old || !args.new) {
+  console.error('Usage: node remap-changeforms.js --dir <changeForms> --old old.json --new new.json [--apply]')
+  process.exit(1)
+}
+
+const readOrder = f => {
+  const arr = JSON.parse(fs.readFileSync(f, 'utf8'))
+  if (!Array.isArray(arr)) throw new Error(`${f} must be a JSON array of plugin names`)
+  // Accept either bare names or full paths; index by lowercased basename.
+  return arr.map(x => path.basename(String(x)).toLowerCase())
+}
+
+const oldOrder = readOrder(args.old)
+const newOrder = readOrder(args.new)
+
+// old index -> plugin name, plugin name -> new index
+const oldName = oldOrder                                   // array: index -> name
+const newIndex = new Map(newOrder.map((n, i) => [n, i]))
+
+const idxOf = id => (id >>> 24) & 0xff
+const localOf = id => id & 0x00ffffff
+const VANILLA_MAX = 4
+
+// Returns { id, note } - id remapped (or unchanged), note describes any issue.
+function remapId(id) {
+  if (typeof id !== 'number' || id <= 0 || id >= 0xff000000) return { id }
+  const i = idxOf(id)
+  if (i === 0xfe) return { id, note: `FE-space (light plugin) id 0x${(id>>>0).toString(16)} left unchanged - remap ESL ids by hand` }
+  if (i <= VANILLA_MAX) return { id }                       // vanilla master, never moves
+  const name = oldName[i]
+  if (!name) return { id, note: `old index ${i} not in --old order (0x${(id>>>0).toString(16)}) left unchanged` }
+  const ni = newIndex.get(name)
+  if (ni === undefined) return { id, note: `plugin ${name} (old index ${i}) not in --new order - id 0x${(id>>>0).toString(16)} left unchanged` }
+  if (ni === i) return { id }                               // no shift
+  return { id: ((ni << 24) | localOf(id)) >>> 0, from: i, to: ni, name }
+}
+
+const changes = []
+const notes = []
+let filesTouched = 0
+
+const files = fs.readdirSync(args.dir).filter(n => n.endsWith('.json'))
+const patched = new Map()   // file -> new content string (only when something changed)
+
+for (const f of files) {
+  const full = path.join(args.dir, f)
+  let cf
+  try { cf = JSON.parse(fs.readFileSync(full, 'utf8')) } catch { continue }
+  let changed = false
+
+  const doId = (label, id) => {
+    const r = remapId(id)
+    if (r.note) notes.push(`${f}: ${label}: ${r.note}`)
+    if (r.from !== undefined) {
+      changes.push(`${f}: ${label} 0x${(id>>>0).toString(16)} -> 0x${(r.id>>>0).toString(16)} (${r.name}: idx ${r.from} -> ${r.to})`)
+      changed = true
+    }
+    return r.id
+  }
+
+  const ap = cf.appearanceDump
+  if (ap) {
+    if (typeof ap.raceId === 'number') ap.raceId = doId('appearance.raceId', ap.raceId)
+    if (Array.isArray(ap.headpartIds)) ap.headpartIds = ap.headpartIds.map((h, i) => doId(`appearance.headpart[${i}]`, h))
+  }
+  for (const e of (cf.inv && cf.inv.entries) || []) if (typeof e.baseId === 'number') e.baseId = doId('inv.baseId', e.baseId)
+  const eq = cf.equipmentDump && cf.equipmentDump.inv
+  for (const e of (eq && eq.entries) || []) if (typeof e.baseId === 'number') e.baseId = doId('equip.baseId', e.baseId)
+
+  if (changed) { patched.set(full, JSON.stringify(cf, null, 2) + '\n'); filesTouched++ }
+}
+
+console.log(`changeForms: ${files.length} scanned, ${filesTouched} would change, ${changes.length} id(s) remapped`)
+if (notes.length) {
+  console.log(`\nLEFT UNCHANGED (review these - they may still be broken):`)
+  for (const n of notes) console.log('  ' + n)
+}
+if (changes.length) {
+  console.log(`\nREMAPS:`)
+  for (const c of changes) console.log('  ' + c)
+}
+
+if (!args.apply) {
+  console.log(`\nDRY RUN - nothing written. Re-run with --apply to write (a timestamped backup is made first).`)
+  process.exit(0)
+}
+
+if (patched.size === 0) { console.log('\nNothing to write.'); process.exit(0) }
+
+// Back up the whole changeForms folder before writing.
+const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+const backup = args.dir.replace(/[\\/]+$/, '') + '.backup-' + stamp
+fs.mkdirSync(backup, { recursive: true })
+for (const f of files) fs.copyFileSync(path.join(args.dir, f), path.join(backup, f))
+console.log(`\nBacked up ${files.length} file(s) to ${backup}`)
+
+for (const [full, content] of patched) fs.writeFileSync(full, content)
+console.log(`Wrote ${patched.size} changed file(s). STOP the game server before running this, then start it after.`)

--- a/unit/FormDescTest.cpp
+++ b/unit/FormDescTest.cpp
@@ -17,7 +17,7 @@ TEST_CASE("ToString/FromString", "[FormDesc]")
 
 TEST_CASE("ToFormId/FromFormId", "[FormDesc]")
 {
-  std::vector<std::string> list = { "Skyrim.esm", "Update.esm" };
+  EspmFileTable list = { "Skyrim.esm", "Update.esm" };
 
   REQUIRE(FormDesc::FromFormId(0x01000001, list) ==
           FormDesc(0x1, "Update.esm"));


### PR DESCRIPTION
Skyrim indexes light plugins in the 0xFE space (0xFE | 12-bit slot | 12-bit local id) and counts them separately from full plugins. 
libespm assigned every plugin a flat byte index, so every form id past the first ESL resolved to a different record on the server than on the client.

IdMapping becomes a real type that can express both spaces; Combiner classifies each source by TES4 flag 0x200 and assigns full/light slots the way the runtime does. References inside a plugin still use its own master-list index, so parsing is unchanged; only the combined space moves.

Verified with an MSVC standalone test of all four mapping directions. Load orders with no ESLs are unaffected.

Disclaimer; This was co-written by claude, verified by myself, and works on the Alduinak repo. I haven't tested this on a flat skymp repo, and since I'm lazy I had claude cherry pick the commits for me and build this PR, because fuck going through the hundreds of commits I've made by hand. 

The direction was simple; Ensure the formIDs (written in the changeforms) take into account modlist changes. When the modlist  changes, the data for the players no longer matches what's saved in the DB, because Skyrim handles its formIDs using an XXYYYYYY system, where Y is the actual ID of the object, and XX is the order of the plugin itself.

 For example, Skyrim.esm will always start with 00, but Hearthfire could be anywhere between 01 and 04, so an item from heartfire could read 0100ce52 on one machine, and 0400ce52 on another. This is why load orders are important and need to be synced when connecting to the server. However, if the load order changes for any reason, what's saved as 0100ce52 could now be 0300ce52, which fucks up the entire changeform since 0100ce52 no longer exists. 

This is the easiest way to explain it, cuz when you dip into the ESL namespace, shit gets even more complicated, which is why I also included an ESL injector in this PR. Claude took care of most of the heavy lifting when I explained exactly what the issue was thanks to my 15(! fucking!) years of expertise modding with the Creation Engine. I cleaned out some junk code, tidied up the comments, and submitted what you see below. 

Enjoy. 